### PR TITLE
Change Data type to char*

### DIFF
--- a/TIBERIANDAWN/MIXFILE.H
+++ b/TIBERIANDAWN/MIXFILE.H
@@ -76,7 +76,7 @@ class MixFileClass : public LinkClass
 		int Count;							// Number of sub-blocks.
 		long DataSize;						// Size of raw data.
 		SubBlock * Buffer;				// Array of sub blocks (could be in EMS).
-		void *Data;							// Pointer to raw data.
+		char *Data;							// Pointer to raw data.
 
 		static MixFileClass * First;
 };


### PR DESCRIPTION
Standard says deleting void* is undefined and thus make it properly
defined by turning into char*.