### PR TITLE
Cleanup common types for portability

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,9 +2,14 @@ cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_SOURCE_DIR}/cmake/")
 
-if(NOT WIN32)
-    # until we are truly portable, assume MinGW
+if(NOT WIN32 AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
+    # until we are truly portable, assume MinGW if no toolchain is set (use -DCMAKE_TOOLCHAIN_FILE= to force native build)
     set(CMAKE_TOOLCHAIN_FILE "cmake/mingw-toolchain.cmake")
+    message(STATUS "Cross-compiling for Win32 with MinGW-W64")
+endif()
+
+if(NOT DEFINED CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE Debug)
 endif()
 
 project(VanillaConquer)
@@ -20,12 +25,18 @@ if(MSVC)
 else()
     set(ASM_DIALECT "_JWASM")
     enable_language(ASM_JWASM)
+    set(CMAKE_CXX_FLAGS_DEBUG "-gstabs3")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w -fpermissive -fpack-struct=1 -fdata-sections -ffunction-sections -Wl,--gc-sections -DNOMINMAX")
+    set(CMAKE_C_FLAGS_DEBUG "-gstabs3")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -w -fpermissive -fpack-struct=1 -fdata-sections -ffunction-sections -Wl,--gc-sections -DNOMINMAX")
     set(STATIC_LIBS "-static-libstdc++ -static-libgcc")
 endif()
 
-add_definitions(-DENGLISH -DTRUE_FALSE_DEFINED -DWIN32 -D_WINDOWS -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE)
+add_definitions(-DENGLISH -DTRUE_FALSE_DEFINED)
+
+if(WIN32 OR CMAKE_CROSSCOMPILING)
+    add_definitions(-DWIN32 -D_WINDOWS -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE)
+endif()
 
 set(COMMON_LIBS winmm)
 

--- a/common/audio.h
+++ b/common/audio.h
@@ -118,19 +118,19 @@ typedef enum
 /*=========================================================================*/
 /* The following prototypes are for the file: SOUNDIO.CPP						*/
 /*=========================================================================*/
-int File_Stream_Sample(char const* filename, BOOL real_time_start = FALSE);
-int File_Stream_Sample_Vol(char const* filename, int volume, BOOL real_time_start = FALSE);
-void __cdecl Sound_Callback(void);
-void __cdecl far maintenance_callback(void);
+int File_Stream_Sample(char const* filename, bool real_time_start = false);
+int File_Stream_Sample_Vol(char const* filename, int volume, bool real_time_start = false);
+void Sound_Callback(void);
+void maintenance_callback(void);
 void* Load_Sample(char const* filename);
 long Load_Sample_Into_Buffer(char const* filename, void* buffer, long size);
 long Sample_Read(int fh, void* buffer, long size);
 void Free_Sample(void const* sample);
-BOOL Audio_Init(HWND window, int bits_per_sample, BOOL stereo, int rate, int reverse_channels);
+bool Audio_Init(int bits_per_sample, bool stereo, int rate, bool reverse_channels);
 void Sound_End(void);
 void Stop_Sample(int handle);
-BOOL Sample_Status(int handle);
-BOOL Is_Sample_Playing(void const* sample);
+bool Sample_Status(int handle);
+bool Is_Sample_Playing(void const* sample);
 void Stop_Sample_Playing(void const* sample);
 int Play_Sample(void const* sample, int priority = 0xFF, int volume = 0xFF, signed short panloc = 0x0);
 int Play_Sample_Handle(void const* sample, int priority, int volume, signed short panloc, int id);
@@ -141,8 +141,8 @@ int Get_Free_Sample_Handle(int priority);
 int Get_Digi_Handle(void);
 long Sample_Length(void const* sample);
 void Restore_Sound_Buffers(void);
-BOOL Set_Primary_Buffer_Format(void);
-BOOL Start_Primary_Sound_Buffer(BOOL forced);
+bool Set_Primary_Buffer_Format(void);
+bool Start_Primary_Sound_Buffer(bool forced);
 void Stop_Primary_Sound_Buffer(void);
 
 /*
@@ -153,7 +153,5 @@ extern void (*Audio_Focus_Loss_Function)(void);
 extern int Misc;
 extern SFX_Type SoundType;
 extern Sample_Type SampleType;
-
-extern CRITICAL_SECTION GlobalAudioCriticalSection;
 
 extern bool StreamLowImpact;

--- a/common/auduncmp.c
+++ b/common/auduncmp.c
@@ -12,7 +12,7 @@ static int clamp(int x, int low, int high)
 }
 #endif
 
-short __cdecl Audio_Unzap(void* source, void* dest, short size)
+short Audio_Unzap(void* source, void* dest, short size)
 {
     short sample;
     unsigned char code;

--- a/common/auduncmp.h
+++ b/common/auduncmp.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-short __cdecl Audio_Unzap(void* source, void* dest, short size);
+short Audio_Unzap(void* source, void* dest, short size);
 
 #ifdef __cplusplus
 }

--- a/common/bitblit.c
+++ b/common/bitblit.c
@@ -17,7 +17,7 @@ typedef struct
     void* GVPBuffPtr; // related graphic buff
 } GraphicViewPort;
 
-int __cdecl Linear_Blit_To_Linear(void* thisptr,
+int Linear_Blit_To_Linear(void* thisptr,
                                   void* dest,
                                    int src_x,
                                    int src_y,

--- a/common/bitblit.h
+++ b/common/bitblit.h
@@ -5,15 +5,15 @@
 extern "C" {
 #endif
 
-int __cdecl Linear_Blit_To_Linear(void* thisptr,
-                                  void* dest,
-                                  int x_pixel,
-                                  int y_pixel,
-                                  int dx_pixel,
-                                  int dy_pixel,
-                                  int pixel_width,
-                                  int pixel_height,
-                                  int trans);
+int Linear_Blit_To_Linear(void* thisptr,
+                          void* dest,
+                          int x_pixel,
+                          int y_pixel,
+                          int dx_pixel,
+                          int dy_pixel,
+                          int pixel_width,
+                          int pixel_height,
+                          int trans);
 
 #ifdef __cplusplus
 }

--- a/common/buffer.cpp
+++ b/common/buffer.cpp
@@ -56,16 +56,16 @@
  * HISTORY:                                                                *
  *   06/01/1994 PWG : Created.                                             *
  *=========================================================================*/
-BufferClass::BufferClass(VOID* buffer, LONG size)
+BufferClass::BufferClass(void* buffer, long size)
 {
     Size = size; // find size of physical buffer
 
-    if (buffer) {               // if buffer is specified
-        Buffer = (BYTE*)buffer; //		point to it and mark
-        Allocated = FALSE;      //		it as user allocated
+    if (buffer) {                        // if buffer is specified
+        Buffer = (unsigned char*)buffer; //		point to it and mark
+        Allocated = false;               //		it as user allocated
     } else {
-        Buffer = new BYTE[Size]; // otherwise allocate it and
-        Allocated = TRUE;        //		mark it system alloced
+        Buffer = new unsigned char[Size]; // otherwise allocate it and
+        Allocated = true;                 //		mark it system alloced
     }
 }
 
@@ -79,11 +79,11 @@ BufferClass::BufferClass(VOID* buffer, LONG size)
  * HISTORY:                                                                *
  *   06/01/1994 PWG : Created.                                             *
  *=========================================================================*/
-BufferClass::BufferClass(LONG size)
+BufferClass::BufferClass(long size)
 {
     Size = size;
-    Buffer = new BYTE[Size]; // otherwise allocate it and
-    Allocated = TRUE;        //		mark it system alloced
+    Buffer = new unsigned char[Size]; // otherwise allocate it and
+    Allocated = true;                 //		mark it system alloced
 }
 
 /***************************************************************************
@@ -100,11 +100,11 @@ BufferClass::BufferClass(LONG size)
  * HISTORY:                                                                *
  *   06/01/1994 PWG : Created.                                             *
  *=========================================================================*/
-BufferClass::BufferClass(VOID)
+BufferClass::BufferClass()
 {
-    Buffer = NULL;
+    Buffer = nullptr;
     Size = 0;
-    Allocated = FALSE;
+    Allocated = false;
 }
 
 /***************************************************************************
@@ -117,7 +117,7 @@ BufferClass::BufferClass(VOID)
  * HISTORY:                                                                *
  *   06/01/1994 PWG : Created.                                             *
  *=========================================================================*/
-BufferClass::~BufferClass(VOID)
+BufferClass::~BufferClass()
 {
     if (Allocated) {
         delete[] Buffer;

--- a/common/buffer.h
+++ b/common/buffer.h
@@ -86,7 +86,7 @@ private:
 protected:
     void* Buffer;
     long Size;
-    BOOL Allocated;
+    bool Allocated;
 };
 /***************************************************************************
  * BC::GET_SIZE -- Returns the buffer size of the BufferClass instance     *

--- a/common/buffglbl.cpp
+++ b/common/buffglbl.cpp
@@ -43,8 +43,8 @@
 /* Globals required by GraphicBufferClass for function pointers.  These		*/
 /*   pointers will be set to the proper function when set mode is called.	*/
 /*=========================================================================*/
-BOOL (*GVPC_Blit_to_VVPC_Func)(void*, void*, int, int, int, int, int, int, BOOL);
-BOOL (*GVPC_Scale_To_VVPC)(void*, void*, int, int, int, int, int, int, int, int, BOOL, char*);
+bool (*GVPC_Blit_to_VVPC_Func)(void*, void*, int, int, int, int, int, int, bool);
+bool (*GVPC_Scale_To_VVPC)(void*, void*, int, int, int, int, int, int, int, int, bool, char*);
 
 #ifdef not_any_more_it_doesnt
 /*=========================================================================*/
@@ -56,11 +56,11 @@ long (*VVPC_To_Buffer_Func)(void*, int x, int y, int w, int h, void* buff, long 
 void (*VVPC_Put_Pixel_Func)(void*, int x, int y, unsigned char color);
 int (*VVPC_Get_Pixel_Func)(void*, int x, int y);
 long (*VVPC_Buffer_To_Page)(int x, int y, int w, int h, void* Buffer, void* view);
-BOOL (*VVPC_Blit_to_GVPC_Func)(void*, void*, int, int, int, int, int, int, BOOL);
-BOOL (*VVPC_Blit_to_VVPC_Func)(void*, void*, int, int, int, int, int, int, BOOL);
-BOOL (*VVPC_Scale_To_GVPC)(void*, void*, int, int, int, int, int, int, int, int, BOOL, char*);
-BOOL (*VVPC_Scale_To_VVPC)(void*, void*, int, int, int, int, int, int, int, int, BOOL, char*);
-LONG (*VVPC_Print_Func)(void*, const char*, int, int, int, int);
+bool (*VVPC_Blit_to_GVPC_Func)(void*, void*, int, int, int, int, int, int, bool);
+bool (*VVPC_Blit_to_VVPC_Func)(void*, void*, int, int, int, int, int, int, bool);
+bool (*VVPC_Scale_To_GVPC)(void*, void*, int, int, int, int, int, int, int, int, bool, char*);
+bool (*VVPC_Scale_To_VVPC)(void*, void*, int, int, int, int, int, int, int, int, bool, char*);
+long (*VVPC_Print_Func)(void*, const char*, int, int, int, int);
 void (*VVPC_Draw_Stamp)(void*, void*, int, int, int, void*);
 long (*VVPC_Size_Of_Region)(void*, int, int);
 
@@ -71,9 +71,9 @@ long (*VVPC_Size_Of_Region)(void*, int, int);
 /*=========================================================================*/
 GraphicViewPortClass* LogicPage;
 
-BOOL IconCacheAllowed = TRUE;
+bool IconCacheAllowed = true;
 
 /*
 ** Pointer to a function we will call if we detect loss of focus
 */
-void (*Gbuffer_Focus_Loss_Function)(void) = NULL;
+void (*Gbuffer_Focus_Loss_Function)(void) = nullptr;

--- a/common/drawbuff.h
+++ b/common/drawbuff.h
@@ -29,60 +29,60 @@ extern "C" {
 /* Externs for all of the common functions between the video buffer		*/
 /*		class and the graphic buffer class.											*/
 /*======================================================================*/
-long __cdecl Buffer_Size_Of_Region(void* thisptr, int w, int h);
+long Buffer_Size_Of_Region(void* thisptr, int w, int h);
 
-void __cdecl Buffer_Put_Pixel(void* thisptr, int x, int y, unsigned char color);
-int __cdecl Buffer_Get_Pixel(void* thisptr, int x, int y);
-void __cdecl Buffer_Clear(void* thisptr, unsigned char color);
-long __cdecl Buffer_To_Buffer(void* thisptr, int x, int y, int w, int h, void* buff, long size);
-long __cdecl Buffer_To_Page(int x, int y, int w, int h, void* Buffer, void* view);
-BOOL __cdecl Linear_Blit_To_Linear(void* thisptr,
-                                   void* dest,
-                                   int x_pixel,
-                                   int y_pixel,
-                                   int dx_pixel,
-                                   int dy_pixel,
-                                   int pixel_width,
-                                   int pixel_height,
-                                   BOOL trans);
-BOOL __cdecl Linear_Scale_To_Linear(void*, void*, int, int, int, int, int, int, int, int, BOOL, char*);
+void Buffer_Put_Pixel(void* thisptr, int x, int y, unsigned char color);
+int Buffer_Get_Pixel(void* thisptr, int x, int y);
+void Buffer_Clear(void* thisptr, unsigned char color);
+long Buffer_To_Buffer(void* thisptr, int x, int y, int w, int h, void* buff, long size);
+long Buffer_To_Page(int x, int y, int w, int h, void* Buffer, void* view);
+bool Linear_Blit_To_Linear(void* thisptr,
+                           void* dest,
+                           int x_pixel,
+                           int y_pixel,
+                           int dx_pixel,
+                           int dy_pixel,
+                           int pixel_width,
+                           int pixel_height,
+                           bool trans);
+bool Linear_Scale_To_Linear(void*, void*, int, int, int, int, int, int, int, int, bool, char*);
 
-LONG __cdecl Buffer_Print(void* thisptr, const char* str, int x, int y, int fcolor, int bcolor);
+long Buffer_Print(void* thisptr, const char* str, int x, int y, int fcolor, int bcolor);
 
 /*======================================================================*/
 /* Externs for all of the graphic buffer class only functions				*/
 /*======================================================================*/
-VOID __cdecl Buffer_Draw_Line(void* thisptr, int sx, int sy, int dx, int dy, unsigned char color);
-VOID __cdecl Buffer_Fill_Rect(void* thisptr, int sx, int sy, int dx, int dy, unsigned char color);
-VOID __cdecl Buffer_Remap(void* thisptr, int sx, int sy, int width, int height, void* remap);
-VOID __cdecl Buffer_Fill_Quad(void* thisptr,
-                              VOID* span_buff,
-                              int x0,
-                              int y0,
-                              int x1,
-                              int y1,
-                              int x2,
-                              int y2,
-                              int x3,
-                              int y3,
-                              int color);
-void __cdecl Buffer_Draw_Stamp(void const* thisptr,
-                               void const* icondata,
-                               int icon,
-                               int x_pixel,
-                               int y_pixel,
-                               void const* remap);
-void __cdecl Buffer_Draw_Stamp_Clip(void const* thisptr,
-                                    void const* icondata,
-                                    int icon,
-                                    int x_pixel,
-                                    int y_pixel,
-                                    void const* remap,
-                                    int,
-                                    int,
-                                    int,
-                                    int);
-void* __cdecl Get_Font_Palette_Ptr(void);
+void Buffer_Draw_Line(void* thisptr, int sx, int sy, int dx, int dy, unsigned char color);
+void Buffer_Fill_Rect(void* thisptr, int sx, int sy, int dx, int dy, unsigned char color);
+void Buffer_Remap(void* thisptr, int sx, int sy, int width, int height, void* remap);
+void Buffer_Fill_Quad(void* thisptr,
+                      void* span_buff,
+                      int x0,
+                      int y0,
+                      int x1,
+                      int y1,
+                      int x2,
+                      int y2,
+                      int x3,
+                      int y3,
+                      int color);
+void Buffer_Draw_Stamp(void const* thisptr,
+                       void const* icondata,
+                       int icon,
+                       int x_pixel,
+                       int y_pixel,
+                       void const* remap);
+void Buffer_Draw_Stamp_Clip(void const* thisptr,
+                            void const* icondata,
+                            int icon,
+                            int x_pixel,
+                            int y_pixel,
+                            void const* remap,
+                            int,
+                            int,
+                            int,
+                            int);
+void* Get_Font_Palette_Ptr(void);
 }
 
 extern GraphicViewPortClass* LogicPage;

--- a/common/drawmisc.cpp
+++ b/common/drawmisc.cpp
@@ -1,9 +1,10 @@
+#ifdef _WIN32
 #include <windows.h>
+HWND MainWindow; // Handle to programs main window
+#endif
 
 extern "C" unsigned char CurrentPalette[768] = {255};
 extern "C" unsigned char PaletteTable[1024] = {0};
-
-HWND MainWindow; // Handle to programs main window
 
 bool SystemToVideoBlits = false;  // Does hardware support system mem to video mem blits?
 bool VideoToSystemBlits = false;  // Does hardware support video mem to system mem blits?

--- a/common/font.cpp
+++ b/common/font.cpp
@@ -33,12 +33,6 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #include "font.h"
-#include <malloc.h>
-#include <dos.h>
-#include <fcntl.h>
-#include <io.h>
-#include <sys/stat.h>
-#include <string.h>
 #include "wwstd.h"
 
 /***************************************************************************
@@ -56,7 +50,7 @@
  *   01/31/1992 DRD : Created.                                             *
  *   06/30/1994 SKB : Converted to 32 bit library.                         *
  *=========================================================================*/
-int __cdecl Char_Pixel_Width(char chr)
+int Char_Pixel_Width(char chr)
 {
     int width;
 
@@ -82,10 +76,10 @@ int __cdecl Char_Pixel_Width(char chr)
  *   01/31/1992 DRD : Use Char_Pixel_Width.                                *
  *   06/30/1994 SKB : Converted to 32 bit library.                         *
  *=========================================================================*/
-unsigned int __cdecl String_Pixel_Width(char const* string)
+unsigned int String_Pixel_Width(char const* string)
 {
-    WORD width;       // Working accumulator of string width.
-    WORD largest = 0; // Largest recorded width of the string.
+    unsigned short width;       // Working accumulator of string width.
+    unsigned short largest = 0; // Largest recorded width of the string.
 
     if (!string)
         return (0);
@@ -120,9 +114,9 @@ unsigned int __cdecl String_Pixel_Width(char const* string)
  * HISTORY:                                                                *
  *   07/20/1994 SKB : Created.                                             *
  *=========================================================================*/
-VOID __cdecl Get_Next_Text_Print_XY(GraphicViewPortClass& gp, unsigned long offset, INT* x, INT* y)
+void Get_Next_Text_Print_XY(GraphicViewPortClass& gp, unsigned long offset, int* x, int* y)
 {
-    INT buffwidth;
+    int buffwidth;
 
     if (offset) {
         buffwidth = gp.Get_Width() + gp.Get_XAdd();

--- a/common/font.h
+++ b/common/font.h
@@ -59,21 +59,21 @@
 /* The following prototypes are for the file: SET_FONT.CPP						*/
 /*=========================================================================*/
 
-void* __cdecl Set_Font(void const* fontptr);
+void* Set_Font(void const* fontptr);
 
 /*=========================================================================*/
 /* The following prototypes are for the file: FONT.CPP							*/
 /*=========================================================================*/
 
-int __cdecl Char_Pixel_Width(char chr);
-unsigned int __cdecl String_Pixel_Width(char const* string);
-void __cdecl Get_Next_Text_Print_XY(GraphicViewPortClass& vp, unsigned long offset, INT* x, INT* y);
+int Char_Pixel_Width(char chr);
+unsigned int String_Pixel_Width(char const* string);
+void Get_Next_Text_Print_XY(GraphicViewPortClass& vp, unsigned long offset, int* x, int* y);
 
 /*=========================================================================*/
 /* The following prototypes are for the file: LOADFONT.CPP	  					*/
 /*=========================================================================*/
 
-void* __cdecl Load_Font(char const* name);
+void* Load_Font(char const* name);
 
 /*=========================================================================*/
 /* The following prototypes are for the file: TEXTPRNT.ASM	  					*/

--- a/common/gbuffer.h
+++ b/common/gbuffer.h
@@ -945,7 +945,7 @@ inline bool GraphicViewPortClass::Scale(GraphicViewPortClass& dest, char* remap)
     if (Lock()) {
         if (dest.Lock()) {
             return_code = (Linear_Scale_To_Linear(
-                this, &dest, 0, 0, 0, 0, Width, Height, dest.Get_Width(), dest.Get_Height(), FALSE, remap));
+                this, &dest, 0, 0, 0, 0, Width, Height, dest.Get_Width(), dest.Get_Height(), false, remap));
             dest.Unlock();
         }
         Unlock();

--- a/common/memflag.h
+++ b/common/memflag.h
@@ -51,7 +51,7 @@ typedef enum
 ** Prototypes for VMPAGEIN.ASM
 */
 extern "C" {
-void __cdecl Force_VM_Page_In(void* buffer, int length);
+void Force_VM_Page_In(void* buffer, int length);
 }
 
 /*=========================================================================*/
@@ -62,8 +62,6 @@ void* operator new(size_t size, MemoryFlagType flag);
 void* operator new[](size_t size, MemoryFlagType flag);
 void* Alloc(unsigned long bytes_to_alloc, MemoryFlagType flags);
 void Free(void const* pointer);
-void DPMI_Lock(VOID const* ptr, long const size);
-void DPMI_Unlock(void const* ptr, long const size);
 void* Resize_Alloc(void* original_ptr, unsigned long new_size_in_bytes);
 long Ram_Free(MemoryFlagType flag);
 long Heap_Size(MemoryFlagType flag);
@@ -87,7 +85,7 @@ inline void* operator new[](size_t size, MemoryFlagType flag)
 /*=========================================================================*/
 
 extern "C" {
-void __cdecl Mem_Copy(void const* source, void* dest, unsigned long bytes_to_copy);
+void Mem_Copy(void const* source, void* dest, unsigned long bytes_to_copy);
 }
 
 inline void* Add_Long_To_Pointer(void const* ptr, long size)

--- a/common/misc.c
+++ b/common/misc.c
@@ -1,4 +1,3 @@
-#include <windows.h>
 #include "miscasm.h"
 
 unsigned short __rotl16(unsigned short a, unsigned b)

--- a/common/misc.h
+++ b/common/misc.h
@@ -34,8 +34,6 @@
 #ifndef MISC_H
 #define MISC_H
 
-#include <windows.h>
-
 /*========================= C++ Routines ==================================*/
 
 /*=========================================================================*/
@@ -54,7 +52,11 @@ extern void (*Misc_Focus_Restore_Function)(void);
 /*=========================================================================*/
 /* The following variables are declared in: DDRAW.CPP                      */
 /*=========================================================================*/
+
+#ifdef _WIN32
+#include <windows.h>
 extern HWND MainWindow;
+#endif
 extern bool SystemToVideoBlits;
 extern bool VideoToSystemBlits;
 extern bool SystemToSystemBlits;
@@ -64,9 +66,9 @@ extern bool OverlappedVideoBlits; // Can video driver blit overlapped regions?
 /* The following prototypes are for the file: EXIT.CPP                     */
 /* Prog_End Must be supplied by the user program in startup.cpp            */
 /*=========================================================================*/
-void __cdecl Prog_End(const char* why = NULL,
-                      bool fatal = false); // Added why and fatal parameters. ST - 6/27/2019 10:10PM
-VOID __cdecl Exit(INT errorval, const BYTE* message, ...);
+void Prog_End(const char* why = nullptr,
+              bool fatal = false); // Added why and fatal parameters. ST - 6/27/2019 10:10PM
+void Exit(int errorval, const unsigned char* message, ...);
 
 /*=========================================================================*/
 /* The following prototypes are for the file: DELAY.CPP                    */
@@ -78,7 +80,7 @@ void Vsync(void);
 /* The following prototypes are for the file: FINDARGV.CPP                 */
 /*=========================================================================*/
 
-BYTE __cdecl Find_Argv(BYTE const* str);
+unsigned char Find_Argv(unsigned char const* str);
 
 /*=========================================================================*/
 /* The following prototypes are for the file: LIB.CPP                      */
@@ -102,7 +104,7 @@ void Convert_HSV_To_RGB(unsigned int h,
 /* The following prototypes are for the file: VERSION.CPP                  */
 /*=========================================================================*/
 
-BYTE __cdecl Version(VOID);
+unsigned char Version(void);
 
 /*=========================================================================*/
 /* The following prototypes are for the file: IRANDOM.CPP                  */
@@ -119,66 +121,66 @@ extern "C" {
 /* The following prototypes are for the file: RANDOM.ASM                   */
 /*=========================================================================*/
 
-unsigned char __cdecl Random(void);
-int __cdecl Get_Random_Mask(int maxval);
+unsigned char Random(void);
+int Get_Random_Mask(int maxval);
 
 /*=========================================================================*/
 /* The following prototype is for the file: SHAKESCR.ASM                   */
 /*=========================================================================*/
 
-void __cdecl Shake_Screen(int shakes);
+void Shake_Screen(int shakes);
 
 /*=========================================================================*/
 /* The following prototypes are for the file: REVERSE.ASM                  */
 /*=========================================================================*/
 
-long __cdecl Reverse_Long(long number);
-short __cdecl Reverse_Short(short number);
-long __cdecl Swap_Long(long number);
+long Reverse_Long(long number);
+short Reverse_Short(short number);
+long Swap_Long(long number);
 #if (0)
 /*=========================================================================*/
 /* The following prototype is for the file: FACING8.ASM                    */
 /*=========================================================================*/
 
-int __cdecl Desired_Facing8(int x1, int y1, int x2, int y2);
+int Desired_Facing8(int x1, int y1, int x2, int y2);
 
 /*=========================================================================*/
 /* The following prototype is for the file: FACING16.ASM                   */
 /*=========================================================================*/
 
-int __cdecl Desired_Facing16(int x1, int y1, int x2, int y2);
+int Desired_Facing16(int x1, int y1, int x2, int y2);
 
 /*=========================================================================*/
 /* The following prototype is for the file: FACINGFF.ASM                   */
 /*=========================================================================*/
 
-int __cdecl Desired_Facing256(int x1, int y1, int x2, int y2);
+int Desired_Facing256(int x1, int y1, int x2, int y2);
 
 /*=========================================================================*/
 /* The following prototype is for the file: FADING.ASM                     */
 /*=========================================================================*/
 #endif
 
-void* __cdecl Build_Fading_Table(void const* palette, void const* dest, long int color, long int frac);
+void* Build_Fading_Table(void const* palette, void const* dest, long int color, long int frac);
 /*=========================================================================*/
 /* The following prototype is for the file: CRC.ASM                        */
 /*=========================================================================*/
 
-long __cdecl Calculate_CRC(void* buffer, long length);
+long Calculate_CRC(void* buffer, long length);
 
 /*=========================================================================*/
 /* The following prototypes are for the file: DETPROC.ASM                  */
 /*=========================================================================*/
 
-extern WORD __cdecl Processor(void);
-extern WORD __cdecl Operating_System(void);
+extern short Processor(void);
+extern short Operating_System(void);
 extern unsigned long random(unsigned long mod);
 
 /*=========================================================================*/
 /* The following prototypes are for the file: OPSYS.ASM                    */
 /*=========================================================================*/
 
-extern WORD OperationgSystem;
+extern short OperationgSystem;
 
 #ifdef __cplusplus
 }

--- a/common/miscasm.h
+++ b/common/miscasm.h
@@ -9,17 +9,17 @@ int calcx(signed short param1, short distance);
 int calcy(signed short param1, short distance);
 unsigned int Cardinal_To_Fixed(unsigned base, unsigned cardinal);
 unsigned int Fixed_To_Cardinal(unsigned base, unsigned fixed);
-void __cdecl Set_Bit(void* array, int bit, int value);
-int __cdecl Get_Bit(void const* array, int bit);
-int __cdecl First_True_Bit(void const* array);
-int __cdecl First_False_Bit(void const* array);
-int __cdecl _Bound(int original, int min, int max);
+void Set_Bit(void* array, int bit, int value);
+int Get_Bit(void const* array, int bit);
+int First_True_Bit(void const* array);
+int First_False_Bit(void const* array);
+int _Bound(int original, int min, int max);
 #define Bound _Bound
-void* __cdecl Conquer_Build_Fading_Table(void const* palette, void* dest, int color, int frac);
-long __cdecl Reverse_Long(long number);
-short __cdecl Reverse_Short(short number);
-long __cdecl Swap_Long(long number);
-void __cdecl strtrim(char* buffer);
+void* Conquer_Build_Fading_Table(void const* palette, void* dest, int color, int frac);
+long Reverse_Long(long number);
+short Reverse_Short(short number);
+long Swap_Long(long number);
+void strtrim(char* buffer);
 
 #ifdef __cplusplus
 }

--- a/common/setfpal.c
+++ b/common/setfpal.c
@@ -2,7 +2,7 @@
 
 extern unsigned char ColorXlat[16][16];
 
-void __cdecl Set_Font_Palette_Range(void const* palette, int start_idx, int end_idx)
+void Set_Font_Palette_Range(void const* palette, int start_idx, int end_idx)
 {
     start_idx &= 15;
     end_idx &= 15;

--- a/common/setfpal.h
+++ b/common/setfpal.h
@@ -5,7 +5,7 @@
 extern "C" {
 #endif
 
-void __cdecl Set_Font_Palette_Range(void const* palette, int start_idx, int end_idx);
+void Set_Font_Palette_Range(void const* palette, int start_idx, int end_idx);
 
 #ifdef __cplusplus
 }

--- a/common/soscodec.c
+++ b/common/soscodec.c
@@ -16,7 +16,7 @@ static const short wCODECStepTab[89] = {
 #define clamp(x, low, high) (((x) > (high)) ? (high) : (((x) < (low)) ? (low) : (x)))
 #endif
 
-void __cdecl sosCODECInitStream(_SOS_COMPRESS_INFO* stream)
+void sosCODECInitStream(_SOS_COMPRESS_INFO* stream)
 {
     stream->wCode = 0;
     stream->wCodeBuf = 0;
@@ -37,7 +37,7 @@ void __cdecl sosCODECInitStream(_SOS_COMPRESS_INFO* stream)
 // decompress data from a 4:1 ADPCM compressed file.  the number of
 // bytes decompressed is returned.
 //
-unsigned long __cdecl sosCODECDecompressData(_SOS_COMPRESS_INFO* stream, unsigned long bytes)
+unsigned long sosCODECDecompressData(_SOS_COMPRESS_INFO* stream, unsigned long bytes)
 {
     short current_nybble;
     unsigned step;
@@ -214,7 +214,7 @@ unsigned long __cdecl sosCODECDecompressData(_SOS_COMPRESS_INFO* stream, unsigne
 // Compresses a data stream into 4:1 ADPCM.  16 bit data is compressed 4:1
 // 8 bit data is compressed 2:1.
 //
-unsigned long __cdecl sosCODECCompressData(_SOS_COMPRESS_INFO* stream, unsigned long bytes)
+unsigned long sosCODECCompressData(_SOS_COMPRESS_INFO* stream, unsigned long bytes)
 {
     int delta;
     int tmp_step;

--- a/common/soscomp.h
+++ b/common/soscomp.h
@@ -77,9 +77,9 @@ typedef struct _tagCOMPRESS_HEADER
 extern "C" {
 #endif
 
-void __cdecl sosCODECInitStream(_SOS_COMPRESS_INFO*);
-unsigned long __cdecl sosCODECCompressData(_SOS_COMPRESS_INFO*, unsigned long);
-unsigned long __cdecl sosCODECDecompressData(_SOS_COMPRESS_INFO*, unsigned long);
+void sosCODECInitStream(_SOS_COMPRESS_INFO*);
+unsigned long sosCODECCompressData(_SOS_COMPRESS_INFO*, unsigned long);
+unsigned long sosCODECDecompressData(_SOS_COMPRESS_INFO*, unsigned long);
 
 #ifdef __cplusplus
 }

--- a/common/soundint.h
+++ b/common/soundint.h
@@ -37,15 +37,6 @@
 #include "sound.h"
 
 /*
-** Defines for true and false.  These are included because we do not allow
-** the sound int to include any of the westwood standard headers.  If we
-** did, there might be too much temptation to call another library function.
-** this would be bad, because then that function would not be locked.
-*/
-#define FALSE 0
-#define TRUE  1
-
-/*
 ** Define the different type of sound compression avaliable to the westwood
 ** library.
 */
@@ -137,7 +128,7 @@ typedef struct
     **	yet playing.  This value is normally the size of the buffer,
     **	except for the case of the last bit of the sample.
     */
-    LONG DataLength;
+    long DataLength;
 
     /*
     **	This is the buffer index for the low buffer that
@@ -151,33 +142,33 @@ typedef struct
     **  chunk of sample to
     **
     */
-    VOID* DestPtr;
+    void* DestPtr;
 
     /*
     **	This flag indicates that there is more source data
     **  to copy to the play buffer
     **
     */
-    BOOL MoreSource;
+    bool MoreSource;
 
     /*
     **	This flag indicates that the entire sample fitted inside the
     ** direct sound secondary buffer
     **
     */
-    BOOL OneShot;
+    bool OneShot;
 
     /*
     **	Pointer to the sound data that has not yet been copied
     **	to the playback buffers.
     */
-    VOID* Source;
+    void* Source;
 
     /*
     **	This is the number of bytes remaining in the source data as
     **	pointed to by the "Source" element.
     */
-    LONG Remainder;
+    long Remainder;
 
     /*
     **	Object to use with Enter/LeaveCriticalSection
@@ -207,11 +198,11 @@ typedef struct
     **	This is the compression that the sound data is using.
     */
     SCompressType Compression;
-    short int TrailerLen;        // Number of trailer bytes in buffer.
-    BYTE Trailer[SONARC_MARGIN]; // Maximum number of 'order' samples needed.
+    short int TrailerLen;                 // Number of trailer bytes in buffer.
+    unsigned char Trailer[SONARC_MARGIN]; // Maximum number of 'order' samples needed.
 
-    DWORD Pitch;
-    WORD Flags;
+    unsigned int Pitch;
+    unsigned short Flags;
 
     /*
     **	This flag indicates whether this sample needs servicing.
@@ -220,18 +211,18 @@ typedef struct
     short int Service;
 
     /*
-    **	This flag is TRUE when the sample has stopped playing,
+    **	This flag is true when the sample has stopped playing,
     **	BUT there is more data available.  The sample must be
     **	restarted upon filling the low buffer.
     */
-    BOOL Restart;
+    bool Restart;
 
     /*
     **	Streaming control handlers.
     */
-    BOOL (*Callback)(short int id, short int* odd, VOID** buffer, LONG* size);
-    VOID* QueueBuffer;    // Pointer to continued sample data.
-    LONG QueueSize;       // Size of queue buffer attached.
+    bool (*Callback)(short int id, short int* odd, void** buffer, long* size);
+    void* QueueBuffer;    // Pointer to continued sample data.
+    long QueueSize;       // Size of queue buffer attached.
     short int Odd;        // Block number tracker (0..StreamBufferCount-1).
     int FilePending;      // Number of buffers already filled ahead.
     long FilePendingSize; // Number of bytes in last filled buffer.
@@ -241,7 +232,7 @@ typedef struct
     **	hard drive.
     */
     int FileHandle;   // Streaming file handle (ERROR = not in use).
-    VOID* FileBuffer; // Temporary streaming buffer (allowed to be freed).
+    void* FileBuffer; // Temporary streaming buffer (allowed to be freed).
     /*
     ** The following structure is used if the sample if compressed using
     ** the sos 16 bit compression Codec.
@@ -254,15 +245,15 @@ typedef struct
 typedef struct LockedData
 {
     unsigned int DigiHandle; // = -1;
-    BOOL ServiceSomething;   // = FALSE;
+    bool ServiceSomething;   // = false;
     long MagicNumber;        // = 0xDEAF;
-    VOID* UncompBuffer;      // = NULL;
+    void* UncompBuffer;      // = NULL;
     long StreamBufferSize;   // = (2*SECONDARY_BUFFER_SIZE)+128;
     short StreamBufferCount; // = 32;
     SampleTrackerType SampleTracker[MAX_SFX];
     unsigned int SoundVolume;
     unsigned int ScoreVolume;
-    BOOL _int;
+    int _int;
 } LockedDataType;
 
 extern LockedDataType LockedData;
@@ -280,18 +271,18 @@ long Sample_Copy(SampleTrackerType* st,
                  SCompressType scomp,
                  void* trailer,
                  short int* trailersize);
-VOID far __cdecl maintenance_callback(VOID);
-VOID __cdecl far DigiCallback(unsigned int driverhandle, unsigned int callsource, unsigned int sampleid);
-void far HMI_TimerCallback(void);
+void maintenance_callback(void);
+void DigiCallback(unsigned int driverhandle, unsigned int callsource, unsigned int sampleid);
+void HMI_TimerCallback(void);
 void* Audio_Add_Long_To_Pointer(void const* ptr, long size);
-void DPMI_Unlock(VOID const* ptr, long const size);
+void DPMI_Unlock(void const* ptr, long const size);
 extern "C" {
-void __cdecl Audio_Mem_Set(void const* ptr, unsigned char value, long size);
+void Audio_Mem_Set(void const* ptr, unsigned char value, long size);
 //	void	Mem_Copy(void *source, void *dest, unsigned long bytes_to_copy);
-long __cdecl Decompress_Frame(void* source, void* dest, long size);
-int __cdecl Decompress_Frame_Lock(void);
-int __cdecl Decompress_Frame_Unlock(void);
-int __cdecl sosCODEC_Lock(void);
-int __cdecl sosCODEC_Unlock(void);
+long Decompress_Frame(void* source, void* dest, long size);
+int Decompress_Frame_Lock(void);
+int Decompress_Frame_Unlock(void);
+int sosCODEC_Lock(void);
+int sosCODEC_Unlock(void);
 void __GETDS(void);
 }

--- a/common/soundio_null.cpp
+++ b/common/soundio_null.cpp
@@ -6,19 +6,19 @@ bool StreamLowImpact = false;
 SFX_Type SoundType;
 Sample_Type SampleType;
 
-int File_Stream_Sample(char const* filename, BOOL real_time_start)
+int File_Stream_Sample(char const* filename, bool real_time_start)
 {
     return 1;
 };
-int File_Stream_Sample_Vol(char const* filename, int volume, BOOL real_time_start)
+int File_Stream_Sample_Vol(char const* filename, int volume, bool real_time_start)
 {
     return 1;
 };
-void __cdecl Sound_Callback(void){};
-void __cdecl far maintenance_callback(void){};
+void Sound_Callback(void){};
+void maintenance_callback(void){};
 void* Load_Sample(char const* filename)
 {
-    return NULL;
+    return nullptr;
 };
 long Load_Sample_Into_Buffer(char const* filename, void* buffer, long size)
 {
@@ -29,17 +29,17 @@ long Sample_Read(int fh, void* buffer, long size)
     return 0;
 };
 void Free_Sample(void const* sample){};
-BOOL Audio_Init(HWND window, int bits_per_sample, BOOL stereo, int rate, int reverse_channels)
+bool Audio_Init(int bits_per_sample, bool stereo, int rate, bool reverse_channels)
 {
     return 0;
 };
 void Sound_End(void){};
 void Stop_Sample(int handle){};
-BOOL Sample_Status(int handle)
+bool Sample_Status(int handle)
 {
     return 0;
 };
-BOOL Is_Sample_Playing(void const* sample)
+bool Is_Sample_Playing(void const* sample)
 {
     return 0;
 };
@@ -74,11 +74,11 @@ long Sample_Length(void const* sample)
     return 0;
 };
 void Restore_Sound_Buffers(void){};
-BOOL Set_Primary_Buffer_Format(void)
+bool Set_Primary_Buffer_Format(void)
 {
     return 0;
 };
-BOOL Start_Primary_Sound_Buffer(BOOL forced)
+bool Start_Primary_Sound_Buffer(bool forced)
 {
     return 0;
 };

--- a/common/winasm.c
+++ b/common/winasm.c
@@ -11,7 +11,7 @@ static unsigned char BottomLine[1600];
 /**
  * Interpolates in X axis, leaves additional lines blank in the Y axis.
  */
-void __cdecl Asm_Interpolate(void* src, void* dst, int src_height, int src_width, int dst_pitch)
+void Asm_Interpolate(void* src, void* dst, int src_height, int src_width, int dst_pitch)
 {
     unsigned char* dptr = (unsigned char*)(dst);
     unsigned char* sptr = (unsigned char*)(src);
@@ -34,7 +34,7 @@ void __cdecl Asm_Interpolate(void* src, void* dst, int src_height, int src_width
 /**
  * Interpolates in X axis, duplicates lines in the Y axis.
  */
-void __cdecl Asm_Interpolate_Line_Double(void* src, void* dst, int src_height, int src_width, int dst_pitch)
+void Asm_Interpolate_Line_Double(void* src, void* dst, int src_height, int src_width, int dst_pitch)
 {
     unsigned char* dptr = (unsigned char*)(dst);
     unsigned char* sptr = (unsigned char*)(src);
@@ -95,7 +95,7 @@ static void Interpolate_Y_Axis(void* top_line, void* bottom_line, void* middle_l
 /**
  * @brief Interpolates in both the X and Y axis.
  */
-void __cdecl Asm_Interpolate_Line_Interpolate(void* src, void* dst, int src_height, int src_width, int dst_pitch)
+void Asm_Interpolate_Line_Interpolate(void* src, void* dst, int src_height, int src_width, int dst_pitch)
 {
     unsigned char* dptr = (unsigned char*)(dst);
     unsigned char* buff_offset1 = TopLine;

--- a/common/winasm.h
+++ b/common/winasm.h
@@ -5,9 +5,9 @@
 extern "C" {
 #endif
 
-void __cdecl Asm_Interpolate(void* src, void* dst, int src_height, int src_width, int dst_pitch);
-void __cdecl Asm_Interpolate_Line_Double(void* src, void* dst, int src_height, int src_width, int dst_pitch);
-void __cdecl Asm_Interpolate_Line_Interpolate(void* src, void* dst, int src_height, int src_width, int dst_pitch);
+void Asm_Interpolate(void* src, void* dst, int src_height, int src_width, int dst_pitch);
+void Asm_Interpolate_Line_Double(void* src, void* dst, int src_height, int src_width, int dst_pitch);
+void Asm_Interpolate_Line_Interpolate(void* src, void* dst, int src_height, int src_width, int dst_pitch);
 
 #ifdef __cplusplus
 }

--- a/common/wwmouse.c
+++ b/common/wwmouse.c
@@ -66,13 +66,13 @@ typedef struct
 #pragma pack(pop)
 
 // Some forward declarations for stuff defined elsewhere.
-int __cdecl Get_Shape_Width(void const* shape);
-int __cdecl Get_Shape_Original_Height(void const* shape);
-int __cdecl Get_Shape_Uncomp_Size(void const* shape);
-long __cdecl LCW_Uncompress(void* source, void* dest, unsigned long length_);
+int Get_Shape_Width(void const* shape);
+int Get_Shape_Original_Height(void const* shape);
+int Get_Shape_Uncomp_Size(void const* shape);
+long LCW_Uncompress(void* source, void* dest, unsigned long length_);
 extern char* _ShapeBuffer;
 
-void __cdecl Mouse_Shadow_Buffer(void* thisptr, void* srcdst, void* buffer, int x, int y, int hotx, int hoty, int store)
+void Mouse_Shadow_Buffer(void* thisptr, void* srcdst, void* buffer, int x, int y, int hotx, int hoty, int store)
 {
     MouseType* mouse = (MouseType*)thisptr;
     GraphicViewPort* viewport = (GraphicViewPort*)srcdst;
@@ -128,7 +128,7 @@ void __cdecl Mouse_Shadow_Buffer(void* thisptr, void* srcdst, void* buffer, int 
     }
 }
 
-void __cdecl Draw_Mouse(void* thisptr, void* srcdst, int x, int y)
+void Draw_Mouse(void* thisptr, void* srcdst, int x, int y)
 {
     MouseType* mouse = (MouseType*)thisptr;
     GraphicViewPort* viewport = (GraphicViewPort*)srcdst;
@@ -184,7 +184,7 @@ void __cdecl Draw_Mouse(void* thisptr, void* srcdst, int x, int y)
     }
 }
 
-void* __cdecl ASM_Set_Mouse_Cursor(void* thisptr, int hotspotx, int hotspoty, void* cursor)
+void* ASM_Set_Mouse_Cursor(void* thisptr, int hotspotx, int hotspoty, void* cursor)
 {
     MouseType* mouse = (MouseType*)thisptr;
     Shape_Type* cursor_header = (Shape_Type*)(cursor);

--- a/common/wwmouse.h
+++ b/common/wwmouse.h
@@ -5,16 +5,9 @@
 extern "C" {
 #endif
 
-void __cdecl Mouse_Shadow_Buffer(void* thisptr,
-                                 void* srcdst,
-                                 void* buffer,
-                                 int x,
-                                 int y,
-                                 int hotx,
-                                 int hoty,
-                                 int store);
-void __cdecl Draw_Mouse(void* thisptr, void* srcdst, int x, int y);
-void* __cdecl ASM_Set_Mouse_Cursor(void* thisptr, int hotspotx, int hotspoty, void* cursor);
+void Mouse_Shadow_Buffer(void* thisptr, void* srcdst, void* buffer, int x, int y, int hotx, int hoty, int store);
+void Draw_Mouse(void* thisptr, void* srcdst, int x, int y);
+void* ASM_Set_Mouse_Cursor(void* thisptr, int hotspotx, int hotspoty, void* cursor);
 
 #ifdef __cplusplus
 }

--- a/common/wwstd.h
+++ b/common/wwstd.h
@@ -34,8 +34,11 @@
 #ifndef WWSTD_H
 #define WWSTD_H
 
+#include <stdint.h>
+
+#ifdef WIN32
 #include <windows.h>
-#include <windowsx.h>
+#endif
 
 #ifndef IBM
 #define IBM TRUE
@@ -148,13 +151,13 @@ template <class T> T Abs(T a)
     return ((a < 0) ? -(a) : a);
 }
 
-template <class T> VOID minimize(T& a, T b)
+template <class T> void minimize(T& a, T b)
 {
     if (b < a)
         a = b;
 }
 
-template <class T> VOID maximize(T& a, T b)
+template <class T> void maximize(T& a, T b)
 {
     if (b > a)
         a = b;
@@ -171,12 +174,12 @@ template <class T> VOID maximize(T& a, T b)
 
 // Template replacements for the user defines above
 #ifdef __cplusplus
-template <class T> VOID BitFlagsOn(T& a, T b)
+template <class T> void BitFlagsOn(T& a, T b)
 {
     a |= (b);
 }
 
-template <class T> VOID BitFlagsOff(T& a, T b)
+template <class T> void BitFlagsOff(T& a, T b)
 {
     a &= (~(b));
 }
@@ -186,7 +189,7 @@ template <class T> T BitFlagsValue(T a, T b)
     return (a & (b));
 }
 
-template <class T> VOID BitFlagsFlip(T& a, T b)
+template <class T> void BitFlagsFlip(T& a, T b)
 {
     a ^= (b);
 }

--- a/redalert/startup.cpp
+++ b/redalert/startup.cpp
@@ -498,7 +498,7 @@ int main(int argc, char* argv[])
             Read_Setup_Options(&cfile);
 
             Create_Main_Window(instance, command_show, ScreenWidth, ScreenHeight);
-            SoundOn = Audio_Init(MainWindow, 16, false, 11025 * 2, 0);
+            SoundOn = Audio_Init(16, false, 11025 * 2, 0);
 #else  // WIN32
             if (!Debug_Quiet) {
                 Audio_Init(NewConfig.DigitCard,

--- a/redalert/winstub.cpp
+++ b/redalert/winstub.cpp
@@ -541,12 +541,12 @@ void Colour_Debug(int call_number)
 
 //#pragma on (unreferenced)
 
-BOOL Any_Locked(void)
+bool Any_Locked()
 {
     if (SeenBuff.Get_LockCount() || HidPage.Get_LockCount()) {
-        return (TRUE);
+        return true;
     } else {
-        return (FALSE);
+        return false;
     }
 }
 

--- a/tiberiandawn/startup.cpp
+++ b/tiberiandawn/startup.cpp
@@ -385,7 +385,7 @@ int PASCAL WinMain(HINSTANCE instance, HINSTANCE, char* command_line, int comman
 
             CCDebugString("C&C95 - Initialising audio.\n");
 
-            SoundOn = Audio_Init(MainWindow, 16, false, 11025 * 2, 0);
+            SoundOn = Audio_Init(16, false, 11025 * 2, 0);
 
             Palette = new (MEM_CLEAR) unsigned char[768];
 

--- a/tiberiandawn/winstub.cpp
+++ b/tiberiandawn/winstub.cpp
@@ -494,12 +494,12 @@ void Colour_Debug(int call_number)
 
 //#pragma on (unreferenced)
 
-BOOL Any_Locked(void)
+bool Any_Locked()
 {
     if (SeenBuff.Get_LockCount() || HidPage.Get_LockCount()) {
-        return (TRUE);
+        return true;
     } else {
-        return (FALSE);
+        return false;
     }
 }
 


### PR DESCRIPTION
There's a lot of Windows types and `__cdecl` around. Replace with standard types for now.