### PR TITLE
[TD] Fixes issue clicking sidebar icons.

### DIFF
--- a/tiberiandawn/sidebar.cpp
+++ b/tiberiandawn/sidebar.cpp
@@ -2115,7 +2115,7 @@ void SidebarClass::StripClass::SelectClass::Set_Owner(StripClass& strip, int ind
     Strip = &strip;
     Index = index;
     X = strip.X;
-    Y = strip.Y + ((index * OBJECT_HEIGHT) * factor);
+    Y = strip.Y + (index * (OBJECT_HEIGHT << factor));
 }
 
 /***********************************************************************************************


### PR DESCRIPTION
Fixes #195. Caused by a multiply being used instead of a shift. Get_Resolution_Factor currently returns a shift value rather than the multiply value used in RA.