### PR TITLE
Make SDL2 more configurable, common settings

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -68,6 +68,7 @@ set(COMMON_SRC
     readline.cpp
     rect.cpp
     rndstraw.cpp
+    settings.cpp
     sha.cpp
     shape.cpp
     shapipe.cpp

--- a/common/ini.h
+++ b/common/ini.h
@@ -36,6 +36,7 @@
 #define INI_H
 
 #include <stdlib.h>
+#include <string.h>
 #include "listnode.h"
 #include "pk.h"
 #include "fixed.h"

--- a/common/settings.cpp
+++ b/common/settings.cpp
@@ -1,0 +1,34 @@
+#include "settings.h"
+#include "ini.h"
+
+SettingsClass Settings;
+
+SettingsClass::SettingsClass()
+{
+    Video.WindowWidth = 640;
+    Video.WindowHeight = 400;
+    Video.Windowed = false;
+    Video.Width = 0;
+    Video.Height = 0;
+    Video.FrameLimit = 120;
+}
+
+void SettingsClass::Load(INIClass& ini)
+{
+    Video.WindowWidth = ini.Get_Int("Video", "WindowWidth", Video.WindowWidth);
+    Video.WindowHeight = ini.Get_Int("Video", "WindowHeight", Video.WindowHeight);
+    Video.Windowed = ini.Get_Bool("Video", "Windowed", Video.Windowed);
+    Video.Width = ini.Get_Int("Video", "Width", Video.Width);
+    Video.Height = ini.Get_Int("Video", "Height", Video.Height);
+    Video.FrameLimit = ini.Get_Int("Video", "FrameLimit", Video.FrameLimit);
+}
+
+void SettingsClass::Save(INIClass& ini)
+{
+    ini.Put_Int("Video", "WindowWidth", Video.WindowWidth);
+    ini.Put_Int("Video", "WindowHeight", Video.WindowHeight);
+    ini.Put_Bool("Video", "Windowed", Video.Windowed);
+    ini.Put_Int("Video", "Width", Video.Width);
+    ini.Put_Int("Video", "Height", Video.Height);
+    ini.Put_Int("Video", "FrameLimit", Video.FrameLimit);
+}

--- a/common/settings.h
+++ b/common/settings.h
@@ -1,0 +1,27 @@
+#ifndef SETTINGS_H
+#define SETTINGS_H
+
+class INIClass;
+
+class SettingsClass
+{
+public:
+    SettingsClass();
+
+    void Load(INIClass& ini);
+    void Save(INIClass& ini);
+
+    struct
+    {
+        int WindowWidth;
+        int WindowHeight;
+        bool Windowed;
+        int Width;
+        int Height;
+        int FrameLimit;
+    } Video;
+};
+
+extern SettingsClass Settings;
+
+#endif

--- a/redalert/externs.h
+++ b/redalert/externs.h
@@ -135,8 +135,6 @@ extern GraphicViewPortClass SeenBuff;
 extern GraphicBufferClass SysMemPage;
 extern int ScreenWidth;
 extern int ScreenHeight;
-extern int OutputWidth;
-extern int OutputHeight;
 extern GraphicBufferClass ModeXBuff;
 
 /*

--- a/redalert/globals.cpp
+++ b/redalert/globals.cpp
@@ -178,8 +178,6 @@ WWMouseClass* WWMouse = NULL;
 GraphicBufferClass SysMemPage(320, 200, (void*)NULL);
 int ScreenWidth = GBUFF_INIT_WIDTH;
 int ScreenHeight = GBUFF_INIT_HEIGHT;
-int OutputWidth = GBUFF_INIT_WIDTH;
-int OutputHeight = GBUFF_INIT_HEIGHT;
 GraphicBufferClass ModeXBuff;
 bool InMovie = false; // Are we currently playing a VQ movie?
 #ifdef _WIN32

--- a/redalert/startup.cpp
+++ b/redalert/startup.cpp
@@ -35,6 +35,7 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #include "function.h"
+#include "settings.h"
 
 #include "ipx95.h"
 
@@ -370,10 +371,6 @@ int main(int argc, char* argv[])
 #ifdef REMASTER_BUILD
             video_success = true;
 #else
-
-#ifdef SDL2_BUILD
-            video_success = static_cast<bool>(Set_Video_Mode(OutputWidth, OutputHeight, 8));
-#else
             if (ScreenHeight == 400) {
                 if (Set_Video_Mode(ScreenWidth, ScreenHeight, 8)) {
                     video_success = true;
@@ -388,8 +385,6 @@ int main(int argc, char* argv[])
                     video_success = true;
                 }
             }
-#endif // SDL2_BUILD
-
 #endif
 
             if (!video_success) {
@@ -550,10 +545,19 @@ int main(int argc, char* argv[])
                 delete MciMovie;
 #endif
 #endif
+            /*
+            ** Save settings if they were changed during gameplay.
+            */
+            Settings.Save(ini);
+            ini.Save(cfile);
 
             VisiblePage.Clear();
             HiddenPage.Clear();
             Memory_Error_Exit = Print_Error_Exit;
+
+#ifdef SDL2_BUILD
+            Reset_Video_Mode();
+#endif
 
             /*
             ** Flag that this is a clean shutdown (not killed with Ctrl-Alt-Del)
@@ -820,13 +824,16 @@ void Read_Setup_Options(RawFileClass* config_file)
         ini.Load(*config_file);
 
         /*
+        ** Read in global settings
+        */
+        Settings.Load(ini);
+
+        /*
         ** Read in the boolean options
         */
         VideoBackBufferAllowed = ini.Get_Bool("Options", "VideoBackBuffer", true);
         AllowHardwareBlitFills = ini.Get_Bool("Options", "HardwareFills", true);
         ScreenHeight = ini.Get_Bool("Options", "Resolution", false) ? GBUFF_INIT_ALTHEIGHT : GBUFF_INIT_HEIGHT;
-        OutputWidth = ini.Get_Int("Options", "OutputWidth", ScreenWidth);
-        OutputHeight = ini.Get_Int("Options", "OutputHeight", ScreenHeight);
 
         /*
         ** See if an alternative socket number has been specified

--- a/tiberiandawn/function.h
+++ b/tiberiandawn/function.h
@@ -941,8 +941,6 @@ extern bool GameInFocus;
 
 extern int ScreenWidth;
 extern int ScreenHeight;
-extern int OutputWidth;
-extern int OutputHeight;
 extern void ModeX_Blit(GraphicBufferClass* source);
 extern void Colour_Debug(int call_number);
 

--- a/tiberiandawn/globals.cpp
+++ b/tiberiandawn/globals.cpp
@@ -943,8 +943,6 @@ int Argc;       // Command line argument count
 
 int ScreenWidth = GBUFF_INIT_WIDTH;
 int ScreenHeight = GBUFF_INIT_HEIGHT;
-int OutputWidth = GBUFF_INIT_WIDTH;
-int OutputHeight = GBUFF_INIT_HEIGHT;
 WWMouseClass* WWMouse = NULL;
 int AllDone;
 bool InMovie = false; // Are we currently playing a VQ movie?


### PR DESCRIPTION
To get the SDL2 renderer properly configurable we need to have a global and shared settings storage. OptionsClass would be ideal but because they are slightly different and use different types for adjustable variables I decided to add a new SettingsClass instead to go forward.

We can migrate from OptionsClass to SettingsClass or vice versa in the future but for now I need a way to set video options (including hw/sw cursor selection, renderer selection [sw/glsl]).

This PR adds support for setting the SDL2 renderer resolution for both windowed+fullscreen and depth. We also _default_ to what would be sane on a modern system to use the native desktop resolution fullscreen. This is debatable and could be changed back to a small window or 1280x800 window by changing the default settings in the SettingsClass constructor.

I'll add support to toggling between fullscreen and windowed once this is merged one way or another. Then having the resolutions separate makes better sense when you can toggle between custom sized window (as an example) and native display fullscreen with Alt+Enter. Aspect ratio correction/enforcing would also be an interesting option to add regardless of the resolution selected.