### PR TITLE
[TD] Fixes remaster building placement.

### DIFF
--- a/tiberiandawn/dllinterface.cpp
+++ b/tiberiandawn/dllinterface.cpp
@@ -4425,7 +4425,11 @@ bool DLLExportClass::Get_Sidebar_State(uint64 player_id, unsigned char* buffer_i
     return true;
 }
 
+#ifdef MEGAMAPS
+static const int _map_width_shift_bits = 7;
+#else
 static const int _map_width_shift_bits = 6;
+#endif
 
 void DLLExportClass::Calculate_Placement_Distances(BuildingTypeClass* placement_type, unsigned char* placement_distance)
 {


### PR DESCRIPTION
Building placement was broken due to a missed shift value in the dll interface.
This has been updated to reflect the needed megamap value and should work correctly now.