### PR TITLE
Fixes reused file classes not clearing bias information.

### DIFF
--- a/common/rawfile.cpp
+++ b/common/rawfile.cpp
@@ -364,6 +364,12 @@ void RawFileClass::Close(void)
         **	At this point the file must have been closed. Mark the file as empty and return.
         */
         Handle = nullptr;
+
+        /*
+        **	Clear any positioning information incase class is reused to open another file.
+        */
+        BiasStart = 0;
+        BiasLength = -1;
     }
 }
 


### PR DESCRIPTION
Mainly affects TD map editor code that reuses a file class to save after opening
from a mix file which sets bias.