### PR TITLE
SDL2 rendering optimization

### DIFF
--- a/common/framelimit.cpp
+++ b/common/framelimit.cpp
@@ -10,6 +10,10 @@
 
 extern WWMouseClass* WWMouse;
 
+#ifdef SDL2_BUILD
+void Video_Render_Frame();
+#endif
+
 void Frame_Limiter()
 {
     // Crude limiter to limit refresh loops to occuring 120 times a second.
@@ -20,11 +24,12 @@ void Frame_Limiter()
     _last = now;
     auto remaining = _ms_per_tick - std::chrono::duration_cast<std::chrono::milliseconds>(diff).count();
 
+#ifdef SDL2_BUILD
+    WWMouse->Process_Mouse();
+    Video_Render_Frame();
+#endif
+
     if (remaining > 0) {
         ms_sleep(unsigned(remaining));
     }
-
-#ifdef SDL2_BUILD
-    WWMouse->Process_Mouse();
-#endif
 }

--- a/redalert/conquer.cpp
+++ b/redalert/conquer.cpp
@@ -3454,7 +3454,7 @@ long VQ_Call_Back(unsigned char*, long)
 #else
     Interpolate_2X_Scale(&SysMemPage, &SeenBuff, NULL);
 #endif
-    // Call_Back();
+    Frame_Limiter();
 
     if ((BreakoutAllowed || Debug_Flag) && key == KN_ESC) {
         Keyboard->Clear();

--- a/tiberiandawn/conquer.cpp
+++ b/tiberiandawn/conquer.cpp
@@ -2820,7 +2820,8 @@ long VQ_Call_Back(unsigned char*, long)
     Check_VQ_Palette_Set();
 
     Interpolate_2X_Scale(&SysMemPage, &SeenBuff, NULL);
-    // Call_Back();
+    Frame_Limiter();
+
     if ((BreakoutAllowed || Debug_Flag) && key == KN_ESC) {
         Keyboard->Clear();
         Brokeout = true;


### PR DESCRIPTION
Original games expect DMA level lock/unlock to asynchronously update the front surface. DirectDraw still had support for this and it worked fine but it doesn't really work with SDL2 anymore.

The  SDL2 rendering pipeline is changed so that the frame limiter flips the screen which also removes all mouse cursor flickering as it's drawn just before flipping.

The speed difference is very noticable on a slower CPU/GPU where you could see the menu being drawn one button at a time or in-game when you move some sliders in settings or just scroll the screen.

Some rendering loops are still missing the frame limiter (dialogs) but once this change is in place it's very easy to spot as the screen stops drawing when such is encountered.

Implemented the frame limiter for VQA playback for both games so we at least have video. TD seems to be mostly hooked up and didn't notice anything missing from in-game dialogs or in the menu.

I know this is not the cleanest way to do this but just to get things forward this should be sufficient so future refactoring will be easy after we drop DirectDraw support.