### PR TITLE
Fix CMAKE_BUILD_TYPE cache

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@ if(NOT WIN32 AND NOT DEFINED CMAKE_TOOLCHAIN_FILE)
 endif()
 
 if(NOT DEFINED CMAKE_BUILD_TYPE)
-    set(CMAKE_BUILD_TYPE Debug)
+    set(CMAKE_BUILD_TYPE "Debug" CACHE STRING "Choose the type of build, options are: Debug Release" FORCE)
 endif()
 
 project(VanillaConquer)


### PR DESCRIPTION
The string wasn't cached so the build defaulted to non-debug all the time after rebuilding.