### PR TITLE
Manage focus in SDL2 windowed mode

### DIFF
--- a/common/video.h
+++ b/common/video.h
@@ -54,6 +54,7 @@ public:
 extern SurfaceMonitorClass& AllSurfaces; // List of all surfaces
 
 bool Set_Video_Mode(int w, int h, int bits_per_pixel);
+bool Is_Video_Fullscreen();
 void Reset_Video_Mode();
 unsigned Get_Free_Video_Memory();
 void Wait_Blit();

--- a/common/video_ddraw.cpp
+++ b/common/video_ddraw.cpp
@@ -718,6 +718,11 @@ bool Set_Video_Mode(int w, int h, int bits_per_pixel)
     return true;
 }
 
+bool Is_Video_Fullscreen()
+{
+    return true;
+}
+
 /***********************************************************************************************
  * Reset_Video_Mode -- Resets video mode and deletes Direct Draw Object                        *
  *                                                                                             *

--- a/common/video_null.cpp
+++ b/common/video_null.cpp
@@ -83,6 +83,11 @@ bool Set_Video_Mode(int w, int h, int bits_per_pixel)
     return true;
 }
 
+bool Is_Video_Fullscreen()
+{
+    return false;
+}
+
 /***********************************************************************************************
  * Reset_Video_Mode -- Resets video mode and deletes Direct Draw Object                        *
  *                                                                                             *

--- a/common/video_sdl2.cpp
+++ b/common/video_sdl2.cpp
@@ -47,7 +47,7 @@
 
 extern WWKeyboardClass* Keyboard;
 
-static SDL_Window* window;
+SDL_Window* window;
 static SDL_Palette* palette;
 
 class SurfaceMonitorClassDummy : public SurfaceMonitorClass
@@ -95,6 +95,11 @@ bool Set_Video_Mode(int w, int h, int bits_per_pixel)
     palette = SDL_AllocPalette(256);
 
     return true;
+}
+
+bool Is_Video_Fullscreen()
+{
+    return false;
 }
 
 /***********************************************************************************************

--- a/common/wwkeyboard.cpp
+++ b/common/wwkeyboard.cpp
@@ -61,6 +61,12 @@
 
 #define ARRAY_SIZE(x) int(sizeof(x) / sizeof(x[0]))
 
+/*
+**  Focus handlers for both games.
+*/
+extern void Focus_Loss();
+extern void Focus_Restore();
+
 /***********************************************************************************************
  * WWKeyboardClass::WWKeyBoardClass -- Construction for Westwood Keyboard Class                *
  *                                                                                             *
@@ -553,6 +559,20 @@ void WWKeyboardClass::Fill_Buffer_From_System(void)
                 break;
             }
             Put_Mouse_Message(key, event.button.x, event.button.y, event.type == SDL_MOUSEBUTTONDOWN ? false : true);
+            break;
+        case SDL_WINDOWEVENT:
+            switch (event.window.event) {
+            case SDL_WINDOWEVENT_EXPOSED:
+            case SDL_WINDOWEVENT_RESTORED:
+            case SDL_WINDOWEVENT_FOCUS_GAINED:
+                Focus_Restore();
+                break;
+            case SDL_WINDOWEVENT_HIDDEN:
+            case SDL_WINDOWEVENT_MINIMIZED:
+            case SDL_WINDOWEVENT_FOCUS_LOST:
+                Focus_Loss();
+                break;
+            }
             break;
         }
     }

--- a/common/wwmouse.cpp
+++ b/common/wwmouse.cpp
@@ -35,6 +35,7 @@
 #include <string.h>
 #ifdef SDL2_BUILD
 #include <SDL.h>
+extern SDL_Window* window;
 #endif
 
 #ifndef min
@@ -175,7 +176,7 @@ void WWMouseClass::Set_Cursor_Clip(void)
 #if !defined(REMASTER_BUILD)
     if (Screen) {
 #if defined(SDL2_BUILD)
-        SDL_CaptureMouse(SDL_TRUE);
+        SDL_SetWindowGrab(window, SDL_TRUE);
 #elif defined(_WIN32)
         RECT region;
 
@@ -194,7 +195,7 @@ void WWMouseClass::Clear_Cursor_Clip(void)
 {
 #if !defined(REMASTER_BUILD)
 #if defined(SDL2_BUILD)
-    SDL_CaptureMouse(SDL_FALSE);
+    SDL_SetWindowGrab(window, SDL_FALSE);
 #elif defined(_WIN32)
     ClipCursor(nullptr);
 #endif

--- a/redalert/init.cpp
+++ b/redalert/init.cpp
@@ -571,6 +571,13 @@ bool Select_Game(bool fade)
     Map.Set_Default_Mouse(MOUSE_NORMAL, false);
 
     /*
+    **  Allow moving mouse outside the game window when in menu.
+    */
+    if (!Is_Video_Fullscreen()) {
+        WWMouse->Clear_Cursor_Clip();
+    }
+
+    /*
     **	If the last game we played was a multiplayer game, jump right to that
     **	menu by pre-setting 'selection'.
     */
@@ -1220,6 +1227,11 @@ bool Select_Game(bool fade)
     HiddenPage.Clear();
     VisiblePage.Clear();
     Show_Mouse();
+
+    if (!Is_Video_Fullscreen()) {
+        WWMouse->Set_Cursor_Clip();
+    }
+
     Set_Logic_Page(SeenBuff);
     /*
     ** Sidebar is always active in hi-res.

--- a/redalert/winstub.cpp
+++ b/redalert/winstub.cpp
@@ -81,18 +81,24 @@ void Focus_Loss(void)
 {
     Theme.Suspend();
     Stop_Primary_Sound_Buffer();
-    if (WWMouse)
+
+    if (WWMouse && Is_Video_Fullscreen()) {
         WWMouse->Clear_Cursor_Clip();
+    }
 }
 
 void Focus_Restore(void)
 {
     Map.Flag_To_Redraw(true);
     Start_Primary_Sound_Buffer(true);
-    if (WWMouse)
-        WWMouse->Set_Cursor_Clip();
-    VisiblePage.Clear();
-    HiddenPage.Clear();
+
+    if (Is_Video_Fullscreen()) {
+        if (WWMouse) {
+            WWMouse->Set_Cursor_Clip();
+        }
+        VisiblePage.Clear();
+        HiddenPage.Clear();
+    }
 }
 
 /***********************************************************************************************

--- a/tiberiandawn/conquer.cpp
+++ b/tiberiandawn/conquer.cpp
@@ -263,7 +263,13 @@ void Main_Game(int argc, char* argv[])
             **	Main_Loop(), allowing the game to run in the background.
             */
             if (SpecialDialog != SDLG_NONE) {
-                // Stop_Profiler();
+                /*
+                **  Always release mouse cursor when a dialog is open.
+                */
+                if (!Is_Video_Fullscreen()) {
+                    WWMouse->Clear_Cursor_Clip();
+                }
+
                 switch (SpecialDialog) {
                 case SDLG_SPECIAL:
                     Map.Help_Text(TXT_NONE);
@@ -293,6 +299,10 @@ void Main_Game(int argc, char* argv[])
 
                 default:
                     break;
+                }
+
+                if (!Is_Video_Fullscreen()) {
+                    WWMouse->Set_Cursor_Clip();
                 }
             }
         }

--- a/tiberiandawn/init.cpp
+++ b/tiberiandawn/init.cpp
@@ -843,6 +843,13 @@ bool Select_Game(bool fade)
     Map.Set_Default_Mouse(MOUSE_NORMAL, false);
 
     /*
+    **  Allow moving mouse outside the game window when in menu.
+    */
+    if (!Is_Video_Fullscreen()) {
+        WWMouse->Clear_Cursor_Clip();
+    }
+
+    /*
     **	If the last game we played was a multiplayer game, jump right to that
     **	menu by pre-setting 'selection'.
     */
@@ -1506,6 +1513,9 @@ bool Select_Game(bool fade)
     Hide_Mouse();
     Hide_Mouse();
     WWMouse->Erase_Mouse(&HidPage, true);
+    if (!Is_Video_Fullscreen()) {
+        WWMouse->Set_Cursor_Clip();
+    }
 
     Fade_Palette_To(BlackPalette, FADE_PALETTE_MEDIUM, Call_Back);
     HiddenPage.Clear();

--- a/tiberiandawn/winstub.cpp
+++ b/tiberiandawn/winstub.cpp
@@ -77,18 +77,24 @@ void Focus_Loss(void)
     }
     Theme.Stop();
     Stop_Primary_Sound_Buffer();
-    if (WWMouse)
+
+    if (WWMouse && Is_Video_Fullscreen()) {
         WWMouse->Clear_Cursor_Clip();
+    }
 }
 
 void Focus_Restore(void)
 {
     Map.Flag_To_Redraw(true);
     Start_Primary_Sound_Buffer(true);
-    if (WWMouse)
-        WWMouse->Set_Cursor_Clip();
-    VisiblePage.Clear();
-    HiddenPage.Clear();
+
+    if (Is_Video_Fullscreen()) {
+        if (WWMouse) {
+            WWMouse->Set_Cursor_Clip();
+        }
+        VisiblePage.Clear();
+        HiddenPage.Clear();
+    }
 }
 
 /***********************************************************************************************


### PR DESCRIPTION
Hook SDL2 focus events into game focus functions and manage cursor grabbing properly in windowed mode. Additionally add a function to check if we are running in fullscreen or not so the games know if they should release the mouse or not. In the future we should support toggling fullscreen.

To be honest this shouldn't be something the games themselves worry about but lock/unlock the cursor how they see fit and let the platform code decide if the cursor is really locked or released but because win32 and SDL handle focus and mouse grabbing differently I'm not keen trying to fix that until the win32 backend is removed completely.