### PR TITLE
Fix opendir() not accepting NULL as current directory

### DIFF
--- a/common/file_posix.cpp
+++ b/common/file_posix.cpp
@@ -87,11 +87,12 @@ bool Find_File_Data_Posix::FindFirst(const char* fname)
         strncat(FullName, fname, (fdir - fname));
         strcat(FullName, "/");
         FileFilter = fdir + 1;
+        Directory = opendir(FullName);
     } else {
         FileFilter = fname;
+        Directory = opendir(".");
     }
 
-    Directory = opendir(FullName);
     if (Directory == nullptr) {
         return false;
     }


### PR DESCRIPTION
This worked on my ARM laptop but not on my desktop. Use `.` instead of NULL if we're looking for local files.