### PR TITLE
[RA] Enables expansion pack detection.

### DIFF
--- a/redalert/conquer.cpp
+++ b/redalert/conquer.cpp
@@ -5108,31 +5108,23 @@ const char* Game_Registry_Key()
  *=============================================================================================*/
 bool Is_Counterstrike_Installed(void)
 {
-    return true; // Remasters always have Counterstrike. ST - 10/18/2019 11:06AM
+#ifdef REMASTER_BUILD
+    return true; // Remasters always have Aftermath. ST - 10/18/2019 11:06AM
 
-#if (0)
+#else
     //	ajw 9/29/98
     static bool bAlreadyChecked = false;
     static bool bInstalled = false;
 
     if (!bAlreadyChecked) {
-        HKEY hKey;
-        if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, Game_Registry_Key(), 0, KEY_READ, &hKey) != ERROR_SUCCESS)
-            return false;
-        DWORD dwValue;
-        DWORD dwBufSize = sizeof(DWORD);
-        if (RegQueryValueEx(hKey, "CStrikeInstalled", 0, NULL, (LPBYTE)&dwValue, &dwBufSize) != ERROR_SUCCESS)
-            bInstalled = false;
-        else
-            bInstalled = (bool)dwValue; //	(Presumably true, if it's there...)
-
-        RegCloseKey(hKey);
-        bAlreadyChecked = true;
+        if (!bAlreadyChecked) {
+            CCFileClass file("EXPAND.MIX");
+            bInstalled = file.Is_Available();
+            bAlreadyChecked = true;
+        }
     }
-    return bInstalled;
 
-//	RawFileClass file("EXPAND.MIX");
-//	return(file.Is_Available());
+    return bInstalled && Options.CounterstrikeEnabled;
 #endif
 }
 
@@ -5141,31 +5133,20 @@ bool Is_Counterstrike_Installed(void)
  *=============================================================================================*/
 bool Is_Aftermath_Installed(void)
 {
+#ifdef REMASTER_BUILD
     return true; // Remasters always have Aftermath. ST - 10/18/2019 11:06AM
 
-#if (0)
-    //	ajw 9/29/98
+#else
     static bool bAlreadyChecked = false;
     static bool bInstalled = false;
 
     if (!bAlreadyChecked) {
-        HKEY hKey;
-        if (RegOpenKeyEx(HKEY_LOCAL_MACHINE, Game_Registry_Key(), 0, KEY_READ, &hKey) != ERROR_SUCCESS)
-            return false;
-        DWORD dwValue;
-        DWORD dwBufSize = sizeof(DWORD);
-        if (RegQueryValueEx(hKey, "AftermathInstalled", 0, NULL, (LPBYTE)&dwValue, &dwBufSize) != ERROR_SUCCESS)
-            bInstalled = false;
-        else
-            bInstalled = (bool)dwValue; //	(Presumably true, if it's there...)
-
-        RegCloseKey(hKey);
+        CCFileClass file("EXPAND2.MIX");
+        bInstalled = file.Is_Available();
         bAlreadyChecked = true;
     }
-    return bInstalled;
 
-//	RawFileClass file("EXPAND2.MIX");
-//	return(file.Is_Available());
+    return bInstalled && Options.AftermathEnabled;
 #endif
 }
 #endif

--- a/redalert/options.cpp
+++ b/redalert/options.cpp
@@ -102,6 +102,8 @@ OptionsClass::OptionsClass(void)
     , IsScoreShuffle(false)
     , IsPaletteScroll(true)
     , ToggleSidebar(true)
+    , CounterstrikeEnabled(true)
+    , AftermathEnabled(true)
     ,
 
     KeyForceMove1(KN_LALT)
@@ -578,6 +580,9 @@ void OptionsClass::Load_Settings(void)
     SlowPalette = ini.Get_Bool(OPTIONS, "SlowPalette", SlowPalette);
     IsPaletteScroll = ini.Get_Bool(OPTIONS, "PaletteScroll", IsPaletteScroll);
     ToggleSidebar = ini.Get_Bool(OPTIONS, "AllowSidebarToggle", ToggleSidebar);
+
+    CounterstrikeEnabled = ini.Get_Bool("Expansions", "CounterstrikeEnabled", CounterstrikeEnabled);
+    AftermathEnabled = ini.Get_Bool("Expansions", "AftermathEnabled", AftermathEnabled);
 
     KeyForceMove1 = (KeyNumType)ini.Get_Int(HotkeyName, "KeyForceMove1", KeyForceMove1);
     KeyForceMove2 = (KeyNumType)ini.Get_Int(HotkeyName, "KeyForceMove2", KeyForceMove2);

--- a/redalert/options.h
+++ b/redalert/options.h
@@ -85,15 +85,17 @@ public:
 #ifdef FIXIT_VERSION_3
     fixed MultiScoreVolume; //	Volume for scores during multiplayer games.
 #endif
-    fixed Brightness;             // Brightness.
-    fixed Tint;                   // Hue
-    fixed Saturation;             // Saturation
-    fixed Contrast;               // Value
-    unsigned AutoScroll : 1;      // Does map autoscroll?
-    unsigned IsScoreRepeat : 1;   // Score should repeat?
-    unsigned IsScoreShuffle : 1;  // Score list should shuffle?
-    unsigned IsPaletteScroll : 1; // Allow palette scrolling?
-    unsigned ToggleSidebar : 1;   // Allow sidebar to be toggled?
+    fixed Brightness;                  // Brightness.
+    fixed Tint;                        // Hue
+    fixed Saturation;                  // Saturation
+    fixed Contrast;                    // Value
+    unsigned AutoScroll : 1;           // Does map autoscroll?
+    unsigned IsScoreRepeat : 1;        // Score should repeat?
+    unsigned IsScoreShuffle : 1;       // Score list should shuffle?
+    unsigned IsPaletteScroll : 1;      // Allow palette scrolling?
+    unsigned ToggleSidebar : 1;        // Allow sidebar to be toggled?
+    unsigned CounterstrikeEnabled : 1; // Allow counterstrike to be detected?
+    unsigned AftermathEnabled : 1;     // Allow aftermath to be detected?
 
     /*
     **	These are the hotkeys used for keyboard control.


### PR DESCRIPTION
Detects expansions through prescence of expandX.mix files.
Adds options to redalert.ini to control if expansions can be detected which are true by default:
[Expansions]
CounterstrikeEnabled=true
AftermathEnabled=true

Setting them to false overrides the presence of the mix files.