### PR TITLE
Fix SDL2 hardware cursor scaling and alpha, mix reinit, demo button skip

### DIFF
--- a/common/video_sdl2.cpp
+++ b/common/video_sdl2.cpp
@@ -68,6 +68,8 @@ static struct
     SDL_Surface* Surface;
 } hwcursor;
 
+static void Update_HWCursor();
+
 static void Update_HWCursor_Settings()
 {
     /*
@@ -82,6 +84,11 @@ static void Update_HWCursor_Settings()
     ** Ensure cursor clip is in the desired state.
     */
     Set_Video_Cursor_Clip(hwcursor.Clip);
+
+    /*
+    ** Update visible cursor scaling.
+    */
+    Update_HWCursor();
 }
 
 class SurfaceMonitorClassDummy : public SurfaceMonitorClass

--- a/common/video_sdl2.cpp
+++ b/common/video_sdl2.cpp
@@ -410,7 +410,7 @@ void Set_DD_Palette(void* rpalette)
         colors[i].r = (unsigned char)rcolors[i * 3] << 2;
         colors[i].g = (unsigned char)rcolors[i * 3 + 1] << 2;
         colors[i].b = (unsigned char)rcolors[i * 3 + 2] << 2;
-        colors[i].a = 0;
+        colors[i].a = 0xFF;
     }
 
     SDL_SetPaletteColors(palette, colors, 0, 256);

--- a/redalert/conquer.cpp
+++ b/redalert/conquer.cpp
@@ -3831,8 +3831,12 @@ typedef enum
 
 static void Reinit_Secondary_Mixfiles()
 {
+    static bool in_progress = false;
+
     // Only reinitialised if the main mix file has been initialised once already.
-    if (MainMix != nullptr) {
+    if (MainMix != nullptr && !in_progress) {
+        in_progress = true;
+
         delete MoviesMix;
         delete Movies2Mix;
         delete GeneralMix;
@@ -3854,6 +3858,8 @@ static void Reinit_Secondary_Mixfiles()
         }
         GeneralMix = new MFCD("GENERAL.MIX", &FastKey);
         ScoreMix = new MFCD("SCORES.MIX", &FastKey);
+
+        in_progress = false;
     }
 }
 

--- a/redalert/menus.cpp
+++ b/redalert/menus.cpp
@@ -669,7 +669,7 @@ int Main_Menu(unsigned long)
     buttons[2] = &startbtn;
     buttons[3] = &loadbtn;
     buttons[4] = &multibtn;
-    buttons[5] = &introbtn;
+    buttons[5] = Is_Demo() ? nullptr : &introbtn;
     buttons[6] = &exitbtn;
 #else
     if (expansions) {
@@ -861,7 +861,9 @@ int Main_Menu(unsigned long)
         case KN_UP:
             buttons[curbutton]->Turn_Off();
             buttons[curbutton]->Flag_To_Redraw();
-            curbutton--;
+            do {
+                curbutton--;
+            } while (buttons[curbutton] == nullptr && curbutton > 0);
 #ifdef FIXIT_VERSION_3
             switch (curbutton) {
             case -1:
@@ -898,7 +900,9 @@ int Main_Menu(unsigned long)
         case KN_DOWN:
             buttons[curbutton]->Turn_Off();
             buttons[curbutton]->Flag_To_Redraw();
-            curbutton++;
+            do {
+                curbutton++;
+            } while (buttons[curbutton] == nullptr && curbutton < max_buttons);
 #ifdef FIXIT_VERSION_3
             if (curbutton == max_buttons) {
                 if (bExpansionCS)

--- a/tiberiandawn/conquer.cpp
+++ b/tiberiandawn/conquer.cpp
@@ -3344,7 +3344,11 @@ typedef enum
 
 static void Reinit_Secondary_Mixfiles()
 {
-    if (GeneralMix != nullptr) {
+    static bool in_progress = false;
+
+    if (GeneralMix != nullptr && !in_progress) {
+        in_progress = true;
+
         delete MoviesMix;
         delete GeneralMix;
         delete ScoreMix;
@@ -3352,6 +3356,8 @@ static void Reinit_Secondary_Mixfiles()
         MoviesMix = new MFCD("MOVIES.MIX");
         GeneralMix = new MFCD("GENERAL.MIX");
         ScoreMix = new MFCD("SCORES.MIX");
+
+        in_progress = false;
     }
 }
 


### PR DESCRIPTION
Scaling was not updated on alt-enter toggle and alpha was incorrectly set on the palette. I have no idea how the cursor was visible before on any platform when the alpha channel was screwed up.