### PR TITLE
[RA] Implements sidebar toggling.

### DIFF
--- a/redalert/credits.cpp
+++ b/redalert/credits.cpp
@@ -91,9 +91,9 @@ void CreditClass::Graphic_Logic(bool forced)
         /*
         ** Adjust the credits display to be above the sidebar for 640x400
         */
-#ifdef WIN32
-        xx += 80 * RESFACTOR;
-#endif
+        if (!Options.ToggleSidebar) {
+            xx += 80 * RESFACTOR;
+        }
 
         /*
         **	Play a sound effect when the money display changes, but only if a sound
@@ -163,9 +163,11 @@ void CreditClass::Graphic_Logic(bool forced)
 #endif
 #ifdef WIN32
 #ifndef REMASTER_BUILD
+            int text_x = Options.ToggleSidebar ? 120 * RESFACTOR : 200 * RESFACTOR;
+
             if (hours) {
                 Fancy_Text_Print(TXT_TIME_FORMAT_HOURS,
-                                 200 * RESFACTOR,
+                                 text_x,
                                  0,
                                  &MetalScheme,
                                  TBLACK,
@@ -175,7 +177,7 @@ void CreditClass::Graphic_Logic(bool forced)
                                  secs);
             } else {
                 Fancy_Text_Print(TXT_TIME_FORMAT_NO_HOURS,
-                                 200 * RESFACTOR,
+                                 text_x,
                                  0,
                                  &MetalScheme,
                                  TBLACK,

--- a/redalert/init.cpp
+++ b/redalert/init.cpp
@@ -1345,7 +1345,7 @@ bool Select_Game(bool fade)
     /*
     ** Sidebar is always active in hi-res.
     */
-    if (!Debug_Map) {
+    if (!Debug_Map && !Options.ToggleSidebar) {
         Map.SidebarClass::Activate(1);
     }
 #endif // WIN32

--- a/redalert/options.cpp
+++ b/redalert/options.cpp
@@ -108,6 +108,7 @@ OptionsClass::OptionsClass(void)
     , IsScoreRepeat(false)
     , IsScoreShuffle(false)
     , IsPaletteScroll(true)
+    , ToggleSidebar(true)
     ,
 
     KeyForceMove1(KN_LALT)
@@ -583,6 +584,7 @@ void OptionsClass::Load_Settings(void)
     Set_Shuffle(ini.Get_Bool(OPTIONS, "IsScoreShuffle", IsScoreShuffle));
     SlowPalette = ini.Get_Bool(OPTIONS, "SlowPalette", SlowPalette);
     IsPaletteScroll = ini.Get_Bool(OPTIONS, "PaletteScroll", IsPaletteScroll);
+    ToggleSidebar = ini.Get_Bool(OPTIONS, "AllowSidebarToggle", ToggleSidebar);
 
     KeyForceMove1 = (KeyNumType)ini.Get_Int(HotkeyName, "KeyForceMove1", KeyForceMove1);
     KeyForceMove2 = (KeyNumType)ini.Get_Int(HotkeyName, "KeyForceMove2", KeyForceMove2);
@@ -742,6 +744,7 @@ void OptionsClass::Save_Settings(void)
     ini.Put_Bool(OPTIONS, "IsScoreRepeat", IsScoreRepeat);
     ini.Put_Bool(OPTIONS, "IsScoreShuffle", IsScoreShuffle);
     ini.Put_Bool(OPTIONS, "PaletteScroll", IsPaletteScroll);
+    ini.Put_Bool(OPTIONS, "AllowSidebarToggle", ToggleSidebar);
 
     ini.Put_Int(HotkeyName, "KeyForceMove1", KeyForceMove1);
     ini.Put_Int(HotkeyName, "KeyForceMove2", KeyForceMove2);

--- a/redalert/options.h
+++ b/redalert/options.h
@@ -93,6 +93,7 @@ public:
     unsigned IsScoreRepeat : 1;   // Score should repeat?
     unsigned IsScoreShuffle : 1;  // Score list should shuffle?
     unsigned IsPaletteScroll : 1; // Allow palette scrolling?
+    unsigned ToggleSidebar : 1;   // Allow sidebar to be toggled?
 
     /*
     **	These are the hotkeys used for keyboard control.

--- a/redalert/scenario.cpp
+++ b/redalert/scenario.cpp
@@ -594,7 +594,7 @@ void Fill_In_Data(void)
     **	Since the sidebar starts up activated, adjust the home start position so that
     **	the right edge of the map will still be visible.
     */
-    if (!Debug_Map) {
+    if (!Debug_Map && !Options.ToggleSidebar) {
         Map.SidebarClass::Activate(1);
         //		if (Session.Type == GAME_NORMAL) {
         Scen.Views[0] = Scen.Views[1] = Scen.Views[2] = Scen.Views[3] = Scen.Waypoint[WAYPT_HOME];

--- a/redalert/sidebar.cpp
+++ b/redalert/sidebar.cpp
@@ -829,15 +829,13 @@ void SidebarClass::AI(KeyNumType& input, int x, int y)
     /*
     **	Toggle the sidebar in and out with the <TAB> key.
     */
-#ifndef WIN32
-    if (input == KN_TAB) {
-        Activate(-1);
-    }
-#else
-    if (!Debug_Map) {
+    if (Options.ToggleSidebar) {
+        if (input == KN_TAB) {
+            Activate(-1);
+        }
+    } else if (!Debug_Map) {
         Activate(1); // Force the sidebar always on in Win95 mode
     }
-#endif // WIN32
     if (!Debug_Map) {
         Column[0].AI(input, x, y);
         Column[1].AI(input, x, y);

--- a/redalert/tab.cpp
+++ b/redalert/tab.cpp
@@ -132,10 +132,9 @@ void TabClass::Draw_It(bool complete)
                          TBLACK,
                          TPF_METAL12 | TPF_NOSHADOW | TPF_CENTER | TPF_BRIGHT_COLOR);
 #endif // WIN32
-        if (IsSidebarActive) {
 #ifndef WIN32
+        if (IsSidebarActive) {
             TabClass::Hilite_Tab(1);
-#endif // WIN32
         } else {
             CC_Draw_Shape(TabShape, 0, width - (EVA_WIDTH * RESFACTOR), 0, WINDOW_MAIN, SHAPE_NORMAL);
             Fancy_Text_Print(TXT_TAB_SIDEBAR,
@@ -145,6 +144,17 @@ void TabClass::Draw_It(bool complete)
                              TBLACK,
                              TPF_METAL12 | TPF_NOSHADOW | TPF_CENTER | TPF_BRIGHT_COLOR);
         }
+#else
+        if (Options.ToggleSidebar) {
+            CC_Draw_Shape(TabShape, 6, width - (EVA_WIDTH * RESFACTOR), 0, WINDOW_MAIN, SHAPE_NORMAL);
+            Fancy_Text_Print(TXT_TAB_SIDEBAR,
+                             width - ((EVA_WIDTH / 2) * RESFACTOR),
+                             0,
+                             &MetalScheme,
+                             TBLACK,
+                             TPF_METAL12 | TPF_CENTER | TPF_USE_GRAD_PAL);
+        }
+#endif
 
         LogicPage->Unlock();
     }
@@ -159,8 +169,17 @@ void TabClass::Draw_Credits_Tab(void)
     /*
     ** Use the new sidebar art for 640x400
     */
-    CC_Draw_Shape(
-        TabShape, Map.MoneyFlashTimer > 1 ? 8 : 6, (320 - EVA_WIDTH) * RESFACTOR, 0, WINDOW_MAIN, SHAPE_NORMAL);
+    if (Options.ToggleSidebar) {
+        CC_Draw_Shape(TabShape,
+                      Map.MoneyFlashTimer > 1 ? 5 : 2,
+                      (320 - (EVA_WIDTH * 2)) * RESFACTOR,
+                      0,
+                      WINDOW_MAIN,
+                      SHAPE_NORMAL);
+    } else {
+        CC_Draw_Shape(
+            TabShape, Map.MoneyFlashTimer > 1 ? 8 : 6, (320 - EVA_WIDTH) * RESFACTOR, 0, WINDOW_MAIN, SHAPE_NORMAL);
+    }
 #else
     CC_Draw_Shape(TabShape, 4, (320 - (EVA_WIDTH * 2)) * RESFACTOR, 0, WINDOW_MAIN, SHAPE_NORMAL);
 #endif
@@ -168,7 +187,11 @@ void TabClass::Draw_Credits_Tab(void)
     if (Scen.MissionTimer.Is_Active()) {
         bool light = ((int)Scen.MissionTimer < TICKS_PER_MINUTE * Rule.TimerWarning) || Map.FlasherTimer > 0;
 #ifdef WIN32
-        CC_Draw_Shape(TabShape, light ? 4 : 2, 320, 0, WINDOW_MAIN, SHAPE_NORMAL);
+        if (Options.ToggleSidebar) {
+            CC_Draw_Shape(TabShape, light ? 4 : 2, (320 - (EVA_WIDTH * 3)) * RESFACTOR, 0, WINDOW_MAIN, SHAPE_NORMAL);
+        } else {
+            CC_Draw_Shape(TabShape, light ? 4 : 2, (320 - (EVA_WIDTH * 2)) * RESFACTOR, 0, WINDOW_MAIN, SHAPE_NORMAL);
+        }
 #else
         CC_Draw_Shape(TabShape, light ? 6 : 5, EVA_WIDTH * RESFACTOR, 0, WINDOW_MAIN, SHAPE_NORMAL);
 #endif
@@ -250,10 +273,10 @@ void TabClass::AI(KeyNumType& input, int x, int y)
                 int sel = -1;
                 if (x < EVA_WIDTH * RESFACTOR)
                     sel = 0;
-#ifndef WIN32 // No Sidebar tab in hires - sidebar is always active.
-                if (x > (320 - 80) * RESFACTOR)
-                    sel = 1;
-#endif // WIN32
+                if (Options.ToggleSidebar) {
+                    if (x > (320 - 80) * RESFACTOR)
+                        sel = 1;
+                }
                 if (sel >= 0) {
                     Set_Active(sel);
                     input = KN_NONE;


### PR DESCRIPTION
Restores sidebar toggle as seen in C&C95.
Old behaviour can be enabled from redalert.ini with `AllowSidebarToggle=no` in `[Options]`.