### PR TITLE
Output scaling for SDL2

### DIFF
--- a/common/wwkeyboard.cpp
+++ b/common/wwkeyboard.cpp
@@ -52,6 +52,7 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #include "wwkeyboard.h"
+#include "wwmouse.h"
 #include "miscasm.h"
 #include <string.h>
 #ifdef SDL2_BUILD
@@ -545,7 +546,8 @@ void WWKeyboardClass::Fill_Buffer_From_System(void)
             Put_Key_Message(event.key.keysym.scancode, true);
             break;
         case SDL_MOUSEBUTTONDOWN:
-        case SDL_MOUSEBUTTONUP:
+        case SDL_MOUSEBUTTONUP: {
+            float scale_x = 1.0f, scale_y = 1.0f;
             switch (event.button.button) {
             case SDL_BUTTON_LEFT:
             default:
@@ -558,8 +560,12 @@ void WWKeyboardClass::Fill_Buffer_From_System(void)
                 key = VK_MBUTTON;
                 break;
             }
-            Put_Mouse_Message(key, event.button.x, event.button.y, event.type == SDL_MOUSEBUTTONDOWN ? false : true);
-            break;
+            Get_Mouse_Scale_XY(scale_x, scale_y);
+            Put_Mouse_Message(key,
+                              event.button.x * scale_x,
+                              event.button.y * scale_y,
+                              event.type == SDL_MOUSEBUTTONDOWN ? false : true);
+        } break;
         case SDL_WINDOWEVENT:
             switch (event.window.event) {
             case SDL_WINDOWEVENT_EXPOSED:

--- a/common/wwmouse.cpp
+++ b/common/wwmouse.cpp
@@ -36,6 +36,7 @@
 #ifdef SDL2_BUILD
 #include <SDL.h>
 extern SDL_Window* window;
+extern SDL_Renderer* renderer;
 #endif
 
 #ifndef min
@@ -114,6 +115,18 @@ WWMouseClass::WWMouseClass(GraphicViewPortClass* scr, int mouse_max_width, int m
     ** Force the windows mouse pointer to stay withing the graphic view port region
     */
     Set_Cursor_Clip();
+
+#ifdef SDL2_BUILD
+    if (window) {
+        int w, h;
+        SDL_GetRendererOutputSize(renderer, &w, &h);
+        MouseXScale = scr->Get_Width() / (float)w;
+        MouseYScale = scr->Get_Height() / (float)h;
+    }
+#else
+    MouseXScale = 1.0f;
+    MouseYScale = 1.0f;
+#endif
 }
 
 WWMouseClass::~WWMouseClass()
@@ -661,6 +674,8 @@ void WWMouseClass::Get_Mouse_XY(int& x, int& y)
 {
 #if defined(SDL2_BUILD)
     SDL_GetMouseState(&x, &y);
+    x *= MouseXScale;
+    y *= MouseYScale;
 #elif defined(_WIN32)
     POINT pt;
 
@@ -668,6 +683,12 @@ void WWMouseClass::Get_Mouse_XY(int& x, int& y)
     x = pt.x;
     y = pt.y;
 #endif
+}
+
+void WWMouseClass::Get_Mouse_Scale_XY(float& x, float& y)
+{
+    x = MouseXScale;
+    y = MouseYScale;
 }
 
 void WWMouseClass::Mouse_Shadow_Buffer(GraphicViewPortClass* viewport,
@@ -976,4 +997,12 @@ int Get_Mouse_Y(void)
     if (!_Mouse)
         return (0);
     return (_Mouse->Get_Mouse_Y());
+}
+
+void Get_Mouse_Scale_XY(float& x, float& y)
+{
+    if (!_Mouse)
+        return;
+
+    _Mouse->Get_Mouse_Scale_XY(x, y);
 }

--- a/common/wwmouse.h
+++ b/common/wwmouse.h
@@ -64,6 +64,7 @@ public:
     int Get_Mouse_X(void);
     int Get_Mouse_Y(void);
     void Get_Mouse_XY(int& x, int& y);
+    void Get_Mouse_Scale_XY(float& x, float& y);
     //
     // The following two routines can be used to render the mouse onto a graphicbuffer
     // other than the hidpage.
@@ -124,6 +125,9 @@ private:
     CRITICAL_SECTION MouseCriticalSection; // Control for mouse re-enterancy
     unsigned TimerHandle;
 #endif
+
+    float MouseXScale;
+    float MouseYScale;
 };
 
 void Hide_Mouse(void);
@@ -134,5 +138,6 @@ int Get_Mouse_State(void);
 void* Set_Mouse_Cursor(int hotx, int hoty, void* cursor);
 int Get_Mouse_X(void);
 int Get_Mouse_Y(void);
+void Get_Mouse_Scale_XY(float& x, float& y);
 
 #endif

--- a/tiberiandawn/function.h
+++ b/tiberiandawn/function.h
@@ -955,6 +955,8 @@ extern bool GameInFocus;
 
 extern int ScreenWidth;
 extern int ScreenHeight;
+extern int OutputWidth;
+extern int OutputHeight;
 extern "C" void ModeX_Blit(GraphicBufferClass* source);
 extern void Colour_Debug(int call_number);
 

--- a/tiberiandawn/globals.cpp
+++ b/tiberiandawn/globals.cpp
@@ -941,6 +941,8 @@ int Argc;       // Command line argument count
 
 int ScreenWidth = GBUFF_INIT_WIDTH;
 int ScreenHeight = GBUFF_INIT_HEIGHT;
+int OutputWidth = GBUFF_INIT_WIDTH;
+int OutputHeight = GBUFF_INIT_HEIGHT;
 WWMouseClass* WWMouse = NULL;
 int AllDone;
 bool InMovie = false; // Are we currently playing a VQ movie?

--- a/tiberiandawn/startup.cpp
+++ b/tiberiandawn/startup.cpp
@@ -303,6 +303,9 @@ int main(int argc, char** argv)
             video_success = true;
 #else
 
+#ifdef SDL2_BUILD
+            video_success = static_cast<bool>(Set_Video_Mode(OutputWidth, OutputHeight, 8));
+#else
             if (ScreenHeight == 400) {
                 if (Set_Video_Mode(ScreenWidth, ScreenHeight, 8)) {
                     video_success = true;
@@ -317,6 +320,8 @@ int main(int argc, char** argv)
                     video_success = true;
                 }
             }
+#endif // SDL2_BUILD
+
 #endif
 
             if (!video_success) {
@@ -634,6 +639,8 @@ void Read_Setup_Options(RawFileClass* config_file)
         AllowHardwareBlitFills = WWGetPrivateProfileInt("Options", "HardwareFills", 1, buffer);
         ScreenHeight =
             WWGetPrivateProfileInt("Options", "Resolution", 0, buffer) ? GBUFF_INIT_ALTHEIGHT : GBUFF_INIT_HEIGHT;
+        OutputWidth = WWGetPrivateProfileInt("Options", "OutputWidth", ScreenWidth, buffer);
+        OutputHeight = WWGetPrivateProfileInt("Options", "OutputHeight", ScreenHeight, buffer);
         IsV107 = WWGetPrivateProfileInt("Options", "Compatibility", 0, buffer);
 
         /*


### PR DESCRIPTION
Implements straightforward scaling from in-game resolution to output window.

Hooked to TD only for now, to use add OutputWidth and OutputHeight to [Options] section in CONQUER.INI.