### PR TITLE
Compatibility changes to unlink byteswapping from sockets apis.

### DIFF
--- a/common/endianness.h
+++ b/common/endianness.h
@@ -1,0 +1,201 @@
+/** 
+* @file
+* @brief  Convert Endianness of shorts, longs, long longs, regardless of architecture/OS
+*
+* Defines (without pulling in platform-specific network include headers):
+* bswap16, bswap32, bswap64, ntoh16, hton16, ntoh32 hton32, ntoh64, hton64
+*
+* Should support linux / macos / solaris / windows.
+* Supports GCC (on any platform, including embedded), MSVC2015, and clang,
+* and should support intel, solaris, and ibm compilers as well.
+*
+* Released under MIT license
+* 
+* Based on https://gist.github.com/jtbr/7a43e6281e6cca353b33ee501421860c
+*/
+
+#ifndef ENDIANNESS_H
+#define ENDIANNESS_H
+
+#include <stdlib.h>
+#include <stdint.h>
+
+/* Detect platform endianness at compile time */
+
+/* When available, these headers can improve platform endianness detection */
+#ifdef __has_include // C++17, supported as extension to C++11 in clang, GCC 5+, vs2015
+#if __has_include(<endian.h>)
+#include <endian.h> // gnu libc normally provides, linux
+#elif __has_include(<machine/endian.h>)
+#include <machine/endian.h> //open bsd, macos
+#elif __has_include(<sys/param.h>)
+#include <sys/param.h> // mingw, some bsd (not open/macos)
+#elif __has_include(<sys/isadefs.h>)
+#include <sys/isadefs.h> // solaris
+#endif
+#endif
+
+#if !defined(__LITTLE_ENDIAN__) && !defined(__BIG_ENDIAN__)
+#if (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)                                                \
+    || (defined(__BYTE_ORDER) && __BYTE_ORDER == __BIG_ENDIAN) || (defined(_BYTE_ORDER) && _BYTE_ORDER == _BIG_ENDIAN) \
+    || (defined(BYTE_ORDER) && BYTE_ORDER == BIG_ENDIAN)                                                               \
+    || (defined(__sun) && defined(__SVR4) && defined(_BIG_ENDIAN)) || defined(__ARMEB__) || defined(__THUMBEB__)       \
+    || defined(__AARCH64EB__) || defined(_MIBSEB) || defined(__MIBSEB) || defined(__MIBSEB__) || defined(_M_PPC)
+#define __BIG_ENDIAN__
+#elif (defined(__BYTE_ORDER__) && __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__) || /* gcc */                              \
+    (defined(__BYTE_ORDER) && __BYTE_ORDER == __LITTLE_ENDIAN)                  /* linux header */                     \
+    || (defined(_BYTE_ORDER) && _BYTE_ORDER == _LITTLE_ENDIAN)                                                         \
+    || (defined(BYTE_ORDER) && BYTE_ORDER == LITTLE_ENDIAN)              /* mingw header */                            \
+    || (defined(__sun) && defined(__SVR4) && defined(_LITTLE_ENDIAN)) || /* solaris */                                 \
+    defined(__ARMEL__) || defined(__THUMBEL__) || defined(__AARCH64EL__) || defined(_MIPSEL) || defined(__MIPSEL)      \
+    || defined(__MIPSEL__) || defined(_M_IX86) || defined(_M_X64) || defined(_M_IA64)                                  \
+    ||              /* msvc for intel processors */                                                                    \
+    defined(_M_ARM) /* msvc code on arm executes in little endian mode */
+#define __LITTLE_ENDIAN__
+#endif
+#endif
+
+/* Undefine these macros if the platform header already defined them */
+#ifdef bswap16
+#undef bswap16
+#endif
+
+#ifdef bswap32
+#undef bswap32
+#endif
+
+#ifdef bswap64
+#undef bswap64
+#endif
+
+/* Define unconditional byte-swap functions, using fast processor-native built-ins where possible */
+#if defined(_MSC_VER) /* needs to be first because msvc doesn't short-circuit after failing defined(__has_builtin) */
+#define bswap16(x) _byteswap_ushort((x))
+#define bswap32(x) _byteswap_ulong((x))
+#define bswap64(x) _byteswap_uint64((x))
+#elif (__GNUC__ > 4) || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
+#define bswap16(x) __builtin_bswap16((x))
+#define bswap32(x) __builtin_bswap32((x))
+#define bswap64(x) __builtin_bswap64((x))
+#elif defined(__has_builtin)                                                                                           \
+    && __has_builtin(                                                                                                  \
+        __builtin_bswap64) /* for clang; gcc 5 fails on this and && shortcircuit fails; must be after GCC check */
+#define bswap16(x) __builtin_bswap16((x))
+#define bswap32(x) __builtin_bswap32((x))
+#define bswap64(x) __builtin_bswap64((x))
+#else
+/* even in this case, compilers often optimize by using native instructions */
+static inline uint16_t bswap16(uint16_t x)
+{
+    return (((x >> 8) & 0xffu) | ((x & 0xffu) << 8));
+}
+static inline uint32_t bswap32(uint32_t x)
+{
+    return (((x & 0xff000000u) >> 24) | ((x & 0x00ff0000u) >> 8) | ((x & 0x0000ff00u) << 8)
+            | ((x & 0x000000ffu) << 24));
+}
+static inline uint64_t bswap64(uint64_t x)
+{
+    return (((x & 0xff00000000000000ull) >> 56) | ((x & 0x00ff000000000000ull) >> 40)
+            | ((x & 0x0000ff0000000000ull) >> 24) | ((x & 0x000000ff00000000ull) >> 8)
+            | ((x & 0x00000000ff000000ull) << 8) | ((x & 0x0000000000ff0000ull) << 24)
+            | ((x & 0x000000000000ff00ull) << 40) | ((x & 0x00000000000000ffull) << 56));
+}
+#endif
+
+/* Check if we have the facility to check if a compiler supports a given attribute */
+#ifndef __has_attribute
+#define __has_attribute(x) 0
+#endif
+
+/* Convert 32-bit float from host to network byte order */
+static inline float bswapf(float f)
+{
+    /* We need to do some type punning, so create types that can violate strict aliasing */
+#if __has_attribute(__may_alias__)
+    typedef float __attribute__((__may_alias__)) float_a;
+    typedef uint32_t __attribute__((__may_alias__)) uint32_a;
+#else
+    /* MSVC doesn't currently enforce strict aliasing and thus has no extension to disable it. */
+    typedef float float_a;
+    typedef uint32_t uint32_a;
+#endif
+
+    uint32_t val = bswap32(*(const uint32_a*)(&f));
+    return *((float_a*)(&val));
+}
+
+static inline double bswapd(double f)
+{
+    /* We need to do some type punning, so create types that can violate strict aliasing */
+#if __has_attribute(__may_alias__)
+    typedef double __attribute__((__may_alias__)) double_a;
+    typedef uint64_t __attribute__((__may_alias__)) uint64_a;
+#else
+    /* MSVC doesn't currently enforce strict aliasing and thus has no extension to disable it. */
+    typedef double double_a;
+    typedef uint64_t uint64_a;
+#endif
+
+    uint64_t val = bswap64(*(const uint64_a*)(&f));
+    return *((double_a*)(&val));
+}
+
+/* Defines byte swaps as needed depending upon platform endianness */
+#if !defined(htobe32) /* Assume all are defined if this is. */
+#if defined(__LITTLE_ENDIAN__)
+#define htobe16(x) bswap16(x)
+#define htole16(x) (x)
+#define be16toh(x) bswap16(x)
+#define le16toh(x) (x)
+
+#define htobe32(x) bswap32(x)
+#define htole32(x) (x)
+#define be32toh(x) bswap32(x)
+#define le32toh(x) (x)
+
+#define htobe64(x) bswap64(x)
+#define htole64(x) (x)
+#define be64toh(x) bswap64(x)
+#define le64toh(x) (x)
+
+#define beftoh(x) bswapf(x)
+#define leftoh(x) (x)
+
+#define bedtoh(x) bswapd(x)
+#define ledtoh(x) (x)
+#elif defined(__BIG_ENDIAN__)
+#define htobe16(x) (x)
+#define htole16(x) bswap16(x)
+#define be16toh(x) (x)
+#define le16toh(x) bswap16(x)
+
+#define htobe32(x) (x)
+#define htole32(x) bswap32(x)
+#define be32toh(x) (x)
+#define le32toh(x) bswap32(x)
+
+#define htobe64(x) (x)
+#define htole64(x) bswap64(x)
+#define be64toh(x) (x)
+#define le64toh(x) bswap64(x)
+
+#define beftoh(x) (x)
+#define leftoh(x) bswapf(x)
+
+#define bedtoh(x) (x)
+#define ledtoh(x) bswapd(x)
+#else
+#warning "Unknown Platform / endianness; network / host byte swaps not defined."
+#endif
+#endif
+
+/* Some aliases similar to the standard sockets byte swaps for network order transmission. */
+#define ntoh16(x) be16toh((x))
+#define hton16(x) htobe16((x))
+#define ntoh32(x) be32toh((x))
+#define hton32(x) htobe32((x))
+#define ntoh64(x) be64toh((x))
+#define hton64(x) htobe64((x))
+
+#endif /* ENDIANNESS_H */

--- a/common/field.cpp
+++ b/common/field.cpp
@@ -31,6 +31,7 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 #include <string.h>
 #include "field.h"
+#include "endianness.h"
 
 // ST - 12/18/2018 10:14AM
 #pragma warning(disable : 4996)
@@ -140,12 +141,12 @@ void FieldClass::Host_To_Net(void)
 
     case TYPE_SHORT:
     case TYPE_UNSIGNED_SHORT:
-        *((unsigned short*)Data) = htons(*((unsigned short*)Data));
+        *((unsigned short*)Data) = hton16(*((unsigned short*)Data));
         break;
 
     case TYPE_LONG:
     case TYPE_UNSIGNED_LONG:
-        *((unsigned long*)Data) = htonl(*((unsigned long*)Data));
+        *((unsigned long*)Data) = hton32(*((unsigned long*)Data));
         break;
 
     //
@@ -158,8 +159,8 @@ void FieldClass::Host_To_Net(void)
     //
     // Finally convert over the data type and the size of the packet.
     //
-    DataType = htons(DataType);
-    Size = htons(Size);
+    DataType = hton16(DataType);
+    Size = hton16(Size);
 }
 /**************************************************************************
  * PACKETCLASS::NET_TO_HOST_FIELD -- Converts net field to host format    *
@@ -177,9 +178,9 @@ void FieldClass::Net_To_Host(void)
     // Convert the variables to host order.  This needs to be converted so
     // the switch statement does compares on the data that follows.
     //
-    Size = ntohs(Size);
+    Size = ntoh16(Size);
 
-    DataType = ntohs(DataType);
+    DataType = ntoh16(DataType);
 
     //
     // Before we convert the data type, we should convert the actual data
@@ -194,12 +195,12 @@ void FieldClass::Net_To_Host(void)
 
     case TYPE_SHORT:
     case TYPE_UNSIGNED_SHORT:
-        *((unsigned short*)Data) = ntohs(*((unsigned short*)Data));
+        *((unsigned short*)Data) = ntoh16(*((unsigned short*)Data));
         break;
 
     case TYPE_LONG:
     case TYPE_UNSIGNED_LONG:
-        *((unsigned long*)Data) = ntohl(*((unsigned long*)Data));
+        *((unsigned long*)Data) = ntoh32(*((unsigned long*)Data));
         break;
 
     //

--- a/common/packet.cpp
+++ b/common/packet.cpp
@@ -36,6 +36,7 @@
 #include <string.h>
 
 #include "packet.h"
+#include "endianness.h"
 
 #ifdef NOMINMAX
 inline int min(int a, int b)
@@ -108,10 +109,10 @@ PacketClass::PacketClass(char* curbuf)
     //
     Size = *(unsigned short*)curbuf;
     curbuf += sizeof(unsigned short);
-    Size = ntohs(Size);
+    Size = ntoh16(Size);
     ID = *(short*)curbuf;
     curbuf += sizeof(short);
-    ID = ntohs(ID);
+    ID = ntoh16(ID);
     Head = NULL;
 
     //
@@ -137,7 +138,7 @@ PacketClass::PacketClass(char* curbuf)
         //
         // Copy the data into the buffer
         //
-        int size = ntohs(field->Size);
+        int size = ntoh16(field->Size);
         field->Data = new char[size];
         memcpy(field->Data, curbuf, size);
         curbuf += size;
@@ -145,7 +146,7 @@ PacketClass::PacketClass(char* curbuf)
         //
         // Make sure we allow for the pad bytes.
         //
-        int pad = (4 - (ntohs(field->Size) & 3)) & 3;
+        int pad = (4 - (ntoh16(field->Size) & 3)) & 3;
         curbuf += pad;
         remaining_size -= pad;
 
@@ -205,9 +206,9 @@ char* PacketClass::Create_Comms_Packet(int& size)
     //
     // write the size into the packet header
     //
-    *(unsigned short*)curbuf = (unsigned short)htons((unsigned short)size);
+    *(unsigned short*)curbuf = (unsigned short)hton16((unsigned short)size);
     curbuf += sizeof(unsigned short);
-    *(short*)curbuf = htons(ID);
+    *(short*)curbuf = hton16(ID);
     curbuf += sizeof(short);
 
     //
@@ -230,13 +231,13 @@ char* PacketClass::Create_Comms_Packet(int& size)
         //
         // Copy the data into the buffer and then advance the buffer
         //
-        memcpy(curbuf, current->Data, ntohs(current->Size));
-        curbuf += ntohs(current->Size);
+        memcpy(curbuf, current->Data, ntoh16(current->Size));
+        curbuf += ntoh16(current->Size);
 
         //
         // Finally take care of any pad bytes by setting them to 0
         //
-        int pad = (4 - (ntohs(current->Size) & 3)) & 3;
+        int pad = (4 - (ntoh16(current->Size) & 3)) & 3;
 
         //
         //	If there is any pad left over, make sure you memset it

--- a/redalert/function.h
+++ b/redalert/function.h
@@ -139,13 +139,6 @@ inline int max(int a, int b)
 }
 #endif
 
-#ifndef NETWORKING
-#define htonl(x) x
-#define htons(x) x
-#define ntohl(x) x
-#define ntohs(x) x
-#endif
-
 /**********************************************************************
 **	This class is solely used as a parameter to a constructor that does
 **	absolutely no initialization to the object being constructed. By using

--- a/redalert/stats.cpp
+++ b/redalert/stats.cpp
@@ -580,8 +580,8 @@ void Send_Statistics_Packet(void)
 
         if (handle != INVALID_HANDLE_VALUE) {
             if (GetFileTime(handle, NULL, NULL, &write_time)) {
-                write_time.dwLowDateTime = htonl(write_time.dwLowDateTime);
-                write_time.dwHighDateTime = htonl(write_time.dwHighDateTime);
+                write_time.dwLowDateTime = hton32(write_time.dwLowDateTime);
+                write_time.dwHighDateTime = hton32(write_time.dwHighDateTime);
                 stats.Add_Field(FIELD_GAME_BUILD_DATE, (void*)&write_time, sizeof(write_time));
             }
         }

--- a/redalert/tcpip.cpp
+++ b/redalert/tcpip.cpp
@@ -53,6 +53,7 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #include "function.h"
+#include "common/endianness.h"
 #include "common/tcpip.h"
 
 #ifdef NETWORKING
@@ -430,8 +431,8 @@ bool TcpipManagerClass::Add_Client(void)
     ** Bind our UDP socket to our UDP port number
     */
     addr.sin_family = AF_INET;
-    addr.sin_port = htons(PlanetWestwoodPortNumber);
-    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_port = hton16(PlanetWestwoodPortNumber);
+    addr.sin_addr.s_addr = hton32(INADDR_ANY);
 
     if (bind(UDPSocket, (LPSOCKADDR)&addr, sizeof(addr)) == SOCKET_ERROR) {
         Close_Socket(UDPSocket);
@@ -584,7 +585,7 @@ void TcpipManagerClass::Message_Handler(HWND, UINT message, UINT, LONG lParam)
                 }
 
                 addr.sin_family = AF_INET;
-                addr.sin_port = htons(PlanetWestwoodPortNumber);
+                addr.sin_port = hton16(PlanetWestwoodPortNumber);
                 memcpy(&addr.sin_addr.s_addr, &UDPIPAddress, 4);
 
                 /*
@@ -722,7 +723,7 @@ void TcpipManagerClass::Start_Client(void)
 
     addr.sin_family = AF_INET;
     addr.sin_port = 0;
-    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_addr.s_addr = hton32(INADDR_ANY);
 
     /*
     ** Set up the incoming and outgoing data buffers head and tail pointers
@@ -760,8 +761,8 @@ void TcpipManagerClass::Start_Client(void)
     ** Bind our UDP socket to our UDP port number
     */
     addr.sin_family = AF_INET;
-    addr.sin_port = htons(PlanetWestwoodPortNumber);
-    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_port = hton16(PlanetWestwoodPortNumber);
+    addr.sin_addr.s_addr = hton32(INADDR_ANY);
 
     if (bind(UDPSocket, (LPSOCKADDR)&addr, sizeof(addr)) == SOCKET_ERROR) {
         Close_Socket(UDPSocket);

--- a/redalert/utracker.cpp
+++ b/redalert/utracker.cpp
@@ -42,14 +42,15 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #include "function.h"
+#include "common/endianness.h"
 
 /*
 ** Define host to network to host functions for DOS
 */
 #ifndef WIN32
 
-#define htonl(val) 0
-#define ntohl(val) 0
+#define hton32(val) 0
+#define ntoh32(val) 0
 
 #endif // WIN32
 
@@ -188,7 +189,7 @@ void UnitTrackerClass::To_Network_Format(void)
 {
     if (!InNetworkFormat) {
         for (int i = 0; i < UnitCount; i++) {
-            UnitTotals[i] = htonl(UnitTotals[i]);
+            UnitTotals[i] = hton32(UnitTotals[i]);
         }
     }
     InNetworkFormat = 1; // Flag that data is now in network format
@@ -212,7 +213,7 @@ void UnitTrackerClass::To_PC_Format(void)
 {
     if (InNetworkFormat) {
         for (int i = 0; i < UnitCount; i++) {
-            UnitTotals[i] = ntohl(UnitTotals[i]);
+            UnitTotals[i] = ntoh32(UnitTotals[i]);
         }
     }
     InNetworkFormat = 0; // Flag that data is now in PC format

--- a/redalert/wol_gsup.cpp
+++ b/redalert/wol_gsup.cpp
@@ -3241,7 +3241,7 @@ void WOL_GameSetupDialog::TriggerGameStart(char* szGoMessage)
             pPlayerNew = new NodeNameType;
             strcpy(pPlayerNew->Name, szPlayerName);
             //	Get player's IP address from pChatSink...
-            unsigned long lAddress = (pWO->pChatSink->GetPlayerGameIP(szPlayerName)); // ntohl(
+            unsigned long lAddress = (pWO->pChatSink->GetPlayerGameIP(szPlayerName)); // ntoh32(
             //			debugprint( "IP address is %i, or 0x%x\n", lAddress, lAddress );
             if (pWO->GameInfoCurrent.bTournament) {
                 //	This is a tournament game, and I therefore have only one opponent: this one.

--- a/redalert/wspudp.cpp
+++ b/redalert/wspudp.cpp
@@ -44,6 +44,7 @@
 #include "function.h"
 #include "internet.h"
 #include "wspudp.h"
+#include "common/endianness.h"
 
 #include <assert.h>
 #include <stdio.h>
@@ -164,8 +165,8 @@ bool UDPInterfaceClass::Open_Socket(SOCKET)
     ** Bind our UDP socket to our UDP port number
     */
     addr.sin_family = AF_INET;
-    addr.sin_port = (unsigned short)htons((unsigned short)PlanetWestwoodPortNumber);
-    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_port = (unsigned short)hton16((unsigned short)PlanetWestwoodPortNumber);
+    addr.sin_addr.s_addr = hton32(INADDR_ANY);
 
     if (bind(Socket, (LPSOCKADDR)&addr, sizeof(addr)) == SOCKET_ERROR) {
         Close_Socket();
@@ -200,7 +201,7 @@ bool UDPInterfaceClass::Open_Socket(SOCKET)
             break;
 
         unsigned long address = **addresses++;
-        // address = ntohl (address);
+        // address = ntoh32 (address);
 
         char temp[128];
         sprintf(temp,
@@ -399,7 +400,7 @@ long UDPInterfaceClass::Message_Handler(HWND, UINT message, UINT, LONG lParam)
         ** Set up the address structure of the outgoing packet
         */
         addr.sin_family = AF_INET;
-        addr.sin_port = (unsigned short)htons((unsigned short)PlanetWestwoodPortNumber);
+        addr.sin_port = (unsigned short)hton16((unsigned short)PlanetWestwoodPortNumber);
         memcpy(&addr.sin_addr.s_addr, packet->Address + 4, 4);
 
         /*

--- a/tiberiandawn/function.h
+++ b/tiberiandawn/function.h
@@ -104,13 +104,6 @@ inline int max(int a, int b)
 #include <windows.h>
 #endif
 
-#ifndef NETWORKING
-#define htonl(x) x
-#define htons(x) x
-#define ntohl(x) x
-#define ntohs(x) x
-#endif
-
 /**********************************************************************
 **	If the following define is enabled, then the memory checking code
 **	will be disabled.

--- a/tiberiandawn/ipxconn.cpp
+++ b/tiberiandawn/ipxconn.cpp
@@ -570,7 +570,7 @@ int IPXConnClass::Send_To(char* buf, int buflen, IPXAddressClass* address, NetNo
 
         char* tempsend = new char[buflen + sizeof(target_mask)];
 
-        *(unsigned short*)tempsend = htons(target_mask);
+        *(unsigned short*)tempsend = hton16(target_mask);
         memcpy(tempsend + 2, buf, buflen);
 #if (0)
         char tempbuf[256];

--- a/tiberiandawn/ipxmgr.cpp
+++ b/tiberiandawn/ipxmgr.cpp
@@ -966,7 +966,7 @@ int IPXManagerClass::Service(void)
             */
             CurHeaderBuf = (IPXHEADER*)&temp_receive_buffer[0]; // NULL;
             unsigned short* swapptr = (unsigned short*)CurHeaderBuf;
-            *swapptr = ntohs(*swapptr);
+            *swapptr = ntoh16(*swapptr);
 
             CurDataBuf = (char*)&temp_receive_buffer[2];
 

--- a/tiberiandawn/stats.cpp
+++ b/tiberiandawn/stats.cpp
@@ -402,8 +402,8 @@ void Send_Statistics_Packet(void)
 
         if (handle != INVALID_HANDLE_VALUE) {
             if (GetFileTime(handle, NULL, NULL, &write_time)) {
-                write_time.dwLowDateTime = htonl(write_time.dwLowDateTime);
-                write_time.dwHighDateTime = htonl(write_time.dwHighDateTime);
+                write_time.dwLowDateTime = hton32(write_time.dwLowDateTime);
+                write_time.dwHighDateTime = hton32(write_time.dwHighDateTime);
                 stats.Add_Field(FIELD_GAME_BUILD_DATE, (void*)&write_time, sizeof(write_time));
             }
         }

--- a/tiberiandawn/tcpip.cpp
+++ b/tiberiandawn/tcpip.cpp
@@ -54,6 +54,7 @@
 
 #include "function.h"
 #include "common/tcpip.h"
+#include "common/endianness.h"
 
 #ifdef NETWORKING
 
@@ -283,8 +284,8 @@ void TcpipManagerClass::Start_Server(void)
     }
 
     addr.sin_family = AF_INET;
-    addr.sin_port = htons(PORTNUM);
-    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_port = hton16(PORTNUM);
+    addr.sin_addr.s_addr = hton32(INADDR_ANY);
 
     if (bind(ListenSocket, (LPSOCKADDR)&addr, sizeof(addr)) == SOCKET_ERROR) {
         Close_Socket(ListenSocket);
@@ -468,8 +469,8 @@ bool TcpipManagerClass::Add_Client(void)
     ** Bind our UDP socket to our UDP port number
     */
     addr.sin_family = AF_INET;
-    addr.sin_port = htons(PlanetWestwoodPortNumber);
-    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_port = hton16(PlanetWestwoodPortNumber);
+    addr.sin_addr.s_addr = hton32(INADDR_ANY);
 
     if (bind(UDPSocket, (LPSOCKADDR)&addr, sizeof(addr)) == SOCKET_ERROR) {
         Close_Socket(UDPSocket);
@@ -622,7 +623,7 @@ void TcpipManagerClass::Message_Handler(HWND, UINT message, UINT, LONG lParam)
                 }
 
                 addr.sin_family = AF_INET;
-                addr.sin_port = htons(PlanetWestwoodPortNumber);
+                addr.sin_port = hton16(PlanetWestwoodPortNumber);
                 memcpy(&addr.sin_addr.s_addr, &UDPIPAddress, 4);
 
                 /*
@@ -809,7 +810,7 @@ void TcpipManagerClass::Start_Client(void)
 
     addr.sin_family = AF_INET;
     addr.sin_port = 0;
-    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_addr.s_addr = hton32(INADDR_ANY);
 
     /*
     ** Set up the incoming and outgoing data buffers head and tail pointers
@@ -852,8 +853,8 @@ void TcpipManagerClass::Start_Client(void)
     ** Bind our UDP socket to our UDP port number
     */
     addr.sin_family = AF_INET;
-    addr.sin_port = htons(PlanetWestwoodPortNumber);
-    addr.sin_addr.s_addr = htonl(INADDR_ANY);
+    addr.sin_port = hton16(PlanetWestwoodPortNumber);
+    addr.sin_addr.s_addr = hton32(INADDR_ANY);
 
     if (bind(UDPSocket, (LPSOCKADDR)&addr, sizeof(addr)) == SOCKET_ERROR) {
         Close_Socket(UDPSocket);

--- a/tiberiandawn/utracker.cpp
+++ b/tiberiandawn/utracker.cpp
@@ -42,6 +42,7 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #include "function.h"
+#include "common/endianness.h"
 
 /***********************************************************************************************
  * UTC::UnitTrackerClass -- Class constructor                                                  *
@@ -178,7 +179,7 @@ void UnitTrackerClass::To_Network_Format(void)
 {
     if (!InNetworkFormat) {
         for (int i = 0; i < UnitCount; i++) {
-            UnitTotals[i] = htonl(UnitTotals[i]);
+            UnitTotals[i] = hton32(UnitTotals[i]);
         }
     }
     InNetworkFormat = 1; // Flag that data is now in network format
@@ -202,7 +203,7 @@ void UnitTrackerClass::To_PC_Format(void)
 {
     if (InNetworkFormat) {
         for (int i = 0; i < UnitCount; i++) {
-            UnitTotals[i] = ntohl(UnitTotals[i]);
+            UnitTotals[i] = ntoh32(UnitTotals[i]);
         }
     }
     InNetworkFormat = 0; // Flag that data is now in PC format


### PR DESCRIPTION
Adds an endianness detection header that provides appropriate byte swapping functions for all fixed width types.
Replaces calls to the sockets api `htonl` and friends with equivalents from the new header.