### PR TITLE
No assembly by default, drop JWasm requirement

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -20,11 +20,13 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get install -y g++-multilib
-        curl -L -O https://github.com/JWasm/JWasm/archive/45f69e4b96ff3e93522464f2c8bb2ff56e6ecbf8.zip
-        unzip 45f69e4b96ff3e93522464f2c8bb2ff56e6ecbf8.zip
-        cd JWasm-45f69e4b96ff3e93522464f2c8bb2ff56e6ecbf8
-        make -f GccUnix.mak
-        sudo cp GccUnixR/jwasm /usr/local/bin/
+        if [ ${{ matrix.asm }} == "ON" ]; then
+            curl -L -O https://github.com/JWasm/JWasm/archive/45f69e4b96ff3e93522464f2c8bb2ff56e6ecbf8.zip
+            unzip 45f69e4b96ff3e93522464f2c8bb2ff56e6ecbf8.zip
+            cd JWasm-45f69e4b96ff3e93522464f2c8bb2ff56e6ecbf8
+            make -f GccUnix.mak
+            sudo cp GccUnixR/jwasm /usr/local/bin/
+        fi
 
     - name: Build common and tests
       run: |

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -23,11 +23,13 @@ jobs:
         sudo dpkg --add-architecture i386
         sudo apt-get update
         sudo apt-get install -y mingw-w64 clang-format-10 wine-stable:i386 imagemagick
-        curl -L -O https://github.com/JWasm/JWasm/archive/45f69e4b96ff3e93522464f2c8bb2ff56e6ecbf8.zip
-        unzip 45f69e4b96ff3e93522464f2c8bb2ff56e6ecbf8.zip
-        cd JWasm-45f69e4b96ff3e93522464f2c8bb2ff56e6ecbf8
-        make -f GccUnix.mak
-        sudo cp GccUnixR/jwasm /usr/local/bin/
+        if [ ${{ matrix.features }} == "ON" ]; then
+            curl -L -O https://github.com/JWasm/JWasm/archive/45f69e4b96ff3e93522464f2c8bb2ff56e6ecbf8.zip
+            unzip 45f69e4b96ff3e93522464f2c8bb2ff56e6ecbf8.zip
+            cd JWasm-45f69e4b96ff3e93522464f2c8bb2ff56e6ecbf8
+            make -f GccUnix.mak
+            sudo cp GccUnixR/jwasm /usr/local/bin/
+        fi
    
     - name: Build Vanilla Conquer
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,23 +14,46 @@ endif()
 
 project(VanillaConquer)
 
+# For now build the dll files by default only for windows while there is only the proprietary GlyphX frontend for them.
+if(WIN32)
+    set(DEFAULT_REMASTER ON)
+else()
+    set(DEFAULT_REMASTER OFF)
+endif()
+
+option(BUILD_REMASTERTD "Build Tiberian Dawn remaster dll." ${DEFAULT_REMASTER})
+option(BUILD_REMASTERRA "Build Red Alert remaster dll." ${DEFAULT_REMASTER})
+option(BUILD_VANILLATD "Build Tiberian Dawn executable." ON)
+option(BUILD_VANILLARA "Build Red Alert executable." ON)
+option(MAP_EDITORTD "Include internal scenario editor in Tiberian Dawn build." OFF)
+option(MAP_EDITORRA "Include internal scenario editor in Red Alert build." OFF)
+option(NETWORKING "Enable network play." ON)
+option(DSOUND "Enable DirectSound audio." ON)
+option(DDRAW "Enable DirectDraw video backend." ON)
+option(USE_ASM "Use x86 assembly optimizations." OFF)
+
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 if(MSVC)
-    enable_language(ASM_MASM)
-    set(CMAKE_ASM_MASM_FLAGS "/Zm /Cp /safeseh" CACHE INTERNAL "MASM flags")
+    if(USE_ASM)
+        enable_language(ASM_MASM)
+        set(CMAKE_ASM_MASM_FLAGS "/Zm /Cp /safeseh" CACHE INTERNAL "MASM flags")
+    endif()
+
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /Zp1")
     set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} /Zp1")
     add_definitions(-DWINDOWS_IGNORE_PACKING_MISMATCH)
 else()
-    set(ASM_DIALECT "_JWASM")
-    enable_language(ASM_JWASM)
+    if(USE_ASM)
+        set(ASM_DIALECT "_JWASM")
+        enable_language(ASM_JWASM)
 
-    # use native object format and disable cdecl decorations for non-Windows
-    if(NOT WIN32)
-        set(CMAKE_ASM_JWASM_FLAGS "-elf -zcw")
-    else()
-        set(CMAKE_ASM_JWASM_FLAGS "-coff")
+        # use native object format and disable cdecl decorations for non-Windows
+        if(NOT WIN32)
+            set(CMAKE_ASM_JWASM_FLAGS "-elf -zcw")
+        else()
+            set(CMAKE_ASM_JWASM_FLAGS "-coff")
+        endif()
     endif()
 
     set(CMAKE_CXX_FLAGS_DEBUG "-gstabs3")
@@ -64,24 +87,6 @@ endif()
 
 find_package(ClangFormat)
 include(ClangFormat)
-
-# For now build the dll files by default only for windows while there is only the proprietary GlyphX frontend for them.
-if(WIN32)
-    set(DEFAULT_REMASTER ON)
-else()
-    set(DEFAULT_REMASTER OFF)
-endif()
-
-option(BUILD_REMASTERTD "Build Tiberian Dawn remaster dll." ${DEFAULT_REMASTER})
-option(BUILD_REMASTERRA "Build Red Alert remaster dll." ${DEFAULT_REMASTER})
-option(BUILD_VANILLATD "Build Tiberian Dawn executable." ON)
-option(BUILD_VANILLARA "Build Red Alert executable." ON)
-option(MAP_EDITORTD "Include internal scenario editor in Tiberian Dawn build." OFF)
-option(MAP_EDITORRA "Include internal scenario editor in Red Alert build." OFF)
-option(NETWORKING "Enable network play." ON)
-option(DSOUND "Enable DirectSound audio." ON)
-option(DDRAW "Enable DirectDraw video backend." ON)
-option(USE_ASM "Use x86 assembly optimizations." ON)
 
 if(NOT USE_ASM)
     add_definitions(-DNOASM)

--- a/README.md
+++ b/README.md
@@ -41,13 +41,16 @@ This will build all available targets to the build directory.
 
 #### Requirements
 
-Recent enough MinGW-w64 packages, CMake and [JWasm](https://www.japheth.de/JWasm.html). On Ubuntu you can install the first two with:
+- MinGW-w64
+- CMake
+
+On Debian/Ubuntu you can install the build requirements as follows:
 
 ```
 sudo apt install mingw-w64 cmake
 ```
 
-JWasm needs to be compiled from sources and added to `$PATH`.
+If you want to build with x86 assembly, [JWasm](https://www.japheth.de/JWasm.html) needs to be compiled from sources and added to `$PATH`.
 
 #### Building
 


### PR DESCRIPTION
Linux CI will also test building without JWasm installed to make
sure we have zero assembly dependencies.