### PR TITLE
[RA] Fixes crash on 64bit linux builds.

### DIFF
--- a/redalert/defines.h
+++ b/redalert/defines.h
@@ -492,7 +492,7 @@ typedef union
     } Sub;
 } LEPTON_COMPOSITE;
 
-typedef unsigned long COORDINATE;
+typedef unsigned COORDINATE;
 typedef union
 {
     COORDINATE Coord;

--- a/redalert/smudge.cpp
+++ b/redalert/smudge.cpp
@@ -115,7 +115,7 @@ SmudgeClass::SmudgeClass(SmudgeType type, COORDINATE pos, HousesType house)
     : ObjectClass(RTTI_SMUDGE, Smudges.ID(this))
     , Class(SmudgeTypes.Ptr((int)type))
 {
-    if (pos != -1) {
+    if (pos != UINT_MAX) {
         ToOwn = house;
         if (!Unlimbo(pos)) {
             delete this;

--- a/redalert/smudge.h
+++ b/redalert/smudge.h
@@ -61,7 +61,7 @@ public:
         return (ptr);
     };
     static void operator delete(void* ptr);
-    SmudgeClass(SmudgeType type, COORDINATE pos = 0xFFFFFFFFUL, HousesType house = HOUSE_NONE);
+    SmudgeClass(SmudgeType type, COORDINATE pos = UINT_MAX, HousesType house = HOUSE_NONE);
     SmudgeClass(NoInitClass const& x)
         : ObjectClass(x)
         , Class(x){};

--- a/tiberiandawn/defines.h
+++ b/tiberiandawn/defines.h
@@ -1639,7 +1639,7 @@ typedef enum RadioMessageType : unsigned char
 **	with cell resolution. The COORD type is used for map coordinates that
 **	have a lepton resolution.
 */
-typedef unsigned long COORDINATE;
+typedef unsigned COORDINATE;
 typedef signed short CELL;
 
 typedef unsigned short TARGET;

--- a/tiberiandawn/smudge.cpp
+++ b/tiberiandawn/smudge.cpp
@@ -153,7 +153,7 @@ void SmudgeClass::operator delete(void* ptr)
 SmudgeClass::SmudgeClass(SmudgeType type, COORDINATE pos, HousesType house)
     : Class(&SmudgeTypeClass::As_Reference(type))
 {
-    if (pos != -1) {
+    if (pos != UINT_MAX) {
         ToOwn = house;
         if (!Unlimbo(pos)) {
             Delete_This();

--- a/tiberiandawn/smudge.h
+++ b/tiberiandawn/smudge.h
@@ -52,7 +52,7 @@ public:
     */
     static void* operator new(size_t size);
     static void operator delete(void* ptr);
-    SmudgeClass(SmudgeType type, COORDINATE pos = -1, HousesType house = HOUSE_NONE);
+    SmudgeClass(SmudgeType type, COORDINATE pos = UINT_MAX, HousesType house = HOUSE_NONE);
     SmudgeClass(void)
         : Class(0){};
     operator SmudgeType(void) const


### PR DESCRIPTION
Fixes crash when a bib is removed.
Alters TD code to be the same for consistency.
Fixes #212.