### PR TITLE
Implements support for Mega Maps in Tiberian Dawn

### DIFF
--- a/tiberiandawn/CMakeLists.txt
+++ b/tiberiandawn/CMakeLists.txt
@@ -181,7 +181,7 @@ if(BUILD_REMASTERTD)
         ${TIBDAWN_HEADERS}
         ${REMASTERTD_RC}
     )
-    target_compile_definitions(TiberianDawn PUBLIC $<$<CONFIG:Debug>:_DEBUG> ${REMASTER_DEFS})
+    target_compile_definitions(TiberianDawn PUBLIC $<$<CONFIG:Debug>:_DEBUG> ${REMASTER_DEFS} MEGAMAPS)
     target_include_directories(TiberianDawn PUBLIC ${CMAKE_SOURCE_DIR} .)
     target_link_libraries(TiberianDawn commonr ${REMASTER_LIBS} ${STATIC_LIBS})
     set_target_properties(TiberianDawn PROPERTIES PREFIX "")
@@ -207,9 +207,10 @@ if(BUILD_VANILLATD)
             ICON "${VANILLATD_ICON}"
         )
     endif()
+
     # A target must include the icon for the custom command to run.
     add_executable(VanillaTD ${TIBDAWN_SRC} ${TIBDAWN_HEADERS} ${VANILLATD_RC} ${VANILLATD_ICON})
-    target_compile_definitions(VanillaTD PUBLIC $<$<CONFIG:Debug>:_DEBUG> ${VANILLA_DEFS})
+    target_compile_definitions(VanillaTD PUBLIC $<$<CONFIG:Debug>:_DEBUG> ${VANILLA_DEFS} MEGAMAPS)
     target_include_directories(VanillaTD PUBLIC ${CMAKE_SOURCE_DIR} .)
     target_link_libraries(VanillaTD commonv ${VANILLA_LIBS} ${STATIC_LIBS})
     set_target_properties(VanillaTD PROPERTIES OUTPUT_NAME vanillatd)

--- a/tiberiandawn/aircraft.cpp
+++ b/tiberiandawn/aircraft.cpp
@@ -1645,7 +1645,8 @@ ResultType AircraftClass::Take_Damage(int& damage, int distance, WarheadType war
         Kill_Cargo(source);
         Death_Announcement();
         COORDINATE coord = Target_Coord();
-        if (!(coord & 0xC000C000L)) {
+
+        if (!(coord & HIGH_COORD_MASK)) {
             new AnimClass(ANIM_FBALL1, coord);
         }
         Delete_This();

--- a/tiberiandawn/base.cpp
+++ b/tiberiandawn/base.cpp
@@ -170,6 +170,16 @@ void BaseClass::Read_INI(CCINIClass& ini)
         */
         node.Coord = atol(strtok(NULL, ","));
 
+#ifdef MEGAMAPS
+        /*
+        ** Convert the normal cell position to a new big map position.
+        */
+        if (Map.MapBinaryVersion == MAP_VERSION_NORMAL) {
+            CELL cell = Confine_Old_Cell(XY_Cell(Coord_X(node.Coord), Coord_Y(node.Coord)));
+            node.Coord = Cell_Coord(cell);
+        }
+#endif
+
         /*
         ** Add this node to the Base's list
         */

--- a/tiberiandawn/building.cpp
+++ b/tiberiandawn/building.cpp
@@ -3282,6 +3282,12 @@ void BuildingClass::Read_INI(CCINIClass& ini)
             */
             cell = atoi(strtok(NULL, ","));
 
+#ifdef MEGAMAPS
+            if (Map.MapBinaryVersion == MAP_VERSION_NORMAL) {
+                cell = Confine_Old_Cell(cell);
+            }
+#endif
+
             /*
             **	5th token: facing.
             */

--- a/tiberiandawn/cell.cpp
+++ b/tiberiandawn/cell.cpp
@@ -102,7 +102,7 @@ int CellClass::Validate(void) const
     int num;
 
     num = Cell_Number();
-    if (num < 0 || num > 4095) {
+    if (num < 0 || num > MAP_CELL_TOTAL) {
         Validate_Error("CELL");
         return (0);
     } else
@@ -1767,7 +1767,8 @@ int CellClass::Clear_Icon(void) const
 {
     Validate();
     CELL cell = Cell_Number();
-    return ((cell & 0x03) | ((cell >> 4) & 0x0C));
+    //return((cell & 0x03) | ((cell>>4) & 0x0C));
+    return ((Cell_X(cell) & 0x03) | ((Cell_Y(cell) & 0x03) << 2)); // From RA Clear_Icon()
 }
 
 /***********************************************************************************************

--- a/tiberiandawn/coord.cpp
+++ b/tiberiandawn/coord.cpp
@@ -348,9 +348,9 @@ COORDINATE Coord_Scatter(COORDINATE coord, unsigned distance, bool lock)
     COORDINATE newcoord;
 
     newcoord = Coord_Move(coord, Random_Pick(DIR_N, DIR_MAX), distance);
-
-    if (newcoord & 0xC000C000L)
+    if (newcoord & HIGH_COORD_MASK) {
         newcoord = coord;
+    }
 
     if (lock) {
         newcoord = Coord_Snap(newcoord);

--- a/tiberiandawn/defines.h
+++ b/tiberiandawn/defines.h
@@ -260,9 +260,16 @@ typedef enum DiffType : unsigned char
 //	of two. This is accomplished by setting the width by the number of
 //	bits it occupies. The number of meta-cells will be a subset of the
 //	cell width.
+#ifdef MEGAMAPS
+#define MAP_CELL_MAX_X_BITS 7
+#define MAP_CELL_MAX_Y_BITS 7
+#define HIGH_COORD_MASK     0x80008000
+#else
 #define MAP_CELL_MAX_X_BITS 6
 #define MAP_CELL_MAX_Y_BITS 6
-#define MAP_CELL_X_MASK     (~(~0 << MAP_CELL_MAX_X_BITS))
+#define HIGH_COORD_MASK     0xC000C000
+#endif
+#define MAP_CELL_X_MASK (~(~0 << MAP_CELL_MAX_X_BITS))
 //#define	MAP_CELL_Y_MASK			((~(~0 << MAP_CELL_MAX_Y_BITS)) << MAP_CELL_MAX_Y_BITS)
 
 // Size of the map in cells.
@@ -281,6 +288,12 @@ typedef enum DiffType : unsigned char
 #define MAP_REGION_WIDTH  (((MAP_CELL_W + (REGION_WIDTH - 1)) / REGION_WIDTH) + 2)
 #define MAP_REGION_HEIGHT (((MAP_CELL_H + (REGION_WIDTH - 1)) / REGION_HEIGHT) + 2)
 #define MAP_TOTAL_REGIONS (MAP_REGION_WIDTH * MAP_REGION_HEIGHT)
+
+/*
+**	To enable big maps we need to load the normal format a little differently.
+*/
+#define MAP_VERSION_NORMAL 0
+#define MAP_VERSION_MEGA   1
 
 /**********************************************************************
 **	These are the various return conditions that production may
@@ -1644,7 +1657,11 @@ typedef enum RadioMessageType : unsigned char
 typedef unsigned COORDINATE;
 typedef signed short CELL;
 
+#ifdef MEGAMAPS
+typedef long TARGET;
+#else
 typedef unsigned short TARGET;
+#endif
 #define TARGET_NONE ((TARGET)0)
 
 /****************************************************************************

--- a/tiberiandawn/dllinterface.h
+++ b/tiberiandawn/dllinterface.h
@@ -30,7 +30,7 @@ struct CarryoverObjectStruct;
 
 #define MAX_EXPORT_CELLS (128 * 128)
 
-#ifdef TIBERIAN_DAWN
+#if defined TIBERIAN_DAWN && !defined MEGAMAPS
 #define MAP_MAX_CELL_WIDTH  64
 #define MAP_MAX_CELL_HEIGHT 64
 #else

--- a/tiberiandawn/externs.h
+++ b/tiberiandawn/externs.h
@@ -52,9 +52,15 @@
 #include "common/vqaconfig.h"
 
 #ifdef REMASTER_BUILD
+#ifdef MEGAMAPS
+#define GBUFF_INIT_WIDTH     3072
+#define GBUFF_INIT_HEIGHT    3072
+#define GBUFF_INIT_ALTHEIGHT 3072
+#else
 #define GBUFF_INIT_WIDTH     1536
 #define GBUFF_INIT_HEIGHT    1536
 #define GBUFF_INIT_ALTHEIGHT 1536
+#endif
 #else
 #define GBUFF_INIT_WIDTH     640
 #define GBUFF_INIT_HEIGHT    400

--- a/tiberiandawn/findpath.cpp
+++ b/tiberiandawn/findpath.cpp
@@ -94,7 +94,7 @@
 **	Maximum lookahead cells. Twice this value in bytes will be
 **	reserved on the stack. The smaller this number, the faster the processing.
 */
-#define MAX_MLIST_SIZE   300
+#define MAX_MLIST_SIZE   400
 #define THREAT_THRESHOLD 5
 
 #define MAX_PATH_EDGE_FOLLOW 400
@@ -137,8 +137,9 @@ static inline void Draw_Cell_Point(CELL cell, bool passable, int threat_stage, i
                 }
             }
         } else {
-            int x = cell & 63;
-            int y = cell / 64;
+            int x = cell & (MAP_CELL_W - 1);
+            int y = cell / MAP_CELL_H;
+
             if (!overide) {
                 SeenBuff.Put_Pixel(64 + (x * 3) + 1, 8 + (y * 3) + 1, (passable) ? WHITE : BLACK);
             } else {
@@ -1547,11 +1548,12 @@ void FootClass::Debug_Draw_Map(char* txt, CELL start, CELL dest, bool pause)
 
     VisiblePage.Clear();
     Fancy_Text_Print(txt, 160, 0, WHITE, BLACK, TPF_8POINT | TPF_CENTER);
-    for (int x = 0; x < 64; x++) {
-        for (int y = 0; y < 64; y++) {
+
+    for (int x = 0; x < MAP_CELL_W; x++) {
+        for (int y = 0; y < MAP_CELL_H; y++) {
             int color = 0;
 
-            switch (Can_Enter_Cell((CELL)((y << 6) + x))) {
+            switch (Can_Enter_Cell(XY_Cell(x, y))) {
             case MOVE_OK:
                 color = GREEN;
                 break;
@@ -1569,10 +1571,11 @@ void FootClass::Debug_Draw_Map(char* txt, CELL start, CELL dest, bool pause)
                 color = RED;
                 break;
             }
-            if ((CELL)((y << 6) + x) == start)
+            if (XY_Cell(x, y) == start)
                 color = LTBLUE;
-            if ((CELL)((y << 6) + x) == dest)
+            if (XY_Cell(x, y) == dest)
                 color = BLUE;
+
             Fat_Put_Pixel(64 + (x * 3), 8 + (y * 3), color, 3, SeenBuff);
         }
     }

--- a/tiberiandawn/fly.cpp
+++ b/tiberiandawn/fly.cpp
@@ -91,7 +91,7 @@ ImpactType FlyClass::Physics(COORDINATE& coord, DirType facing)
             **	If the new coordinate is off the edge of the world, then report
             **	this.
             */
-            if (newcoord & 0xC000C000L /*|| !Map.In_Radar(Coord_Cell(newcoord))*/) {
+            if (newcoord & HIGH_COORD_MASK /*|| !Map.In_Radar(Coord_Cell(newcoord))*/) {
                 coord = old;
                 return (IMPACT_EDGE);
             }

--- a/tiberiandawn/infantry.cpp
+++ b/tiberiandawn/infantry.cpp
@@ -2994,7 +2994,18 @@ void InfantryClass::Read_INI(CCINIClass& ini)
                         /*
                         **	4th token: cell #.
                         */
-                        COORDINATE coord = Cell_Coord((CELL)atoi(strtok(NULL, ",\n\r")));
+                        CELL cell = (CELL)atoi(strtok(NULL, ",\n\r"));
+
+#ifdef MEGAMAPS
+                        /*
+                        ** Convert the normal cell position to a new big map position.
+                        */
+                        if (Map.MapBinaryVersion == MAP_VERSION_NORMAL) {
+                            cell = Confine_Old_Cell(cell);
+                        }
+#endif
+
+                        COORDINATE coord = Cell_Coord(cell);
 
                         /*
                         **	5th token: cell sub-location.

--- a/tiberiandawn/map.h
+++ b/tiberiandawn/map.h
@@ -37,8 +37,6 @@
 
 #include "gscreen.h"
 
-#define BIGMAP 0
-
 class MapClass : public GScreenClass
 {
 public:
@@ -121,6 +119,20 @@ public:
     **	This is the total value of all harvestable Tiberium on the map.
     */
     long TotalValue;
+
+#ifdef MEGAMAPS
+    /*
+    **	To enable big maps we need to load the normal format a little differently.
+    **  This value should be set when reading the map ini before the binary is loaded.
+    */
+    int MapBinaryVersion;
+
+    /*
+    **	Slighty different version of Read/Write_Binary, suited for big maps.
+    */
+    bool Read_Binary_Big(char const* fname, uint32_t* crc);
+    bool Write_Binary_Big(char const* root);
+#endif
 
 protected:
     /*

--- a/tiberiandawn/overlay.cpp
+++ b/tiberiandawn/overlay.cpp
@@ -353,7 +353,14 @@ void OverlayClass::Read_INI(CCINIClass& ini)
         char const* entry = ini.Get_Entry(INI_Name(), index);
         CELL cell = atoi(entry);
         OverlayType classid = ini.Get_OverlayType(INI_Name(), entry, OVERLAY_NONE);
-
+#ifdef MEGAMAPS
+        /*
+        ** Convert the normal cell position to a new big map position.
+        */
+        if (Map.MapBinaryVersion == MAP_VERSION_NORMAL) {
+            cell = Confine_Old_Cell(cell);
+        }
+#endif
         /*
         **	Don't allow placement of crates in the multiplayer scenarios.
         */

--- a/tiberiandawn/radar.cpp
+++ b/tiberiandawn/radar.cpp
@@ -129,8 +129,9 @@ void RadarClass::One_Time(void)
     RadHeight = 70 << factor;
     RadX = SeenBuff.Get_Width() - RadWidth;
     RadY = Map.Get_Tab_Height() - (1 << factor);
-    RadPWidth = 64 << factor;
-    RadPHeight = 64 << factor;
+    RadPWidth = MAP_CELL_W << factor;
+    RadPHeight = MAP_CELL_H << factor;
+
     if (factor) {
         RadOffX = 16;
         RadOffY = 7;

--- a/tiberiandawn/smudge.cpp
+++ b/tiberiandawn/smudge.cpp
@@ -297,6 +297,14 @@ void SmudgeClass::Read_INI(CCINIClass& ini)
             if (ptr) {
                 int data = 0;
                 CELL cell = atoi(ptr);
+#ifdef MEGAMAPS
+                /*
+                ** Convert the normal cell position to a new big map position.
+                */
+                if (Map.MapBinaryVersion == MAP_VERSION_NORMAL) {
+                    cell = Confine_Old_Cell(cell);
+                }
+#endif
                 ptr = strtok(NULL, ",");
                 if (ptr)
                     data = atoi(ptr);

--- a/tiberiandawn/target.h
+++ b/tiberiandawn/target.h
@@ -57,7 +57,11 @@ typedef enum KindType : unsigned char
     KIND_TEAMTYPE
 } KindType;
 
-#define TARGET_MANTISSA      12 // Bits of value precision.
+#ifdef MEGAMAPS
+#define TARGET_MANTISSA 24 // Bits of value precision.
+#else
+#define TARGET_MANTISSA 12 // Bits of value precision.
+#endif
 #define TARGET_MANTISSA_MASK (~((~0) << TARGET_MANTISSA))
 #define TARGET_EXPONENT      ((sizeof(TARGET) * 8) - TARGET_MANTISSA)
 #define TARGET_EXPONENT_MASK (~(((unsigned)(~0)) >> TARGET_EXPONENT))

--- a/tiberiandawn/techno.cpp
+++ b/tiberiandawn/techno.cpp
@@ -1542,7 +1542,8 @@ bool TechnoClass::Evaluate_Cell(ThreatType method,
     /*
     **	If the cell is not on the legal map, then always ignore it.
     */
-    if (cell & 0xF000)
+    //	if (cell & 0xF000) return(false);
+    if ((unsigned)cell > MAP_CELL_TOTAL)
         return (false);
     if (!Map.In_Radar(cell))
         return (false);

--- a/tiberiandawn/terrain.cpp
+++ b/tiberiandawn/terrain.cpp
@@ -813,7 +813,14 @@ void TerrainClass::Read_INI(CCINIClass& ini)
         char const* entry = ini.Get_Entry(INI_Name(), index);
         TerrainType terrain = ini.Get_TerrainType(INI_Name(), entry, TERRAIN_NONE);
         CELL cell = atoi(entry);
-
+#ifdef MEGAMAPS
+        /*
+        ** Convert the normal cell position to a new big map position.
+        */
+        if (Map.MapBinaryVersion == MAP_VERSION_NORMAL) {
+            cell = Confine_Old_Cell(cell);
+        }
+#endif
         if (terrain != TERRAIN_NONE) {
             tptr = new TerrainClass(terrain, cell);
         }

--- a/tiberiandawn/unit.cpp
+++ b/tiberiandawn/unit.cpp
@@ -3799,7 +3799,16 @@ void UnitClass::Read_INI(CCINIClass& ini)
                         **	Read the raw data.
                         */
                         int strength = atoi(strtok(NULL, ",\r\n"));
-                        COORDINATE coord = Cell_Coord((CELL)atoi(strtok(NULL, ",\r\n")));
+                        CELL cell = (CELL)atoi(strtok(NULL, ",\n\r"));
+#ifdef MEGAMAPS
+                        /*
+                        ** Convert the normal cell position to a new big map position.
+                        */
+                        if (Map.MapBinaryVersion == MAP_VERSION_NORMAL) {
+                            cell = Confine_Old_Cell(cell);
+                        }
+#endif
+                        COORDINATE coord = Cell_Coord(cell);
                         DirType dir = (DirType)atoi(strtok(NULL, ",\r\n"));
                         MissionType mission = MissionClass::Mission_From_Name(strtok(NULL, ",\n\r"));
                         unit->Trigger = TriggerClass::As_Pointer(strtok(NULL, ",\r\n"));


### PR DESCRIPTION
Implements the Sole Survivor map format in Tiberian Dawn and extends the map size it supports to 128x128 to match the max map size Red Alert supports.

The internal map editor will be required to actually author larger maps at this point in time until another map editor can be extended.