### PR TITLE
Fix Aircraft pip logic so it returns the max Ammo for armed non-Spy plane aircraft. This fixes Migs showing 5 pips when it has 3 max ammo.

### DIFF
--- a/redalert/aadata.cpp
+++ b/redalert/aadata.cpp
@@ -561,7 +561,10 @@ int AircraftTypeClass::Max_Pips(void) const
     if (PrimaryWeapon != NULL) {
         // Camera weapon (ex. on the Spy plane) doesn't display any pips
         if (!PrimaryWeapon->IsCamera) {
-            return (5);
+            if (MaxAmmo > 5) {
+                return 5;
+            }
+            return MaxAmmo;
         }
     }
     return (Max_Passengers());


### PR DESCRIPTION
…