### PR TITLE
Replaces version numbers with git commit short hash.

### DIFF
--- a/cmake/GitWatcher.cmake
+++ b/cmake/GitWatcher.cmake
@@ -89,6 +89,7 @@ set(_state_variable_names
     GIT_COMMIT_TSTAMP
     GIT_HEAD_SHORT_SHA1
     GIT_REV_LIST_COUNT
+    GIT_TAG
     # >>>
     # 1. Add the name of the additional git variable you're interested in monitoring
     #    to this list.
@@ -196,6 +197,13 @@ function(GetGitState _working_dir)
     RunGitCommand(rev-list --count ${object})
     if(exit_code EQUAL 0)
         set(ENV{GIT_REV_LIST_COUNT} ${output})
+    endif()
+
+    RunGitCommand(describe --tags ${object})
+    if(exit_code EQUAL 0)
+        set(ENV{GIT_TAG} ${output})
+    else()
+        set(ENV{GIT_TAG} "")
     endif()
     
     # >>>

--- a/cmake/GitWatcher.cmake
+++ b/cmake/GitWatcher.cmake
@@ -88,6 +88,7 @@ set(_state_variable_names
     GIT_COMMIT_BODY
     GIT_COMMIT_TSTAMP
     GIT_HEAD_SHORT_SHA1
+    GIT_REV_LIST_COUNT
     # >>>
     # 1. Add the name of the additional git variable you're interested in monitoring
     #    to this list.
@@ -191,13 +192,17 @@ function(GetGitState _working_dir)
     if(exit_code EQUAL 0)
         set(ENV{GIT_HEAD_SHORT_SHA1} ${output})
     endif()
+
+    RunGitCommand(rev-list --count ${object})
+    if(exit_code EQUAL 0)
+        set(ENV{GIT_REV_LIST_COUNT} ${output})
+    endif()
     
     # >>>
     # 2. Additional git properties can be added here via the
     #    "execute_process()" command. Be sure to set them in
     #    the environment using the same variable name you added
     #    to the "_state_variable_names" list.
-
 endfunction()
 
 

--- a/common/gitinfo.cpp.in
+++ b/common/gitinfo.cpp.in
@@ -18,3 +18,4 @@ const char GitCommitAuthorName[] = "@GIT_AUTHOR_NAME@";
 time_t GitCommitTimeStamp = @GIT_COMMIT_TSTAMP@;
 bool GitUncommittedChanges = @GIT_IS_DIRTY@;
 bool GitHaveInfo = @GIT_RETRIEVED_STATE@;
+int GitRevision = @GIT_REV_LIST_COUNT@;

--- a/common/gitinfo.cpp.in
+++ b/common/gitinfo.cpp.in
@@ -15,6 +15,7 @@ const char GitSHA1[] = "@GIT_HEAD_SHA1@";
 const char GitShortSHA1[] = "@GIT_HEAD_SHORT_SHA1@";
 const char GitCommitDate[] = "@GIT_COMMIT_DATE_ISO8601@";
 const char GitCommitAuthorName[] = "@GIT_AUTHOR_NAME@";
+const char GitTag[] = "@GIT_TAG@";
 time_t GitCommitTimeStamp = @GIT_COMMIT_TSTAMP@;
 bool GitUncommittedChanges = @GIT_IS_DIRTY@;
 bool GitHaveInfo = @GIT_RETRIEVED_STATE@;

--- a/common/gitinfo.h
+++ b/common/gitinfo.h
@@ -21,5 +21,6 @@ extern const char GitCommitAuthorName[];
 extern time_t GitCommitTimeStamp;
 extern bool GitUncommittedChanges;
 extern bool GitHaveInfo;
+extern int GitRevision;
 
 #endif

--- a/common/gitinfo.h
+++ b/common/gitinfo.h
@@ -18,6 +18,7 @@ extern const char GitSHA1[];
 extern const char GitShortSHA1[];
 extern const char GitCommitDate[];
 extern const char GitCommitAuthorName[];
+extern const char GitTag[];
 extern time_t GitCommitTimeStamp;
 extern bool GitUncommittedChanges;
 extern bool GitHaveInfo;

--- a/redalert/goptions.cpp
+++ b/redalert/goptions.cpp
@@ -316,13 +316,13 @@ void GameOptionsClass::Process(void)
             **	Display the version number at the bottom of the dialog box.
             */
 #ifndef REMASTER_BUILD
-            Fancy_Text_Print("%s\rV%s",
-                             (OptionX + OptionWidth) - (25 * RESFACTOR),
+            Fancy_Text_Print("%s\r%s",
+                             (OptionX + OptionWidth) - (18 * RESFACTOR),
                              OptionY + OptionHeight
-                                 - ((Session.Type == GAME_NORMAL) ? (32 * RESFACTOR) : (24 * RESFACTOR)),
+                                 - ((Session.Type == GAME_NORMAL) ? (30 * RESFACTOR) : (19 * RESFACTOR)),
                              GadgetClass::Get_Color_Scheme(),
                              TBLACK,
-                             TPF_EFNT | TPF_NOSHADOW | TPF_RIGHT,
+                             TPF_6POINT | TPF_NOSHADOW | TPF_RIGHT,
                              Scen.ScenarioName,
                              Version_Name());
 #endif

--- a/redalert/menus.cpp
+++ b/redalert/menus.cpp
@@ -751,25 +751,14 @@ int Main_Menu(unsigned long)
             //			Dialog_Box(d_dialog_x, d_dialog_y, d_dialog_w, d_dialog_h);
             //			Draw_Caption (TXT_NONE, d_dialog_x, d_dialog_y, d_dialog_w);
             commands->Draw_All();
-#ifdef FIXIT_VERSION_3
 #ifndef REMASTER_BUILD
-            Fancy_Text_Print("V%s",
-                             d_dialog_x + d_dialog_w - (18 * RESFACTOR),
-                             d_dialog_y + d_dialog_h - (5 * RESFACTOR),
+            Fancy_Text_Print("%s",
+                             d_dialog_x + d_dialog_w - (1 * RESFACTOR),
+                             d_dialog_y + d_dialog_h + (4 * RESFACTOR),
                              GadgetClass::Get_Color_Scheme(),
                              TBLACK,
-                             TPF_EFNT | TPF_NOSHADOW | TPF_RIGHT,
+                             TPF_6POINT | TPF_NOSHADOW | TPF_RIGHT,
                              Version_Name());
-#endif
-#else
-            Fancy_Text_Print("V%s",
-                             d_dialog_x + d_dialog_w - (18 * RESFACTOR),
-                             d_dialog_y + d_dialog_h - (11 * RESFACTOR),
-                             GadgetClass::Get_Color_Scheme(),
-                             TBLACK,
-                             TPF_EFNT | TPF_NOSHADOW | TPF_RIGHT,
-                             Version_Name());
-
 #endif
 
             /*

--- a/redalert/stats.cpp
+++ b/redalert/stats.cpp
@@ -564,7 +564,7 @@ void Send_Statistics_Packet(void)
         */
 #ifdef _WIN32
         char version[128];
-        sprintf(version, "V%s", VerNum.Version_Name());
+        sprintf(version, "%s", VerNum.Version_Name());
         stats.Add_Field(FIELD_GAME_VERSION, (char*)version);
 
         char path_to_exe[280];

--- a/redalert/version.cpp
+++ b/redalert/version.cpp
@@ -408,7 +408,17 @@ unsigned short VersionClass::Minor_Version(void)
  *=========================================================================*/
 char* VersionClass::Version_Name(void)
 {
-    snprintf(VersionName, sizeof(VersionName), "R:%d %s%s", GitRevision, (GitUncommittedChanges ? "~" : ""), GitShortSHA1);
+    if (*GitTag == '\0') {
+        snprintf(VersionName,
+                 sizeof(VersionName),
+                 "r%d %s%s",
+                 GitRevision,
+                 (GitUncommittedChanges ? "~" : ""),
+                 GitShortSHA1);
+    } else {
+        snprintf(VersionName, sizeof(VersionName), "%s %s%s", GitTag, (GitUncommittedChanges ? "~" : ""), GitShortSHA1);
+    }
+
     return (VersionName);
 
 } /* end of Version_Name */

--- a/redalert/version.cpp
+++ b/redalert/version.cpp
@@ -44,6 +44,8 @@
 #ifndef REMASTER_BUILD
 #include "function.h"
 
+#include "common/gitinfo.h"
+
 /****************************** Globals ************************************/
 //---------------------------------------------------------------------------
 // This is a table of version numbers # the communications protocol used for
@@ -406,30 +408,7 @@ unsigned short VersionClass::Minor_Version(void)
  *=========================================================================*/
 char* VersionClass::Version_Name(void)
 {
-    //------------------------------------------------------------------------
-    // For developmental versions, just use the major & minor version #'s
-    //------------------------------------------------------------------------
-#ifdef DEV_VERSION
-    sprintf(VersionName, "%x.%x", VerNum.Major_Version(), VerNum.Minor_Version());
-
-    //------------------------------------------------------------------------
-    // For final versions, trim 0's off the minor version
-    //------------------------------------------------------------------------
-#else
-    unsigned short adjusted_minor;
-    int i;
-
-    adjusted_minor = Minor_Version();
-    for (i = 0; i < 4; i++) {
-        if ((adjusted_minor & 0x000f) != 0) {
-            break;
-        }
-        adjusted_minor >>= 4;
-    }
-
-    sprintf(VersionName, "%x.%x", VerNum.Major_Version(), adjusted_minor);
-#endif
-
+    snprintf(VersionName, sizeof(VersionName), "R:%d %s%s", GitRevision, (GitUncommittedChanges ? "~" : ""), GitShortSHA1);
     return (VersionName);
 
 } /* end of Version_Name */
@@ -714,101 +693,22 @@ unsigned long VersionClass::Max_Version(void)
 
 char const* Version_Name(void)
 {
-#ifdef NEVER
-    static char buffer[32];
-
-    /*
-    **	Fetch the day and month components from the current
-    **	build date.
-    */
-    static char* date = __DATE__; // format: Mmm dd yyyy
-    strupr(date);
-    char const* tok = strtok(date, " ");
-    static char const* months = "JANFEBMARAPRMAYJUNJULAUGSEPOCTNOVDEC";
-    char const* ptr = strstr(months, tok);
-    int monthnum = 0;
-    if (ptr != NULL) {
-        monthnum = (((ptr - months) / 3) + 1);
-    }
-
-    tok = strtok(NULL, " ");
-    int daynum = 0;
-    if (tok != NULL) {
-        daynum = atoi(tok);
-    }
-
-    /*
-    **	Fetch the time components from the current build time.
-    */
-    static char* time = __TIME__; // format: hh:mm:ss
-    tok = strtok(time, ": ");
-    int hournum = 0;
-    if (tok != NULL) {
-        hournum = atoi(tok);
-    }
-
-    tok = strtok(NULL, ": ");
-    int minnum = 0;
-    if (tok != NULL) {
-        minnum = atoi(tok);
-    }
-
-    sprintf(buffer, "%02d%02d%02d", monthnum, daynum, (hournum * 4) + (minnum / 15));
-    return (buffer);
-#else
-
     static char buffer[128];
 
     memset(buffer, '\0', sizeof(buffer));
-
-#ifdef FIXIT_VERSION_3
-    strcpy(buffer, "3.03");
-
-#ifdef ENGLISH
-    strcat(buffer, "E");
-#else
-#ifdef GERMAN
-    strcat(buffer, "G");
-#else
-#ifdef FRENCH
-    strcat(buffer, "F");
-#endif
-#endif
-#endif
-
-#else //	FIXIT_VERSION_3
-
-#ifdef FIXIT_PATCH_108
-    // strcpy(buffer, "1.08PE");
-    strcpy(buffer, "1.08P");
-
-#ifdef FIXIT_CSII
-    strcpy(buffer, "2.00");
-#ifdef DEV_VERSION
     strcpy(buffer, VerNum.Version_Name());
-#endif
-#ifdef DEV_VER_NAME
-    strcpy(buffer, __DATE__); // format: Mmm dd yyyy
-#endif
-#endif
 
 #ifdef ENGLISH
-    strcat(buffer, "E");
+    strcat(buffer, " E");
 #else
 #ifdef GERMAN
-    strcat(buffer, "G");
+    strcat(buffer, " G");
 #else
 #ifdef FRENCH
-    strcat(buffer, "F");
+    strcat(buffer, " F");
 #endif
 #endif
 #endif
-
-#else
-    strcpy(buffer, "1.07E");
-#endif
-
-#endif //	FIXIT_VERSION_3
 
     if (Is_Demo()) {
         strcat(buffer, "D");
@@ -826,6 +726,5 @@ char const* Version_Name(void)
         file.Read(&buffer[strlen(buffer)], 25);
     }
     return (buffer);
-#endif
 }
 #endif

--- a/tiberiandawn/externs.h
+++ b/tiberiandawn/externs.h
@@ -108,7 +108,7 @@ extern bool IsV107;
 extern char OverridePath[128];
 #endif
 extern bool SlowPalette;
-extern char VersionText[16];
+extern char VersionText[64];
 extern bool ScoresPresent;
 extern int CrateCount;
 extern TCountDownTimerClass CrateTimer;

--- a/tiberiandawn/globals.cpp
+++ b/tiberiandawn/globals.cpp
@@ -92,7 +92,7 @@ SelectedObjectsType CurrentObject;
 **	This holds the custom version text that is fetched from the version
 **	text file. This version is displayed on the options dialog.
 */
-char VersionText[16];
+char VersionText[64];
 
 /***************************************************************************
 **	This is the VQ animation controller structure. It is filled in by reading

--- a/tiberiandawn/goptions.cpp
+++ b/tiberiandawn/goptions.cpp
@@ -250,31 +250,16 @@ void GameOptionsClass::Process(void)
             /*
             **	Display the version number at the bottom of the dialog box.
             */
-#ifdef DEMO
-            Version_Number();
-            Fancy_Text_Print("DEMO%s",
+            Fancy_Text_Print("%s\r%s",
                              (WindowList[WINDOW_EDITOR][WINDOWX] + WindowList[WINDOW_EDITOR][WINDOWWIDTH])
                                  - 3 * resfactor,
                              WindowList[WINDOW_EDITOR][WINDOWY] + WindowList[WINDOW_EDITOR][WINDOWHEIGHT]
-                                 - ((GameToPlay == GAME_NORMAL) ? (32 * resfactor) : (24 * resfactor)),
-                             DKGREY,
+                                 - ((GameToPlay == GAME_NORMAL) ? (30 * resfactor) : (19 * resfactor)),
+                             GREEN,
                              TBLACK,
                              TPF_6POINT | TPF_NOSHADOW | TPF_RIGHT,
                              ScenarioName,
                              VersionText);
-#else
-            Fancy_Text_Print("%s\rV.%d%s",
-                             (WindowList[WINDOW_EDITOR][WINDOWX] + WindowList[WINDOW_EDITOR][WINDOWWIDTH])
-                                 - 3 * resfactor,
-                             WindowList[WINDOW_EDITOR][WINDOWY] + WindowList[WINDOW_EDITOR][WINDOWHEIGHT]
-                                 - ((GameToPlay == GAME_NORMAL) ? (32 * resfactor) : (24 * resfactor)),
-                             DKGREY,
-                             TBLACK,
-                             TPF_6POINT | TPF_NOSHADOW | TPF_RIGHT,
-                             ScenarioName,
-                             Version_Number(),
-                             VersionText);
-#endif
 
             buttons->Draw_All();
             TabClass::Hilite_Tab(0);

--- a/tiberiandawn/init.cpp
+++ b/tiberiandawn/init.cpp
@@ -2378,8 +2378,17 @@ void Parse_INI_File(void)
  *=============================================================================================*/
 int Version_Number(void)
 {
-    snprintf(
-        VersionText, sizeof(VersionText), "R:%d %s%s", GitRevision, (GitUncommittedChanges ? "~" : ""), GitShortSHA1);
+    if (*GitTag == '\0' || GitUncommittedChanges) {
+        snprintf(VersionText,
+                 sizeof(VersionText),
+                 "r%d %s%s",
+                 GitRevision,
+                 (GitUncommittedChanges ? "~" : ""),
+                 GitShortSHA1);
+    } else {
+        snprintf(VersionText, sizeof(VersionText), "%s %s%s", GitTag, (GitUncommittedChanges ? "~" : ""), GitShortSHA1);
+    }
+
     return (1);
 }
 

--- a/tiberiandawn/init.cpp
+++ b/tiberiandawn/init.cpp
@@ -42,6 +42,7 @@
 
 #include "function.h"
 #include "loaddlg.h"
+#include "common/gitinfo.h"
 #include "common/tcpip.h"
 #include "common/vqaconfig.h"
 #include <time.h>
@@ -853,40 +854,15 @@ bool Select_Game(bool fade)
                 }
 
                 Set_Logic_Page(SeenBuff);
-#ifdef VIRGIN_CHEAT_KEYS
-                Fancy_Text_Print("V.%d%s",
-                                 SeenBuff.Get_Width() - 1,
-                                 SeenBuff.Get_Height() - 10,
-                                 DKGREY,
-                                 TBLACK,
-                                 TPF_6POINT | TPF_FULLSHADOW | TPF_RIGHT,
-                                 Version_Number(),
-                                 VersionText,
-                                 FOREIGN_VERSION_NUMBER);
-//				Fancy_Text_Print("V.%d%s%02d", 319, 190, DKGREY, TBLACK, TPF_6POINT|TPF_FULLSHADOW|TPF_RIGHT,
-//Version_Number(), VersionText, FOREIGN_VERSION_NUMBER);
-#else
 
-#ifdef DEMO
-                Version_Number();
-                Fancy_Text_Print("DEMO V%s",
+                Fancy_Text_Print("%s",
                                  SeenBuff.Get_Width() - 1,
                                  SeenBuff.Get_Height() - 10,
-                                 DKGREY,
+                                 GREEN,
                                  TBLACK,
                                  TPF_6POINT | TPF_FULLSHADOW | TPF_RIGHT,
                                  VersionText);
-#else
-                Fancy_Text_Print("V.%d%s",
-                                 SeenBuff.Get_Width() - 1,
-                                 SeenBuff.Get_Height() - 10,
-                                 DKGREY,
-                                 TBLACK,
-                                 TPF_6POINT | TPF_FULLSHADOW | TPF_RIGHT,
-                                 Version_Number(),
-                                 VersionText);
-#endif
-#endif
+
                 display = false;
                 Show_Mouse();
             } else {
@@ -2402,127 +2378,9 @@ void Parse_INI_File(void)
  *=============================================================================================*/
 int Version_Number(void)
 {
-#ifdef OBSOLETE
-    static bool initialized = false;
-    static int version;
-    static char* date = __DATE__;
-    static char* time = __TIME__;
-    static char const* months = "JANFEBMARAPRMAYJUNJULAUGSEPOCTNOVDEC";
-
-    if (!initialized) {
-        char* ptr;
-        char* tok;
-
-        /*
-        **	Fetch the month and place in the first two digit positions.
-        */
-        strupr(date);
-        tok = strtok(date, " ");
-        ptr = strstr(months, tok);
-        if (ptr) {
-            version = (((ptr - months) / 3) + 1) * 10000;
-        }
-
-        /*
-        **	Fetch the date and place that in the next two digit positions.
-        */
-        tok = strtok(NULL, " ");
-        if (tok) {
-            version += atoi(tok) * 100;
-        }
-
-        /*
-        **	Fetch the time and place that in the last two digit positions.
-        */
-        tok = strtok(time, ": ");
-        if (tok) {
-            version += atoi(tok);
-        }
-
-        /*
-        **	Fetch the virgin text file (if present).
-        */
-        RawFileClass file("VERSION.TXT");
-        if (file.Is_Available()) {
-            file.Read(VersionText, sizeof(VersionText));
-            VersionText[sizeof(VersionText) - 1] = '\0';
-            while (VersionText[sizeof(VersionText) - 1] == '\r') {
-                VersionText[sizeof(VersionText) - 1] = '\0';
-            }
-        } else {
-            VersionText[0] = '\0';
-        }
-
-        initialized = true;
-    }
-    return (version);
-#endif
-
-#ifdef WIN32
-
-#if (FRENCH)
-    sprintf(VersionText, ".02"); // Win95 french version number
-#endif                           // FRENCH
-
-#if (GERMAN)
-    sprintf(VersionText, ".01"); // Win95 german version number
-#endif                           // GERMAN
-
-#if (JAPANESE)
-    sprintf(VersionText, ".01"); // Win95 german version number
-#endif                           // GERMAN
-
-#if !(FRENCH | GERMAN | JAPANESE)
-    sprintf(VersionText, ".07"); // Win95 USA version number
-#endif                           // FRENCH | GERMAN
-
-    RawFileClass file("VERSION.TXT");
-    char version[16];
-    memset(version, 0, sizeof(version));
-    if (file.Is_Available()) {
-        file.Read(version, sizeof(version));
-    }
-    strncat(VersionText, version, sizeof(VersionText) - strlen(VersionText) - 1);
-
-#if (FRENCH)
-    return (1); // Win95 french version number
-#endif          // FRENCH
-
-#if (GERMAN)
-    return (1); // Win95 german version number
-#endif          // GERMAN
-
-#if (JAPANESE)
-    return (1); // Win95 german version number
-#endif          // GERMAN
-
-#if !(FRENCH | GERMAN | JAPANESE)
-    return (1); // Win95 USA version number
-#endif          // FRENCH | GERMAN
-
-#else
-
-#ifdef PATCH
-
-#ifdef DEMO
-    sprintf(VersionText, " 1.0a"); // Demo version.
-#else
-    strcpy(VersionText, ".34 ");
-#endif
+    snprintf(
+        VersionText, sizeof(VersionText), "R:%d %s%s", GitRevision, (GitUncommittedChanges ? "~" : ""), GitShortSHA1);
     return (1);
-
-#else
-
-#ifdef DEMO
-    sprintf(VersionText, " 1.0a"); // Demo version.
-#else
-    //	sprintf(VersionText, ".%02dp", 13);			// Patch version.
-    sprintf(VersionText, ".%02d", 14); // Master version.
-#endif
-    return (1);
-#endif
-
-#endif // WIN32
 }
 
 /***********************************************************************************************

--- a/tiberiandawn/menus.cpp
+++ b/tiberiandawn/menus.cpp
@@ -825,50 +825,16 @@ int Main_Menu(unsigned long timeout)
             Set_Logic_Page(HidPage);
             Dialog_Box(D_DIALOG_X, D_DIALOG_Y, D_DIALOG_W, D_DIALOG_H);
             Draw_Caption(TXT_NONE, D_DIALOG_X, D_DIALOG_Y, D_DIALOG_W);
-#ifdef VIRGIN_CHEAT_KEYS
-#ifdef DEMO
+
             Version_Number();
-            Fancy_Text_Print("Demo%s",
+
+            Fancy_Text_Print("%s",
                              D_DIALOG_X + D_DIALOG_W - 5 * 2,
                              D_DIALOG_Y + D_DIALOG_H - 10 * 2,
-                             DKGREY,
+                             GREEN,
                              TBLACK,
                              TPF_6POINT | TPF_FULLSHADOW | TPF_RIGHT,
                              VersionText);
-#else
-            Fancy_Text_Print("V.%d%s",
-                             D_DIALOG_X + D_DIALOG_W - 5 * 2,
-                             D_DIALOG_Y + D_DIALOG_H - 10 * 2,
-                             DKGREY,
-                             TBLACK,
-                             TPF_6POINT | TPF_FULLSHADOW | TPF_RIGHT,
-                             Version_Number(),
-                             VersionText,
-                             FOREIGN_VERSION_NUMBER);
-#endif
-//			Fancy_Text_Print("V.%d%s%02d", D_DIALOG_X+D_DIALOG_W-5, D_DIALOG_Y+D_DIALOG_H-10, DKGREY, TBLACK,
-//TPF_6POINT|TPF_FULLSHADOW|TPF_RIGHT, Version_Number(), VersionText, FOREIGN_VERSION_NUMBER);
-#else
-#ifdef DEMO
-            Version_Number();
-            Fancy_Text_Print("Demo%s",
-                             D_DIALOG_X + D_DIALOG_W - 5 * 2,
-                             D_DIALOG_Y + D_DIALOG_H - 10 * 2,
-                             DKGREY,
-                             TBLACK,
-                             TPF_6POINT | TPF_FULLSHADOW | TPF_RIGHT,
-                             VersionText);
-#else
-            Fancy_Text_Print("V.%d%s",
-                             D_DIALOG_X + D_DIALOG_W - 5 * 2,
-                             D_DIALOG_Y + D_DIALOG_H - 10 * 2,
-                             DKGREY,
-                             TBLACK,
-                             TPF_6POINT | TPF_FULLSHADOW | TPF_RIGHT,
-                             Version_Number(),
-                             VersionText);
-#endif
-#endif
 
             /*
             **	Copy the menu to the visible page.


### PR DESCRIPTION
Where versions numbers were printed on the main menu and options menu, the commit hash is now displayed.

If there were uncommitted changes to the code when it was compiled, "- DEV" is appended to mark where a build may have diverged.

Comments welcome on font change for TD, including placement, spacing and color choice. I had wanted to use the same font for both, but that is difficult due to the hires/lores system in RA and the fact the font used in RA is not present in TD.