### PR TITLE
[TD] Fixes crash in main menu using keys to navigate.

### DIFF
--- a/tiberiandawn/init.cpp
+++ b/tiberiandawn/init.cpp
@@ -777,8 +777,7 @@ bool Select_Game(bool fade)
         SEL_START_NEW_GAME, // start a new game
 #ifdef BONUS_MISSIONS
         SEL_BONUS_MISSIONS,
-#endif // BONUS_MISSIONS
-        SEL_INTERNET,
+#endif                        // BONUS_MISSIONS
         SEL_LOAD_MISSION,     // load a saved game
         SEL_MULTIPLAYER_GAME, // play modem/null-modem/network game
         SEL_INTRO,            // replay the intro
@@ -968,9 +967,6 @@ bool Select_Game(bool fade)
             switch (selection) {
 
 #ifdef NEWMENU
-
-            case SEL_INTERNET:
-                break;
 
             /*
             **	Pick an expansion scenario.

--- a/tiberiandawn/menus.cpp
+++ b/tiberiandawn/menus.cpp
@@ -510,6 +510,7 @@ int Main_Menu(unsigned long timeout)
     int starty = 25 * 2;
 #endif
 
+    // Make sure any changes to buttons here are also reflected in the enum and handling in Select_Game in init.cpp.
     enum
     {
 #ifdef NEWMENU
@@ -518,7 +519,6 @@ int Main_Menu(unsigned long timeout)
 #ifdef BONUS_MISSIONS
         BUTTON_BONUS,
 #endif // BONUS_MISSIONS
-        BUTTON_INTERNET,
 #else
         BUTTON_START = 100 * 2,
 #endif
@@ -900,11 +900,6 @@ int Main_Menu(unsigned long timeout)
             process = false;
             break;
 
-        case (BUTTON_INTERNET | KN_BUTTON):
-            retval = (input & 0x7FFF) - BUTTON_EXPAND;
-            process = false;
-            break;
-
 #else
 #define BUTTON_EXPAND BUTTON_START
 #endif
@@ -960,11 +955,11 @@ int Main_Menu(unsigned long timeout)
 #ifdef NEWMENU
             if (expansions) {
                 if (curbutton < 0) {
-                    curbutton = 6;
+                    curbutton = 5;
                 }
             } else {
                 if (curbutton < 1) {
-                    curbutton = 6;
+                    curbutton = 5;
                 }
             }
 #else
@@ -981,7 +976,7 @@ int Main_Menu(unsigned long timeout)
             buttons[curbutton]->Flag_To_Redraw();
             curbutton++;
 #ifdef NEWMENU
-            if (curbutton > 6) {
+            if (curbutton > 5) {
                 if (expansions) {
                     curbutton = 0;
                 } else {


### PR DESCRIPTION
Crashed when wrapping selected button from top to bottom or vice versa.
Issue is that Internet button doesn't exist but values assume it does.
Fixes #168 