### PR TITLE
RawFileClass support for case sensitive filesystems

### DIFF
--- a/common/file.cpp
+++ b/common/file.cpp
@@ -1,4 +1,39 @@
 #include "file.h"
+#include <string.h>
+
+#ifndef _WIN32
+static void Resolve_File_Single(char* fname)
+{
+    Find_File_Data* ffblk;
+
+    ffblk = Find_File_Data::CreateFindData();
+
+    if (ffblk == nullptr) {
+        return;
+    }
+
+    if (ffblk->FindFirst(fname) && strlen(fname) == strlen(ffblk->GetName())) {
+        strncpy(fname, ffblk->GetName(), strlen(fname) + 1);
+    }
+
+    delete ffblk;
+}
+#endif
+
+void Resolve_File(char* fname)
+{
+#ifndef _WIN32
+    // step through each sub-directory before going for the win
+    char* next = fname;
+    while (next = strchr(next, '/')) {
+        *next = '\0';
+        Resolve_File_Single(fname);
+        *next++ = '/';
+    }
+
+    Resolve_File_Single(fname);
+#endif
+}
 
 bool Find_First(const char* fname, unsigned int mode, Find_File_Data** ffblk)
 {

--- a/common/file.h
+++ b/common/file.h
@@ -220,6 +220,8 @@ int Find_File_Index(char const* filename);
 /* The following prototypes are for the file: file.cpp                     */
 /*=========================================================================*/
 
+void Resolve_File(char* fname);
+
 class Find_File_Data
 {
 public:

--- a/common/file_posix.cpp
+++ b/common/file_posix.cpp
@@ -1,5 +1,6 @@
 #include "file.h"
 
+#include <string.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <dirent.h>
@@ -24,6 +25,7 @@ private:
     DIR* Directory;
     struct dirent* DirEntry;
     const char* FileFilter;
+    char FullName[PATH_MAX];
 
     bool FindNextWithFilter();
 };
@@ -44,7 +46,7 @@ const char* Find_File_Data_Posix::GetName() const
     if (DirEntry == nullptr) {
         return nullptr;
     }
-    return DirEntry->d_name;
+    return FullName;
 }
 
 unsigned long Find_File_Data_Posix::GetTime() const
@@ -66,14 +68,8 @@ bool Find_File_Data_Posix::FindNextWithFilter()
         if (DirEntry == nullptr) {
             return false;
         }
-        struct stat buf = {0};
-        if (stat(DirEntry->d_name, &buf) != 0) {
-            return false;
-        }
-        if (!S_ISREG(buf.st_mode)) {
-            continue;
-        }
-        if (fnmatch(FileFilter, DirEntry->d_name, FNM_PATHNAME) == 0) {
+        if (fnmatch(FileFilter, DirEntry->d_name, FNM_PATHNAME | FNM_CASEFOLD) == 0) {
+            strcat(FullName, DirEntry->d_name);
             break;
         }
     }
@@ -83,13 +79,23 @@ bool Find_File_Data_Posix::FindNextWithFilter()
 bool Find_File_Data_Posix::FindFirst(const char* fname)
 {
     Close();
-    FileFilter = fname;
-    char cwd[PATH_MAX] = {0};
-    getcwd(cwd, PATH_MAX);
-    Directory = opendir(cwd);
+    FullName[0] = '\0';
+
+    // split directory and file from the path
+    char* fdir = strrchr((char*)fname, '/');
+    if (fdir != nullptr) {
+        strncat(FullName, fname, (fdir - fname));
+        strcat(FullName, "/");
+        FileFilter = fdir + 1;
+    } else {
+        FileFilter = fname;
+    }
+
+    Directory = opendir(FullName);
     if (Directory == nullptr) {
         return false;
     }
+
     return FindNextWithFilter();
 }
 

--- a/common/rawfile.cpp
+++ b/common/rawfile.cpp
@@ -37,6 +37,7 @@
  *   RawFileClass::Error -- Handles displaying a file error message.                           *
  *   RawFileClass::Get_Date_Time -- Gets the date and time the file was last modified.         *
  *   RawFileClass::Is_Available -- Checks to see if the specified file is available to open.   *
+ *   RawFileClass::Is_Directory -- Checks to see if the specified file is a directory.         *
  *   RawFileClass::Open -- Assigns name and opens file in one operation.                       *
  *   RawFileClass::Open -- Opens the file object with the rights specified.                    *
  *   RawFileClass::RawFileClass -- Simple constructor for a file object.                       *
@@ -60,6 +61,8 @@
 #include <unistd.h>
 #define _unlink unlink
 #endif
+
+#include <sys/stat.h>
 
 /***********************************************************************************************
  * RawFileClass::Error -- Handles displaying a file error message.                             *
@@ -329,6 +332,24 @@ int RawFileClass::Is_Available(int forced)
     Handle = nullptr;
 
     return (true);
+}
+
+/***********************************************************************************************
+ * RawFileClass::Is_Directory -- Checks to see if the specified file is a directory.           *
+ *                                                                                             *
+ * INPUT:   none                                                                               *
+ *                                                                                             *
+ * OUTPUT:  bool; Is the file a directory?                                                     *
+ *                                                                                             *
+ *=============================================================================================*/
+bool RawFileClass::Is_Directory()
+{
+    if (Filename == NULL) {
+        return false;
+    }
+
+    struct stat st;
+    return stat(Filename, &st) == 0 && (st.st_mode & S_IFDIR) == S_IFDIR;
 }
 
 /***********************************************************************************************

--- a/common/rawfile.h
+++ b/common/rawfile.h
@@ -126,19 +126,9 @@ private:
     FILE* Handle;
 
     /*
-    **	This points to the filename as a NULL terminated string. It may point to either a
-    **	constant or an allocated string as indicated by the "Allocated" flag.
+    **	This points to a copy of the filename as a NULL terminated string.
     */
-    const char* Filename;
-
-    /*
-    **	Filenames that were assigned as part of the construction process
-    **	are not allocated. It is assumed that the filename string is a
-    **	constant in that case and thus making duplication unnecessary.
-    **	This value will be non-zero if the filename has be allocated
-    **	(using strdup()).
-    */
-    unsigned Allocated : 1;
+    char* Filename;
 };
 
 /***********************************************************************************************
@@ -184,7 +174,6 @@ inline RawFileClass::RawFileClass(void)
     , BiasLength(-1)
     , Handle(nullptr)
     , Filename(0)
-    , Allocated(false)
 {
 }
 
@@ -207,10 +196,9 @@ inline RawFileClass::RawFileClass(void)
 inline RawFileClass::~RawFileClass(void)
 {
     Close();
-    if (Allocated && Filename) {
+    if (Filename) {
         free((char*)Filename);
         ((char*&)Filename) = 0;
-        Allocated = false;
     }
 }
 

--- a/common/rawfile.h
+++ b/common/rawfile.h
@@ -82,6 +82,7 @@ public:
     virtual int Create(void);
     virtual int Delete(void);
     virtual int Is_Available(int forced = false);
+    virtual bool Is_Directory(void);
     virtual int Is_Open(void) const;
     virtual int Open(char const* filename, int rights = READ);
     virtual int Open(int rights = READ);

--- a/redalert/conquer.cpp
+++ b/redalert/conquer.cpp
@@ -79,7 +79,6 @@ TcpipManagerClass Winsock;
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <sys/stat.h>
 #include "vortex.h"
 #include "common/framelimit.h"
 #include "common/vqatask.h"
@@ -3989,9 +3988,9 @@ static bool Change_Local_Dir(int cd)
     // Detect which if any of the discs have had their data copied to an appropriate local folder.
     if (!_initialised) {
         for (int i = 0; i < CD_COUNT; ++i) {
-            struct stat st;
+            RawFileClass vol(_vol_labels[i]);
 
-            if (stat(_vol_labels[i], &st) == 0 && (st.st_mode & S_IFDIR) == S_IFDIR) {
+            if (vol.Is_Directory()) {
                 CDFileClass::Refresh_Search_Drives();
                 snprintf(vol_buff, sizeof(vol_buff), "%s/", _vol_labels[i]);
                 CDFileClass::Add_Search_Drive(vol_buff);
@@ -4051,10 +4050,10 @@ static bool Change_Local_Dir(int cd)
 
     // If the data from the CD we want was detected, then double check it and set it as though we used the -CD command line.
     if (_detected & (1 << cd)) {
-        struct stat st;
+        RawFileClass vol(_vol_labels[cd]);
 
         // Verify that the file is still available and hasn't been deleted out from under us.
-        if (stat(_vol_labels[cd], &st) == 0 && (st.st_mode & S_IFDIR) == S_IFDIR) {
+        if (vol.Is_Directory()) {
             CDFileClass::Refresh_Search_Drives();
             snprintf(vol_buff, sizeof(vol_buff), "%s/", _vol_labels[cd]);
             CDFileClass::Add_Search_Drive(vol_buff);

--- a/tiberiandawn/conquer.cpp
+++ b/tiberiandawn/conquer.cpp
@@ -64,7 +64,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
-#include <sys/stat.h>
 #include "common/framelimit.h"
 #include "common/vqatask.h"
 #include "common/vqaloader.h"
@@ -3465,9 +3464,9 @@ static bool Change_Local_Dir(int cd)
     // Detect which if any of the discs have had their data copied to an appropriate local folder.
     if (!_initialised) {
         for (int i = 0; i < CD_COUNT; ++i) {
-            struct stat st;
+            RawFileClass vol(_vol_labels[i]);
 
-            if (stat(_vol_labels[i], &st) == 0 && (st.st_mode & S_IFDIR) == S_IFDIR) {
+            if (vol.Is_Directory()) {
                 CDFileClass::Refresh_Search_Drives();
                 snprintf(vol_buff, sizeof(vol_buff), "%s/", _vol_labels[i]);
                 CDFileClass::Add_Search_Drive(vol_buff);
@@ -3517,10 +3516,10 @@ static bool Change_Local_Dir(int cd)
 
     // If the data from the CD we want was detected, then double check it and set it as though we used the -CD command line.
     if (_detected & (1 << cd)) {
-        struct stat st;
+        RawFileClass vol(_vol_labels[cd]);
 
         // Verify that the file is still available and hasn't been deleted out from under us.
-        if (stat(_vol_labels[cd], &st) == 0 && (st.st_mode & S_IFDIR) == S_IFDIR) {
+        if (vol.Is_Directory()) {
             CDFileClass::Refresh_Search_Drives();
             snprintf(vol_buff, sizeof(vol_buff), "%s/", _vol_labels[cd]);
             CDFileClass::Add_Search_Drive(vol_buff);


### PR DESCRIPTION
Always make a defensive copy of the filename and try to resolve it
to an actual file on the disk.

This doesn't yet work with directories but at least we don't need
to require people to be careful with cases.