### PR TITLE
Pin supported clang-format to 10, fix usage

### DIFF
--- a/cmake/ClangFormat.cmake
+++ b/cmake/ClangFormat.cmake
@@ -1,32 +1,31 @@
 if(CLANG_FORMAT_FOUND)
-    if (CLANG_FORMAT_VERSION VERSION_GREATER "8.0.0")
-        message(STATUS "Found clang-format ${CLANG_FORMAT_VERSION}, 'format' target enabled")
-        if (CLANG_FORMAT_VERSION VERSION_GREATER "10.0.0")
-            message(WARNING "clang-format ${CLANG_FORMAT_VERSION} is newer than tested, formatting may yield unexpected results")
-        endif()
-
-        set(GLOB_PATTERNS
-            common/*.cpp
-            common/*.h
-            tiberiandawn/*.cpp
-            tiberiandawn/*.h
-            redalert/*.cpp
-            redalert/*.h
-        )
-
-        file(GLOB_RECURSE ALL_SOURCE_FILES RELATIVE ${CMAKE_SOURCE_DIR} ${GLOB_PATTERNS})
-
-        add_custom_target(format)
-        foreach(SOURCE_FILE ${ALL_SOURCE_FILES})
-            add_custom_command(
-                TARGET format
-                PRE_BUILD
-                COMMAND clang-format -style=file -i --verbose \"${SOURCE_FILE}\"
-                WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
-        endforeach()
+    if(CLANG_FORMAT_VERSION VERSION_LESS "10.0.0")
+        message(WARNING "clang-format ${CLANG_FORMAT_VERSION} is older than 10.0.0, formatting may yield unexpected results")
+    elseif(CLANG_FORMAT_VERSION VERSION_GREATER "10.0.1")
+        message(WARNING "clang-format ${CLANG_FORMAT_VERSION} is newer than 10.0.1, formatting may yield unexpected results")
     else()
-        message(WARNING "clang-format found but ${CLANG_FORMAT_VERSION} is too old, 'format' target unavailable")
+        message(STATUS "Found clang-format ${CLANG_FORMAT_VERSION}, 'format' target enabled")
     endif()
+
+    set(GLOB_PATTERNS
+        common/*.cpp
+        common/*.h
+        tiberiandawn/*.cpp
+        tiberiandawn/*.h
+        redalert/*.cpp
+        redalert/*.h
+    )
+
+    file(GLOB_RECURSE ALL_SOURCE_FILES RELATIVE ${CMAKE_SOURCE_DIR} ${GLOB_PATTERNS})
+
+    add_custom_target(format)
+    foreach(SOURCE_FILE ${ALL_SOURCE_FILES})
+        add_custom_command(
+            TARGET format
+            PRE_BUILD
+            COMMAND ${CLANG_FORMAT_EXECUTABLE} -style=file -i --verbose \"${SOURCE_FILE}\"
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR})
+    endforeach()
 else()
     message(WARNING "clang-format not found, 'format' target unavailable")
 endif()

--- a/cmake/FindClangFormat.cmake
+++ b/cmake/FindClangFormat.cmake
@@ -11,9 +11,9 @@ if(CLANG_FORMAT_EXECUTABLE)
                         OUTPUT_VARIABLE clang_format_version
                         ERROR_QUIET OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-        if(clang_format_version MATCHES "^clang-format version .*")
+        if(clang_format_version MATCHES "^.*clang-format version .*")
             string(REGEX
-                   REPLACE "clang-format version ([.0-9]+).*"
+                   REPLACE ".*clang-format version ([.0-9]+).*"
                            "\\1"
                            clang_format_version_parsed
                            "${clang_format_version}")

--- a/redalert/buff.h
+++ b/redalert/buff.h
@@ -68,11 +68,11 @@ public:
     ~Buffer(void);
 
     Buffer& operator=(Buffer const& buffer);
-    operator void*(void)const
+    operator void*(void) const
     {
         return (BufferPtr);
     }
-    operator char*(void)const
+    operator char*(void) const
     {
         return ((char*)BufferPtr);
     }

--- a/redalert/ccptr.h
+++ b/redalert/ccptr.h
@@ -48,19 +48,19 @@ public:
     CCPtr(NoInitClass const&){};
     CCPtr(T* ptr);
 
-    operator T*(void)const
+    operator T*(void) const
     {
         if (ID == -1)
             return (NULL);
         assert(Heap != NULL && ID < Heap->Length());
         return ((T*)(*Heap)[ID]);
     }
-    T& operator*(void)const
+    T& operator*(void) const
     {
         assert(Heap != NULL && ID < Heap->Length());
         return (*(T*)(*Heap)[ID]);
     }
-    T* operator->(void)const
+    T* operator->(void) const
     {
         if (ID == -1)
             return (NULL);

--- a/redalert/jshell.h
+++ b/redalert/jshell.h
@@ -503,7 +503,7 @@ public:
         Pointer = 0;
     }
 
-    operator T*(void)const
+    operator T*(void) const
     {
         return (Pointer);
     }
@@ -545,12 +545,12 @@ public:
         Pointer = rvalue.Pointer;
         return (*this);
     }
-    T* operator->(void)const
+    T* operator->(void) const
     {
         assert(Pointer != 0);
         return (Pointer);
     }
-    T& operator*(void)const
+    T& operator*(void) const
     {
         assert(Pointer != 0);
         return (*Pointer);

--- a/redalert/ramfile.h
+++ b/redalert/ramfile.h
@@ -74,7 +74,7 @@ public:
     {
     }
 
-    operator char const*()
+    operator char const *()
     {
         return File_Name();
     }

--- a/redalert/teamtype.h
+++ b/redalert/teamtype.h
@@ -178,7 +178,7 @@ public:
 #if defined(CHEAT_KEYS) || defined(SCENARIO_EDITOR)
     char const* Member_Description(void) const;
     char const* Description(void) const;
-    operator const char*(void)const
+    operator const char*(void) const
     {
         return (Description());
     };

--- a/redalert/trigtype.h
+++ b/redalert/trigtype.h
@@ -150,7 +150,7 @@ public:
     bool Edit(void);
 #if defined(CHEAT_KEYS) || defined(SCENARIO_EDITOR)
     char const* Description(void) const;
-    operator const char*(void)const
+    operator const char*(void) const
     {
         return (Description());
     };

--- a/redalert/win32lib/wwfile.h
+++ b/redalert/win32lib/wwfile.h
@@ -62,7 +62,7 @@ public:
     virtual long Write(void const* buffer, long size) = 0;
     virtual void Close(void) = 0;
 
-    operator char const*()
+    operator char const *()
     {
         return File_Name();
     };

--- a/redalert/wwfile.h
+++ b/redalert/wwfile.h
@@ -96,7 +96,7 @@ public:
     }
     virtual void Error(int error, int canretry = false, char const* filename = NULL) = 0;
 
-    operator char const*()
+    operator char const *()
     {
         return File_Name();
     };

--- a/tiberiandawn/win32lib/wwfile.h
+++ b/tiberiandawn/win32lib/wwfile.h
@@ -62,7 +62,7 @@ public:
     virtual long Write(void const* buffer, long size) = 0;
     virtual void Close(void) = 0;
 
-    operator char const*()
+    operator char const *()
     {
         return File_Name();
     };

--- a/tiberiandawn/wwfile.h
+++ b/tiberiandawn/wwfile.h
@@ -67,7 +67,7 @@ public:
     virtual long Write(void const* buffer, long size) = 0;
     virtual void Close(void) = 0;
 
-    operator char const*()
+    operator char const *()
     {
         return File_Name();
     };


### PR DESCRIPTION
Found clang-format binary was not used in ClangFormat.make which caused confusion if you had more than one installed and the found was not the same as your alias.

Version 10 has a slight difference how some formatting is done so to keep things stable we now use it as our supported one. We also pick 11 already as the next best thing over 9.

Additionally updated the clang-format version match regex to work with upstream builds, their version strings are a bit different.