### PR TITLE
Add CodeQL Analysis

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,0 +1,56 @@
+# For most projects, this workflow file will not need changing; you simply need
+# to commit it to your repository.
+#
+# You may wish to alter this file to override the set of languages analyzed,
+# or to provide custom queries or build logic.
+name: "CodeQL"
+
+on:
+  pull_request:
+  push:
+  release:
+    types: published
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: windows-2019
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # Override automatic language detection by changing the below list
+        # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
+        language: ['cpp']
+        # Learn more...
+        # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
+        buildtype: [Debug]
+        features: [ON, OFF]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+      with:
+        submodules: 'true'
+
+    - name: Install Dependencies
+      run: |
+        choco install imagemagick.app
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+
+    - name: Build Vanilla Conquer
+      run: |
+        cmake -A Win32 -DBUILD_TESTS=ON -DDSOUND=${{ matrix.features }} -DDDRAW=${{ matrix.features }} -DUSE_ASM=${{ matrix.features }} -DNETWORKING=${{ matrix.features }} -DMAP_EDITORRA=${{ matrix.features }} -DMAP_EDITORTD=${{ matrix.features }} -B build
+        cmake --build build --parallel --config ${{ matrix.buildtype }}
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v1


### PR DESCRIPTION
Probably too early for static analysis, however there is a easy Github Action available, CodeQL.

[Finding security vulnerabilities and errors in your code - GitHub Docs](https://docs.github.com/en/free-pro-team@latest/github/finding-security-vulnerabilities-and-errors-in-your-code)

Currently set to build Debug only. Set to run on Pull Request as well, might be best to just to do it on Push?

Viewable at Security -> Code Scanning Alerts
36 Open (2 completed jobs in 36m 30s)
19 Wrong type of arguments to formatting function
1 Overflow in uncontrolled allocation size
2 Mismatching new/free or malloc/delete
12 Comparison of narrow type with wide type in loop condition
1 Suspicious add with sizeof