### PR TITLE
Changes gitignore of build directory to be a wildcard prefix.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,1 @@
-/build
+/build*


### PR DESCRIPTION
Any directory prefixed with "build" will now be ignored.
Makes it easier to maintain multiple types of build for testing.