### PR TITLE
[RA1] Add missing resign hotkey code (copied from C&C95)

### DIFF
--- a/redalert/conquer.cpp
+++ b/redalert/conquer.cpp
@@ -680,18 +680,12 @@ void Keyboard_Process(KeyNumType& input)
         input = KN_NONE;
     }
 
-#ifdef TOFIX
-    /*
-    ** For multiplayer, 'R' pops up the surrender dialog.
-    */
     if (input != 0 && input == Options.KeyResign) {
-        if (!PlayerLoses && /*Session.Type != GAME_NORMAL &&*/ !PlayerPtr->IsDefeated) {
+        if (!PlayerPtr->IsDefeated) {
             SpecialDialog = SDLG_SURRENDER;
-            input = KN_NONE;
         }
         input = KN_NONE;
     }
-#endif
 
     /*
     **	Handle making and breaking alliances.


### PR DESCRIPTION
The original code is guarded under ifdef #TOFIX, but C&C95 uses similar code without issue and the CnCNet patches too. 