### PR TITLE
Fixes redraw issues in TD and radar sounds for both games.

### DIFF
--- a/redalert/radar.cpp
+++ b/redalert/radar.cpp
@@ -249,8 +249,10 @@ bool RadarClass::Radar_Activate(int control)
     case 0:
         if (Map.IsSidebarActive) {
             if (IsRadarActive && !IsRadarDeactivating) {
-                // Sound_Effect(VOC_RADAR_OFF); // MBL 07.20.2020: These are never being sent to the client, so handled
-                // there; Disabling here for good measure.
+#ifndef REMASTER_BUILD
+                // MBL 07.20.2020: These are never being sent to the client, so handled there; Disabling here for good measure.
+                Sound_Effect(VOC_RADAR_OFF);
+#endif
                 IsRadarDeactivating = true;
                 IsRadarActive = false;
                 if (IsRadarActivating == true) {
@@ -267,8 +269,10 @@ bool RadarClass::Radar_Activate(int control)
     case 1:
         if (Map.IsSidebarActive) {
             if (!IsRadarActivating && !IsRadarActive) {
-                // Sound_Effect(VOC_RADAR_ON); // MBL 07.20.2020: These are never being sent to the client, so handled
-                // there; Disabling here for good measure.
+#ifndef REMASTER_BUILD
+                // MBL 07.20.2020: These are never being sent to the client, so handled there; Disabling here for good measure.
+                Sound_Effect(VOC_RADAR_ON);
+#endif
                 IsRadarActivating = true;
                 if (IsRadarDeactivating == true) {
                     IsRadarDeactivating = false;

--- a/tiberiandawn/radar.cpp
+++ b/tiberiandawn/radar.cpp
@@ -918,7 +918,7 @@ int RadarClass::Click_In_Radar(int& ptr_x, int& ptr_y, bool change)
 
     x -= (RadX + RadOffX);
     y -= (RadY + RadOffY);
-    if (x < RadIWidth && y < RadIHeight) {
+    if ((unsigned)x < (unsigned)RadIWidth && (unsigned)y < (unsigned)RadIHeight) {
         x -= BaseX;
         y -= BaseY;
 

--- a/tiberiandawn/radar.cpp
+++ b/tiberiandawn/radar.cpp
@@ -230,8 +230,10 @@ bool RadarClass::Radar_Activate(int control)
     case 0:
         if (Map.IsSidebarActive) {
             if (IsRadarActive && !IsRadarDeactivating) {
-                // Sound_Effect(VOC_RADAR_OFF); // MBL 07.20.2020: These are never being sent to the client, so handled
-                // there; Disabling here for good measure.
+#ifndef REMASTER_BUILD
+                // MBL 07.20.2020: These are never being sent to the client, so handled there; Disabling here for good measure.
+                Sound_Effect(VOC_RADAR_OFF);
+#endif
                 IsRadarDeactivating = true;
                 IsRadarActive = false;
                 if (IsRadarActivating == true) {
@@ -248,8 +250,10 @@ bool RadarClass::Radar_Activate(int control)
     case 1:
         if (Map.IsSidebarActive) {
             if (!IsRadarActivating && !IsRadarActive) {
-                // Sound_Effect(VOC_RADAR_ON); // MBL 07.20.2020: These are never being sent to the client, so handled
-                // there; Disabling here for good measure.
+#ifndef REMASTER_BUILD
+                // MBL 07.20.2020: These are never being sent to the client, so handled there; Disabling here for good measure.
+                Sound_Effect(VOC_RADAR_ON);
+#endif
                 IsRadarActivating = true;
                 if (IsRadarDeactivating == true) {
                     IsRadarDeactivating = false;


### PR DESCRIPTION
Activate/Deactivate sound is handled by glyphx frontend so remaster code has the audio call disabled in the original call for it. This restores it for standalone builds.

There was also a redraw issue in TD when the radar was active which is now fixed due to signed/unsigned comparison behaviour.