### PR TITLE
Fixes missing setting of the Window state for TD.

### DIFF
--- a/tiberiandawn/startup.cpp
+++ b/tiberiandawn/startup.cpp
@@ -42,7 +42,7 @@ void Delete_Swap_Files(void);
 void Print_Error_End_Exit(char* string);
 void Print_Error_Exit(char* string);
 #ifdef _WIN32
-extern void Create_Main_Window(HANDLE instance, int command_show, int width, int height);
+extern void Create_Main_Window(HANDLE instance, int width, int height);
 HINSTANCE ProgramInstance;
 #endif
 
@@ -313,7 +313,7 @@ int main(int argc, char** argv)
             CCDebugString("C&C95 - Creating main window.\n");
 
 #ifdef _WIN32
-            Create_Main_Window(ProgramInstance, 0, ScreenWidth, ScreenHeight);
+            Create_Main_Window(ProgramInstance, ScreenWidth, ScreenHeight);
 #endif
 
             CCDebugString("C&C95 - Initialising audio.\n");

--- a/tiberiandawn/winstub.cpp
+++ b/tiberiandawn/winstub.cpp
@@ -358,7 +358,7 @@ long FAR PASCAL Windows_Procedure(HWND hwnd, UINT message, UINT wParam, LONG lPa
 int ShowCommand;
 
 #ifdef _WIN32
-void Create_Main_Window(HANDLE instance, int command_show, int width, int height)
+void Create_Main_Window(HANDLE instance, int width, int height)
 
 {
 #ifdef REMASTER_BUILD
@@ -367,6 +367,19 @@ void Create_Main_Window(HANDLE instance, int command_show, int width, int height
 #else
     HWND hwnd;
     WNDCLASS wndclass;
+
+    STARTUPINFOA sinfo;
+    int command_show;
+
+    sinfo.dwFlags = 0;
+    GetStartupInfoA(&sinfo);
+
+    if (sinfo.dwFlags & STARTF_USESHOWWINDOW) {
+        command_show = sinfo.wShowWindow;
+    } else {
+        command_show = SW_SHOWDEFAULT;
+    }
+
     //
     // Register the window class
     //


### PR DESCRIPTION
Original code passed on the WinMain's command_show argument to the function.
The 8fa69511 refactor broke this, defaulting to 0, SW_HIDE, which hid the window making TD seemingly freeze and do nothing when ran.