### PR TITLE
Fix harves action in the radar map showing wrong cursor (ORIGINAL BUG)

### DIFF
--- a/redalert/radar.cpp
+++ b/redalert/radar.cpp
@@ -1755,6 +1755,7 @@ int RadarClass::RTacticalClass::Action(unsigned flags, KeyNumType& key)
                 case ACTION_ENTER:
                 case ACTION_CAPTURE:
                 case ACTION_SABOTAGE:
+                case ACTION_HARVEST:
                     break;
 
                 default:


### PR DESCRIPTION
 Fix harvest action in the radar map showign the 'cant move' cursor instead of the 'attack' cursor

