### PR TITLE
Implement SDL2 hardware cursor with scaling

### DIFF
--- a/common/framelimit.cpp
+++ b/common/framelimit.cpp
@@ -19,7 +19,6 @@ void Frame_Limiter()
 {
     static auto frame_start = std::chrono::steady_clock::now();
 #ifdef SDL2_BUILD
-    WWMouse->Process_Mouse();
     Video_Render_Frame();
 #endif
 

--- a/common/settings.cpp
+++ b/common/settings.cpp
@@ -11,6 +11,7 @@ SettingsClass::SettingsClass()
     Video.Width = 0;
     Video.Height = 0;
     Video.FrameLimit = 120;
+    Video.HardwareCursor = true;
 }
 
 void SettingsClass::Load(INIClass& ini)
@@ -21,6 +22,7 @@ void SettingsClass::Load(INIClass& ini)
     Video.Width = ini.Get_Int("Video", "Width", Video.Width);
     Video.Height = ini.Get_Int("Video", "Height", Video.Height);
     Video.FrameLimit = ini.Get_Int("Video", "FrameLimit", Video.FrameLimit);
+    Video.HardwareCursor = ini.Get_Bool("Video", "HardwareCursor", Video.HardwareCursor);
 }
 
 void SettingsClass::Save(INIClass& ini)
@@ -31,4 +33,5 @@ void SettingsClass::Save(INIClass& ini)
     ini.Put_Int("Video", "Width", Video.Width);
     ini.Put_Int("Video", "Height", Video.Height);
     ini.Put_Int("Video", "FrameLimit", Video.FrameLimit);
+    ini.Put_Bool("Video", "HardwareCursor", Video.HardwareCursor);
 }

--- a/common/settings.h
+++ b/common/settings.h
@@ -19,6 +19,7 @@ public:
         int Width;
         int Height;
         int FrameLimit;
+        bool HardwareCursor;
     } Video;
 };
 

--- a/common/video.h
+++ b/common/video.h
@@ -60,6 +60,11 @@ unsigned Get_Free_Video_Memory();
 void Wait_Blit();
 
 /*
+** Set desired cursor image in game palette.
+*/
+void Set_Video_Cursor(void* cursor, int w, int h, int hotx, int hoty);
+
+/*
  *  Flags returned by Get_Video_Hardware_Capabilities
  */
 /* Hardware blits supported? */

--- a/common/wwmouse.cpp
+++ b/common/wwmouse.cpp
@@ -32,6 +32,7 @@
 
 #include "wwmouse.h"
 #include "lcw.h"
+#include "settings.h"
 #include <string.h>
 #ifdef SDL2_BUILD
 #include <SDL.h>
@@ -217,8 +218,7 @@ void WWMouseClass::Clear_Cursor_Clip(void)
 
 void WWMouseClass::Process_Mouse(void)
 {
-    // ST - 1/3/2019 10:50AM
-#if !defined(REMASTER_BUILD)
+#if !defined(REMASTER_BUILD) && !defined(SDL2_BUILD)
     int x, y;
 
     //
@@ -342,7 +342,7 @@ void* WWMouseClass::Set_Cursor(int xhotspot, int yhotspot, void* cursor)
 void WWMouseClass::Low_Hide_Mouse()
 {
 // ST - 1/3/2019 10:50AM
-#ifndef REMASTER_BUILD
+#if !defined(REMASTER_BUILD) && !defined(SDL2_BUILD)
     if (!State) {
         if (MouseBuffX != -1 || MouseBuffY != -1) {
             if (Screen->Lock()) {
@@ -376,7 +376,7 @@ void WWMouseClass::Low_Show_Mouse(int x, int y)
     State--;
 
 // ST - 1/3/2019 10:50AM
-#ifndef REMASTER_BUILD
+#if !defined(REMASTER_BUILD) && !defined(SDL2_BUILD)
 
     //
     //	If the mouse is completely visible then draw it at its current
@@ -504,7 +504,7 @@ void WWMouseClass::Conditional_Show_Mouse(void)
 
 void WWMouseClass::Draw_Mouse(GraphicViewPortClass* scr)
 {
-#if defined(REMASTER_BUILD)
+#if defined(REMASTER_BUILD) || defined(SDL2_BUILD)
     scr;
     return;
 // ST - 1/3/2019 10:50AM
@@ -565,7 +565,7 @@ void WWMouseClass::Draw_Mouse(GraphicViewPortClass* scr)
 
 void WWMouseClass::Erase_Mouse(GraphicViewPortClass* scr, int forced)
 {
-#if defined(REMASTER_BUILD)
+#if defined(REMASTER_BUILD) || defined(SDL2_BUILD)
     // ST - 1/3/2019 10:50AM
     scr;
     forced;
@@ -913,6 +913,10 @@ void* WWMouseClass::Set_Mouse_Cursor(int hotspotx, int hotspoty, Cursor* cursor)
 
     result = PrevCursor;
     PrevCursor = cursor;
+
+#ifdef SDL2_BUILD
+    Set_Video_Cursor(MouseCursor, CursorWidth, CursorHeight, MouseXHot, MouseYHot);
+#endif
 
     return result;
 }

--- a/redalert/init.cpp
+++ b/redalert/init.cpp
@@ -2640,7 +2640,7 @@ static void Init_Mouse(void)
     ** Since there is no mouse shape currently available we need
     ** to set one of our own.
     */
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(SDL2_BUILD)
     ShowCursor(false);
 #endif
     if (MouseInstalled) {

--- a/tiberiandawn/init.cpp
+++ b/tiberiandawn/init.cpp
@@ -230,7 +230,7 @@ bool Init_Game(int, char*[])
     ** Since there is no mouse shape currently available we need'
     ** to set one of our own.
     */
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(SDL2_BUILD)
     ShowCursor(FALSE);
 #endif
     if (MouseInstalled) {


### PR DESCRIPTION
This is a naive implementation for animated cursors where the
cursor is being re-created every time an animation frame is
executed.

Scaling could be decoupled from in-game scaling but it's 1:1 now
for consistency.

Should still be plenty performant and responsive.