### PR TITLE
Allow fullscreen toggle with SDL2

### DIFF
--- a/common/video.h
+++ b/common/video.h
@@ -54,7 +54,9 @@ public:
 extern SurfaceMonitorClass& AllSurfaces; // List of all surfaces
 
 bool Set_Video_Mode(int w, int h, int bits_per_pixel);
-bool Is_Video_Fullscreen();
+void Get_Video_Scale(float& x, float& y);
+void Set_Video_Cursor_Clip(bool clipped);
+void Toggle_Video_Fullscreen();
 void Reset_Video_Mode();
 unsigned Get_Free_Video_Memory();
 void Wait_Blit();

--- a/common/video_ddraw.cpp
+++ b/common/video_ddraw.cpp
@@ -715,11 +715,18 @@ bool Set_Video_Mode(int w, int h, int bits_per_pixel)
         }
     }
 
-    return true;
-}
+    /*
+    ** In legacy DirectDraw mode we clip the cursor for the duration of the session.
+    */
+    RECT region;
 
-bool Is_Video_Fullscreen()
-{
+    region.left = 0;
+    region.top = 0;
+    region.right = w;
+    region.bottom = h;
+
+    ClipCursor(&region);
+
     return true;
 }
 
@@ -751,6 +758,11 @@ void Reset_Video_Mode(void)
 
         DirectDrawObject = NULL;
     }
+
+    /*
+    ** Release cursor on exit.
+    */
+    ClipCursor(NULL);
 }
 
 /***********************************************************************************************
@@ -961,6 +973,14 @@ void Wait_Blit(void)
     do {
         return_code = PaletteSurface->GetBltStatus(DDGBS_ISBLTDONE);
     } while (return_code != DD_OK && return_code != DDERR_SURFACELOST);
+}
+
+void Set_Video_Cursor_Clip(bool clipped)
+{
+    /*
+    ** In DD mode we ignore the request and always clip.
+    */
+    clipped;
 }
 
 /***********************************************************************************************

--- a/common/video_null.cpp
+++ b/common/video_null.cpp
@@ -194,6 +194,10 @@ void Wait_Blit(void)
 {
 }
 
+void Set_Video_Cursor_Clip(bool clipped)
+{
+}
+
 /***********************************************************************************************
  * SMC::SurfaceMonitorClass -- constructor for surface monitor class                           *
  *                                                                                             *

--- a/common/wwkeyboard.cpp
+++ b/common/wwkeyboard.cpp
@@ -52,7 +52,7 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #include "wwkeyboard.h"
-#include "wwmouse.h"
+#include "video.h"
 #include "miscasm.h"
 #include <string.h>
 #ifdef SDL2_BUILD
@@ -543,7 +543,11 @@ void WWKeyboardClass::Fill_Buffer_From_System(void)
             Put_Key_Message(event.key.keysym.scancode, false);
             break;
         case SDL_KEYUP:
-            Put_Key_Message(event.key.keysym.scancode, true);
+            if (event.key.keysym.scancode == SDL_SCANCODE_RETURN && Down(VK_MENU)) {
+                Toggle_Video_Fullscreen();
+            } else {
+                Put_Key_Message(event.key.keysym.scancode, true);
+            }
             break;
         case SDL_MOUSEBUTTONDOWN:
         case SDL_MOUSEBUTTONUP: {
@@ -560,10 +564,10 @@ void WWKeyboardClass::Fill_Buffer_From_System(void)
                 key = VK_MBUTTON;
                 break;
             }
-            Get_Mouse_Scale_XY(scale_x, scale_y);
+            Get_Video_Scale(scale_x, scale_y);
             Put_Mouse_Message(key,
-                              event.button.x * scale_x,
-                              event.button.y * scale_y,
+                              event.button.x / scale_x,
+                              event.button.y / scale_y,
                               event.type == SDL_MOUSEBUTTONDOWN ? false : true);
         } break;
         case SDL_WINDOWEVENT:

--- a/common/wwmouse.h
+++ b/common/wwmouse.h
@@ -64,7 +64,6 @@ public:
     int Get_Mouse_X(void);
     int Get_Mouse_Y(void);
     void Get_Mouse_XY(int& x, int& y);
-    void Get_Mouse_Scale_XY(float& x, float& y);
     //
     // The following two routines can be used to render the mouse onto a graphicbuffer
     // other than the hidpage.
@@ -77,8 +76,6 @@ public:
 
     void Block_Mouse(GraphicBufferClass* buffer);
     void Unblock_Mouse(GraphicBufferClass* buffer);
-    void Set_Cursor_Clip(void);
-    void Clear_Cursor_Clip(void);
 
 private:
     enum
@@ -118,16 +115,12 @@ private:
     int EraseBuffY;    // Y position of the hidden page background
     int EraseBuffHotX; // X position of the hidden page background
     int EraseBuffHotY; // Y position of the hidden page background
-
-    int EraseFlags; // Records whether mutex has been released
+    int EraseFlags;    // Records whether mutex has been released
 
 #ifdef _WIN32
     CRITICAL_SECTION MouseCriticalSection; // Control for mouse re-enterancy
     unsigned TimerHandle;
 #endif
-
-    float MouseXScale;
-    float MouseYScale;
 };
 
 void Hide_Mouse(void);
@@ -138,6 +131,5 @@ int Get_Mouse_State(void);
 void* Set_Mouse_Cursor(int hotx, int hoty, void* cursor);
 int Get_Mouse_X(void);
 int Get_Mouse_Y(void);
-void Get_Mouse_Scale_XY(float& x, float& y);
 
 #endif

--- a/redalert/conquer.cpp
+++ b/redalert/conquer.cpp
@@ -224,6 +224,8 @@ void Main_Game(int argc, char* argv[])
             Show_Mouse();
         }
 
+        Set_Video_Cursor_Clip(true);
+
 #ifdef SCENARIO_EDITOR
         /*
         **	Scenario-editor version of main-loop processing
@@ -244,12 +246,7 @@ void Main_Game(int argc, char* argv[])
                 }
 
                 if (SpecialDialog != SDLG_NONE) {
-                    /*
-                    **  Always release mouse cursor when a dialog is open.
-                    */
-                    if (!Is_Video_Fullscreen()) {
-                        WWMouse->Clear_Cursor_Clip();
-                    }
+                    Set_Video_Cursor_Clip(false);
 
                     switch (SpecialDialog) {
                     case SDLG_SPECIAL:
@@ -282,9 +279,7 @@ void Main_Game(int argc, char* argv[])
                         break;
                     }
 
-                    if (!Is_Video_Fullscreen()) {
-                        WWMouse->Set_Cursor_Clip();
-                    }
+                    Set_Video_Cursor_Clip(true);
                 }
             } else {
 
@@ -320,12 +315,7 @@ void Main_Game(int argc, char* argv[])
             **	Main_Loop(), allowing the game to run in the background.
             */
             if (SpecialDialog != SDLG_NONE) {
-                /*
-                **  Always release mouse cursor when a dialog is open.
-                */
-                if (!Is_Video_Fullscreen()) {
-                    WWMouse->Clear_Cursor_Clip();
-                }
+                Set_Video_Cursor_Clip(false);
 
                 switch (SpecialDialog) {
                 case SDLG_SPECIAL:
@@ -380,12 +370,12 @@ void Main_Game(int argc, char* argv[])
                     break;
                 }
 
-                if (!Is_Video_Fullscreen()) {
-                    WWMouse->Set_Cursor_Clip();
-                }
+                Set_Video_Cursor_Clip(true);
             }
         }
 #endif
+
+        Set_Video_Cursor_Clip(false);
 
         /*
         **	Scenario is done; fade palette to black

--- a/redalert/init.cpp
+++ b/redalert/init.cpp
@@ -563,13 +563,6 @@ bool Select_Game(bool fade)
     Map.Set_Default_Mouse(MOUSE_NORMAL, false);
 
     /*
-    **  Allow moving mouse outside the game window when in menu.
-    */
-    if (!Is_Video_Fullscreen()) {
-        WWMouse->Clear_Cursor_Clip();
-    }
-
-    /*
     **	If the last game we played was a multiplayer game, jump right to that
     **	menu by pre-setting 'selection'.
     */
@@ -1218,10 +1211,6 @@ bool Select_Game(bool fade)
     HiddenPage.Clear();
     VisiblePage.Clear();
     Show_Mouse();
-
-    if (!Is_Video_Fullscreen()) {
-        WWMouse->Set_Cursor_Clip();
-    }
 
     Set_Logic_Page(SeenBuff);
     /*

--- a/redalert/winstub.cpp
+++ b/redalert/winstub.cpp
@@ -81,10 +81,6 @@ void Focus_Loss(void)
 {
     Theme.Suspend();
     Stop_Primary_Sound_Buffer();
-
-    if (WWMouse && Is_Video_Fullscreen()) {
-        WWMouse->Clear_Cursor_Clip();
-    }
 }
 
 void Focus_Restore(void)
@@ -92,13 +88,10 @@ void Focus_Restore(void)
     Map.Flag_To_Redraw(true);
     Start_Primary_Sound_Buffer(true);
 
-    if (Is_Video_Fullscreen()) {
-        if (WWMouse) {
-            WWMouse->Set_Cursor_Clip();
-        }
-        VisiblePage.Clear();
-        HiddenPage.Clear();
-    }
+#ifndef SDL2_BUILD
+    VisiblePage.Clear();
+    HiddenPage.Clear();
+#endif
 }
 
 /***********************************************************************************************

--- a/tiberiandawn/conquer.cpp
+++ b/tiberiandawn/conquer.cpp
@@ -181,6 +181,7 @@ void Main_Game(int argc, char* argv[])
         }
 
         InMainLoop = true;
+        Set_Video_Cursor_Clip(true);
 
 #ifdef SCENARIO_EDITOR
         /*
@@ -198,7 +199,8 @@ void Main_Game(int argc, char* argv[])
                 }
 
                 if (SpecialDialog != SDLG_NONE) {
-                    // Stop_Profiler();
+                    Set_Video_Cursor_Clip(false);
+
                     switch (SpecialDialog) {
                     case SDLG_SPECIAL:
                         Map.Help_Text(TXT_NONE);
@@ -229,6 +231,8 @@ void Main_Game(int argc, char* argv[])
                     default:
                         break;
                     }
+
+                    Set_Video_Cursor_Clip(true);
                 }
             } else {
 
@@ -260,12 +264,7 @@ void Main_Game(int argc, char* argv[])
             **	Main_Loop(), allowing the game to run in the background.
             */
             if (SpecialDialog != SDLG_NONE) {
-                /*
-                **  Always release mouse cursor when a dialog is open.
-                */
-                if (!Is_Video_Fullscreen()) {
-                    WWMouse->Clear_Cursor_Clip();
-                }
+                Set_Video_Cursor_Clip(false);
 
                 switch (SpecialDialog) {
                 case SDLG_SPECIAL:
@@ -298,13 +297,11 @@ void Main_Game(int argc, char* argv[])
                     break;
                 }
 
-                if (!Is_Video_Fullscreen()) {
-                    WWMouse->Set_Cursor_Clip();
-                }
+                Set_Video_Cursor_Clip(true);
             }
         }
 #endif
-        // Stop_Profiler();
+        Set_Video_Cursor_Clip(false);
         InMainLoop = false;
 
         if (!GameStatisticsPacketSent && PacketLater) {

--- a/tiberiandawn/init.cpp
+++ b/tiberiandawn/init.cpp
@@ -782,13 +782,6 @@ bool Select_Game(bool fade)
     Map.Set_Default_Mouse(MOUSE_NORMAL, false);
 
     /*
-    **  Allow moving mouse outside the game window when in menu.
-    */
-    if (!Is_Video_Fullscreen()) {
-        WWMouse->Clear_Cursor_Clip();
-    }
-
-    /*
     **	If the last game we played was a multiplayer game, jump right to that
     **	menu by pre-setting 'selection'.
     */
@@ -1486,9 +1479,6 @@ bool Select_Game(bool fade)
     Hide_Mouse();
     Hide_Mouse();
     WWMouse->Erase_Mouse(&HidPage, true);
-    if (!Is_Video_Fullscreen()) {
-        WWMouse->Set_Cursor_Clip();
-    }
 
     Fade_Palette_To(BlackPalette, FADE_PALETTE_MEDIUM, Call_Back);
     HiddenPage.Clear();

--- a/tiberiandawn/winstub.cpp
+++ b/tiberiandawn/winstub.cpp
@@ -77,10 +77,6 @@ void Focus_Loss(void)
     }
     Theme.Stop();
     Stop_Primary_Sound_Buffer();
-
-    if (WWMouse && Is_Video_Fullscreen()) {
-        WWMouse->Clear_Cursor_Clip();
-    }
 }
 
 void Focus_Restore(void)
@@ -88,13 +84,10 @@ void Focus_Restore(void)
     Map.Flag_To_Redraw(true);
     Start_Primary_Sound_Buffer(true);
 
-    if (Is_Video_Fullscreen()) {
-        if (WWMouse) {
-            WWMouse->Set_Cursor_Clip();
-        }
-        VisiblePage.Clear();
-        HiddenPage.Clear();
-    }
+#ifndef SDL2_BUILD
+    VisiblePage.Clear();
+    HiddenPage.Clear();
+#endif
 }
 
 /***********************************************************************************************


### PR DESCRIPTION
Alt-Enter now toggles between configured windowed size and
fullscreen. The default configuration uses native fullscreen and
original window size.

Cursor locking has been moved to the video driver as it makes
more sense as the video driver also natively knows the scaling
factor which needs to be updated when changing between fullscreen
and windowed.

Games now request locking the cursor only when no in-game dialog
is open and always release it in any other state. No locking is
requested until the main game loop is running.

When toggling between windowed and fullscreen the game requested
state is re-evaluated and applied if necessary. This means that
the cursor will always be locked when going fullscreen and
released in windowed mode if you're in any of the menus.

The SDL2 video driver honors the game locking requests in windowed
mode but ignores in fullscreen and always relocks the cursor
regardless what the request was.

The DirectDraw video driver ignores all locking requests and does
a one time ClipCursor call on video mode set and release it when
the mode is reset. This is likely broken in some way but since we
are phasing out DirectDraw and CnC-DDraw is likely used for testing
I'm not very interested in making this more robust.