### PR TITLE
Adds a compatibility header to mask most differences between the basic sockets API.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,7 +102,7 @@ endif()
 
 if(NETWORKING)
     list(APPEND VANILLA_DEFS NETWORKING)
-    list(APPEND VANILLA_LIBS wsock32 ws2_32)
+    list(APPEND VANILLA_LIBS ws2_32)
 endif()
 
 add_subdirectory(common)

--- a/common/field.h
+++ b/common/field.h
@@ -34,14 +34,12 @@
 #ifndef __FIELD_H
 #define __FIELD_H
 
-#ifdef _WIN32
-#include <windows.h>
-#else
-#include <arpa/inet.h>
+#ifdef NETWORKING
+#include "sockets.h"
 #endif
 
-#ifdef NETWORKING
-#include <winsock.h>
+#ifdef _WIN32
+#include <windows.h>
 #endif
 
 #define FIELD_HEADER_SIZE (sizeof(FieldClass) - (sizeof(void*) * 2))

--- a/common/sockets.h
+++ b/common/sockets.h
@@ -1,0 +1,66 @@
+/**
+ * @file
+ * @brief Single include to mask most sockets api differences between windows and posix.
+ */
+#ifndef SOCKETS_H
+#define SOCKETS_H
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+
+#define LastSocketError (WSAGetLastError())
+
+static inline int socket_startup(void)
+{
+    WSADATA wsa_data;
+    return WSAStartup(MAKEWORD(2, 2), &wsa_data);
+}
+
+static inline int socket_cleanup(void)
+{
+    return WSACleanup();
+}
+
+#else /* Assume posix style sockets on non-windows */
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netdb.h> // for getaddrinfo() and freeaddrinfo()
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h> // for close()
+typedef int SOCKET;
+#define INVALID_SOCKET       (-1)
+#define SOCKET_ERROR         (-1)
+#define closesocket(x)       close(x)
+#define ioctlsocket(x, y, z) ioctl(x, y, z)
+#define LastSocketError      (errno)
+
+#define WSAEISCONN       EISCONN
+#define WSAEINPROGRESS   EINPROGRESS
+#define WSAEALREADY      EALREADY
+#define WSAEADDRINUSE    EADDRINUSE
+#define WSAEADDRNOTAVAIL EADDRNOTAVAIL
+#define WSAEBADF         EBADF
+#define WSAECONNREFUSED  ECONNREFUSED
+#define WSAEINTR         EINTR
+#define WSAENOTSOCK      ENOTSOCK
+#define WSAEWOULDBLOCK   EWOULDBLOCK
+#define WSAEINVAL        EINVAL
+#define WSAETIMEDOUT     ETIMEDOUT
+
+static inline int socket_startup(void)
+{
+    return 0;
+}
+
+static inline int socket_cleanup(void)
+{
+    return 0;
+}
+
+#endif /* _WIN32 */
+
+#endif /* SOCKETS_H */

--- a/redalert/function.h
+++ b/redalert/function.h
@@ -99,6 +99,7 @@ Map(screen) class heirarchy.
 
 #include "watcom.h"
 #include "lint.h"
+#include "common/sockets.h" // Must come before windows.h include.
 
 #ifdef WIN32
 //#define WIN32_LEAN_AND_MEAN

--- a/redalert/stats.cpp
+++ b/redalert/stats.cpp
@@ -412,10 +412,10 @@ void Send_Statistics_Packet(void)
                             }
                         }
                         //						else
-                        //							debugprint( "gethostbyname failed. Error %i\n", WSAGetLastError() );
+                        //							debugprint( "gethostbyname failed. Error %i\n", LastSocketError );
                     }
                     //					else
-                    //						debugprint( "gethostname failed with %i, error %i\n", iRes, WSAGetLastError()
+                    //						debugprint( "gethostname failed with %i, error %i\n", iRes, LastSocketError
                     //);
                 }
                 stats.Add_Field(FIELD_PLAYER1_IP, (char*)szIPAddress);

--- a/redalert/tcpip.cpp
+++ b/redalert/tcpip.cpp
@@ -164,7 +164,7 @@ void TcpipManagerClass::Close(void)
     /*
     ** Call the Winsock cleanup function to say we are finished using Winsock
     */
-    WSACleanup();
+    socket_cleanup();
 
     WinsockInitialised = FALSE;
     Connected = FALSE;
@@ -187,7 +187,6 @@ void TcpipManagerClass::Close(void)
 
 bool TcpipManagerClass::Init(void)
 {
-    short version;
     int rc;
 
     /*
@@ -206,16 +205,8 @@ bool TcpipManagerClass::Init(void)
     /*
     ** Start WinSock, and fill in our WinSockData
     */
-    version = (WINSOCK_MINOR_VER << 8) | WINSOCK_MAJOR_VER;
-    rc = WSAStartup(version, &WinsockInfo);
+    rc = socket_startup();
     if (rc != 0) {
-        return (FALSE);
-    }
-
-    /*
-    ** Check the Winsock version number
-    */
-    if ((WinsockInfo.wVersion & 0x00ff) != (version & 0x00ff) || (WinsockInfo.wVersion >> 8) != (version >> 8)) {
         return (FALSE);
     }
 
@@ -386,7 +377,7 @@ bool TcpipManagerClass::Add_Client(void)
     addrsize = sizeof(addr);
     ConnectSocket = accept(ListenSocket, (LPSOCKADDR)&addr, &addrsize);
     if (ConnectSocket == INVALID_SOCKET) {
-        // Show_Error("accept", WSAGetLastError());
+        // Show_Error("accept", LastSocketError);
         return (FALSE);
     }
 
@@ -603,7 +594,7 @@ void TcpipManagerClass::Message_Handler(HWND, UINT message, UINT, LONG lParam)
                                 sizeof(addr));
 
                     if (rc == SOCKET_ERROR) {
-                        if (WSAGetLastError() != WSAEWOULDBLOCK) {
+                        if (LastSocketError != WSAEWOULDBLOCK) {
                             Clear_Socket_Error(UDPSocket);
                         }
                         break;

--- a/redalert/wsproto.cpp
+++ b/redalert/wsproto.cpp
@@ -134,7 +134,7 @@ void WinsockInterfaceClass::Close(void)
     /*
     ** Call the Winsock cleanup function to say we are finished using Winsock
     */
-    WSACleanup();
+    socket_cleanup();
 
     WinsockInitialised = false;
 }
@@ -278,7 +278,6 @@ void WinsockInterfaceClass::Discard_Out_Buffers(void)
  *=============================================================================================*/
 bool WinsockInterfaceClass::Init(void)
 {
-    short version;
     int rc;
 
     /*
@@ -286,13 +285,6 @@ bool WinsockInterfaceClass::Init(void)
     */
     if (WinsockInitialised)
         return (true);
-
-    /*
-    ** Create a buffer much larger than the sizeof (WSADATA) would indicate since Bounds Checker
-    ** says that a buffer of that size gets overrun.
-    */
-    char* buffer = new char[sizeof(WSADATA) + 1024];
-    WSADATA* winsock_info = (WSADATA*)(&buffer[0]);
 
     /*
     ** Initialise socket and event handle to null
@@ -305,22 +297,11 @@ bool WinsockInterfaceClass::Init(void)
     /*
     ** Start WinSock, and fill in our Winsock info structure
     */
-    version = (WINSOCK_MINOR_VER << 8) | WINSOCK_MAJOR_VER;
-    rc = WSAStartup(version, winsock_info);
+    rc = socket_startup();
     if (rc != 0) {
         char out[128];
         sprintf(out, "TS: Winsock failed to initialise - error code %d.\n", GetLastError());
         OutputDebugString(out);
-        delete[] buffer;
-        return (false);
-    }
-
-    /*
-    ** Check the Winsock version number
-    */
-    if ((winsock_info->wVersion & 0x00ff) != (version & 0x00ff) || (winsock_info->wVersion >> 8) != (version >> 8)) {
-        OutputDebugString("TS: Winsock version is less than 1.1\n");
-        delete[] buffer;
         return (false);
     }
 
@@ -329,7 +310,6 @@ bool WinsockInterfaceClass::Init(void)
     */
     WinsockInitialised = true;
 
-    delete[] buffer;
     return (true);
 }
 

--- a/redalert/wsproto.h
+++ b/redalert/wsproto.h
@@ -37,10 +37,10 @@
 #include "_wsproto.h"
 
 /*
-** Include standard Winsock 1.0 header file.
+** Include compatability sockets header file.
 */
 #ifdef NETWORKING
-#include <winsock.h>
+#include "common/sockets.h"
 #endif
 
 /*

--- a/redalert/wspudp.cpp
+++ b/redalert/wspudp.cpp
@@ -412,7 +412,7 @@ long UDPInterfaceClass::Message_Handler(HWND, UINT message, UINT, LONG lParam)
         rc = sendto(Socket, (const char*)packet->Buffer, packet->BufferLen, 0, (LPSOCKADDR)&addr, sizeof(addr));
 
         if (rc == SOCKET_ERROR) {
-            if (WSAGetLastError() != WSAEWOULDBLOCK) {
+            if (LastSocketError != WSAEWOULDBLOCK) {
                 Clear_Socket_Error(Socket);
                 return (0);
             }

--- a/tiberiandawn/function.h
+++ b/tiberiandawn/function.h
@@ -100,6 +100,8 @@ inline int max(int a, int b)
 }
 #endif
 
+#include "common/sockets.h" // Must come before windows.h include.
+
 #ifdef _WIN32
 #include <windows.h>
 #endif


### PR DESCRIPTION
Keeps most differences hidden behind single header for standard sockets api stuff. A solution to replace the asyncronous notifications that file descriptors are ready to read and write will still be needed, either a polling thread on fd sets or an alternative async api for IO.

Requires #126 to be merged first to build on linux correctly.