### PR TITLE
Implement OS specific paths for read only and writeable data.

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -63,6 +63,7 @@ set(COMMON_SRC
     packet.cpp
     palette.cpp
     palettec.cpp
+    paths.cpp
     pipe.cpp
     pk.cpp
     pkpipe.cpp
@@ -98,9 +99,9 @@ set(COMMON_SRC
 )
 
 if (WIN32)
-    list(APPEND COMMON_SRC file_win.cpp)
+    list(APPEND COMMON_SRC file_win.cpp paths_win.cpp)
 else()
-    list(APPEND COMMON_SRC file_posix.cpp)
+    list(APPEND COMMON_SRC file_posix.cpp paths_posix.cpp)
 endif()
 
 set(COMMONR_SRC
@@ -158,7 +159,7 @@ file(GLOB_RECURSE COMMON_HEADERS "*.h")
 add_library(common STATIC ${COMMON_SRC} ${COMMON_HEADERS})
 target_link_libraries(common PUBLIC ${COMMON_LIBS})
 target_include_directories(common PUBLIC .)
-target_compile_definitions(common PRIVATE FIXIT_FAST_LOAD)
+target_compile_definitions(common PRIVATE FIXIT_FAST_LOAD $<$<CONFIG:Debug>:_DEBUG>)
 # Make build check state of git to check for uncommitted changes.
 add_dependencies(common check_git)
 

--- a/common/cdfile.h
+++ b/common/cdfile.h
@@ -69,7 +69,7 @@ public:
         return (First != NULL);
     };
     static int Set_Search_Drives(char* pathlist);
-    static void Add_Search_Drive(char* path);
+    static void Add_Search_Drive(const char* path);
     static void Clear_Search_Drives(void);
     static void Refresh_Search_Drives(void);
     static void Set_CD_Drive(int drive);

--- a/common/paths.cpp
+++ b/common/paths.cpp
@@ -1,0 +1,110 @@
+// TiberianDawn.DLL and RedAlert.dll and corresponding source code is free
+// software: you can redistribute it and/or modify it under the terms of
+// the GNU General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+
+// TiberianDawn.DLL and RedAlert.dll and corresponding source code is distributed
+// in the hope that it will be useful, but with permitted additional restrictions
+// under Section 7 of the GPL. See the GNU General Public License in LICENSE.TXT
+// distributed with this program. You should have received a copy of the
+// GNU General Public License along with permitted additional restrictions
+// with this program. If not, see https://github.com/electronicarts/CnC_Remastered_Collection
+#include "paths.h"
+#include "debugstring.h"
+#include "ini.h"
+#include "rawfile.h"
+#include <stdlib.h>
+#include <string>
+
+#ifdef _WIN32
+#include <direct.h>
+#else
+#include <unistd.h>
+#endif
+
+PathsClass Paths;
+
+void PathsClass::Init(const char* suffix, const char* ini_name, const char* data_name, const char* cmd_arg)
+{
+    if (suffix != nullptr) {
+        Suffix = suffix;
+    }
+
+    // Check the argv[0] arg assuming it was passed. This may be a symlink so should be checked.
+    std::string argv_path;
+
+    if (cmd_arg != nullptr) {
+        argv_path = Argv_Path(cmd_arg);
+    }
+
+    // Calls with unused returns to set the default variable values if not already set.
+    Program_Path();
+    Data_Path();
+    User_Path();
+
+    DBG_INFO("Searching the following paths for path config data:\n  argv: '%s'\n  binary: '%s'\n  default data: "
+             "'%s'\n  default user: '%s'",
+             argv_path.c_str(),
+             ProgramPath.c_str(),
+             DataPath.c_str(),
+             UserPath.c_str());
+
+    // Check for a config file to load paths from.
+    RawFileClass file;
+    bool use_argv_path = false;
+    bool use_prog_path = false;
+
+    if (ini_name != nullptr) {
+        if (!argv_path.empty() && RawFileClass((argv_path + SEP + ini_name).c_str()).Is_Available()) {
+            file.Set_Name((argv_path + SEP + ini_name).c_str());
+            use_argv_path = true;
+        } else if (RawFileClass((ProgramPath + SEP + ini_name).c_str()).Is_Available()) {
+            file.Set_Name((ProgramPath + SEP + ini_name).c_str());
+            use_prog_path = true;
+        } else if (RawFileClass((UserPath + SEP + ini_name).c_str()).Is_Available()) {
+            file.Set_Name((UserPath + SEP + ini_name).c_str());
+        } else if (RawFileClass((DataPath + SEP + ini_name).c_str()).Is_Available()) {
+            file.Set_Name((DataPath + SEP + ini_name).c_str());
+        }
+    }
+
+    // Next we check if the data path is either the argv or program path.
+    bool have_argv_data = false;
+    bool have_prog_data = false;
+
+    if (data_name != nullptr) {
+        if (!argv_path.empty() && RawFileClass((argv_path + SEP + data_name).c_str()).Is_Available()) {
+            have_argv_data = true;
+        } else if (RawFileClass((ProgramPath + SEP + data_name).c_str()).Is_Available()) {
+            have_prog_data = true;
+        }
+    }
+
+    INIClass ini;
+    ini.Load(file);
+
+    const char section[] = "Paths";
+    char buffer[128]; // TODO max ini line size.
+
+    // Even if the config was found with the binary, we still check to see if it gives use alternative paths.
+    // If not, assume we are in portable mode and point the DataPath to ProgramPath.
+    if (ini.Get_String(section, "DataPath", "", buffer, sizeof(buffer)) < sizeof(buffer) && buffer[0] != '\0') {
+        DataPath = buffer;
+    } else if (have_argv_data) {
+        DataPath = argv_path;
+    } else if (have_prog_data) {
+        DataPath = ProgramPath;
+    }
+
+    // Same goes for the UserPath.
+    if (ini.Get_String(section, "UserPath", "", buffer, sizeof(buffer)) < sizeof(buffer) && buffer[0] != '\0') {
+        UserPath = buffer;
+    } else if (use_argv_path) {
+        UserPath = argv_path;
+    } else if (use_prog_path) {
+        UserPath = ProgramPath;
+    }
+
+    DBG_INFO("Read only data directory is set to '%s'", DataPath.c_str());
+    DBG_INFO("Read/Write user data directory is set to '%s'", UserPath.c_str());
+}

--- a/common/paths.h
+++ b/common/paths.h
@@ -1,0 +1,60 @@
+// TiberianDawn.DLL and RedAlert.dll and corresponding source code is free
+// software: you can redistribute it and/or modify it under the terms of
+// the GNU General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+
+// TiberianDawn.DLL and RedAlert.dll and corresponding source code is distributed
+// in the hope that it will be useful, but with permitted additional restrictions
+// under Section 7 of the GPL. See the GNU General Public License in LICENSE.TXT
+// distributed with this program. You should have received a copy of the
+// GNU General Public License along with permitted additional restrictions
+// with this program. If not, see https://github.com/electronicarts/CnC_Remastered_Collection
+
+#ifndef COMMON_PATHS_H
+#define COMMON_PATHS_H
+
+#include <string>
+
+class PathsClass
+{
+public:
+    PathsClass()
+    {
+    }
+
+    PathsClass(PathsClass const&) = delete;
+    void operator=(PathsClass const&) = delete;
+
+    /**
+    * @brief Initialise the paths from an ini file to override normal OS defaults.
+    */
+    void Init(const char* suffix = nullptr,
+              const char* ini_name = nullptr,
+              const char* data_name = nullptr,
+              const char* cmd_arg = nullptr);
+
+    const char* Program_Path();
+    const char* Data_Path();
+    const char* User_Path();
+
+    static bool Create_Directory(const char* path);
+    static bool Is_Absolute(const char* path);
+
+#ifdef _WIN32
+    constexpr static char SEP = '\\';
+#else
+    constexpr static char SEP = '/';
+#endif
+private:
+    static std::string Argv_Path(const char* cmd_arg);
+
+private:
+    std::string Suffix;
+    std::string ProgramPath;
+    std::string DataPath;
+    std::string UserPath;
+};
+
+extern PathsClass Paths;
+
+#endif /* COMMON_PATHS_H */

--- a/common/paths_posix.cpp
+++ b/common/paths_posix.cpp
@@ -1,0 +1,262 @@
+// TiberianDawn.DLL and RedAlert.dll and corresponding source code is free
+// software: you can redistribute it and/or modify it under the terms of
+// the GNU General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+
+// TiberianDawn.DLL and RedAlert.dll and corresponding source code is distributed
+// in the hope that it will be useful, but with permitted additional restrictions
+// under Section 7 of the GPL. See the GNU General Public License in LICENSE.TXT
+// distributed with this program. You should have received a copy of the
+// GNU General Public License along with permitted additional restrictions
+// with this program. If not, see https://github.com/electronicarts/CnC_Remastered_Collection
+#include "paths.h"
+#include "debugstring.h"
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <dlfcn.h>
+#include <pwd.h>
+#include <stdexcept>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <vector>
+
+#if defined(__linux__)
+#include <linux/limits.h>
+#else
+#include <limits.h>
+#endif
+
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS
+#endif
+#include <inttypes.h>
+
+#if defined(__APPLE__)
+#define _DARWIN_BETTER_REALPATH
+#include <mach-o/dyld.h>
+#include <TargetConditionals.h>
+#elif defined(__DragonFly__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__)
+#include <sys/sysctl.h>
+#endif
+
+namespace
+{
+    const std::string& User_Home()
+    {
+        static std::string _path;
+
+        if (_path.empty()) {
+            int uid = getuid();
+            const char* home_env = std::getenv("HOME");
+
+            if (home_env) {
+                _path = home_env;
+            } else if (uid == 0) {
+                _path = "/root";
+            } else {
+                struct passwd* pw = nullptr;
+                struct passwd pwd;
+                long bufsize = sysconf(_SC_GETPW_R_SIZE_MAX);
+
+                if (bufsize < 0) {
+                    bufsize = 16384;
+                }
+
+                std::vector<char> buffer;
+                buffer.resize(bufsize);
+                int error_code = getpwuid_r(uid, &pwd, buffer.data(), buffer.size(), &pw);
+
+                if (error_code) {
+                    DBG_ERROR("Unable to get passwd entry for uid %d, error was %d.", uid, error_code);
+                    return _path;
+                }
+
+                const char* tmp = pw->pw_dir;
+
+                if (!tmp) {
+                    DBG_ERROR("User does not appear to have a home directory?");
+                    return _path;
+                }
+
+                _path = tmp;
+            }
+        }
+
+        return _path;
+    }
+
+    std::string Get_Posix_Default(const char* env_var, const char* relative_path)
+    {
+        const char* tmp = std::getenv(env_var);
+
+        if (tmp != nullptr && tmp[0] != '\0') {
+            if (tmp[0] != '/') {
+                char buffer[200];
+                std::snprintf(buffer,
+                              sizeof(buffer),
+                              "'%s' should start with '/' as per XDG specification that the value must be absolute. "
+                              "The current value is: "
+                              "'%s'.",
+                              tmp,
+                              env_var);
+                DBG_WARN(buffer);
+            } else {
+                return tmp;
+            }
+        }
+
+        return User_Home() + "/" + relative_path;
+    }
+} // namespace
+
+#if defined(__sun)
+#define PROC_SELF_EXE "/proc/self/path/a.out"
+#else
+#define PROC_SELF_EXE "/proc/self/exe"
+#endif
+
+const char* PathsClass::Program_Path()
+{
+    if (ProgramPath.empty()) {
+        /*
+        ** Adapted from https://github.com/gpakosz/whereami
+        ** dual licensed under the WTFPL v2 and MIT licenses without any warranty. by Gregory Pakosz (@gpakosz)
+        */
+        std::string tmp;
+        char buffer[PATH_MAX];
+        char* resolved = nullptr;
+#if defined(__linux__) || defined(__CYGWIN__) || defined(__sun)
+        resolved = realpath(PROC_SELF_EXE, buffer);
+#elif defined(__APPLE__)
+        char buffer1[PATH_MAX];
+        char* path = buffer1;
+
+        uint32_t size = (uint32_t)sizeof(buffer1);
+        if (_NSGetExecutablePath(path, &size) == -1) {
+            path = (char*)malloc(size);
+            if (!_NSGetExecutablePath(path, &size)) {
+                free(path);
+                return ProgramPath.c_str();
+            }
+        }
+
+        resolved = realpath(path, buffer);
+
+        if (path != buffer1) {
+            free(path);
+        }
+#elif defined(__DragonFly__) || defined(__FreeBSD__) || defined(__FreeBSD_kernel__) || defined(__NetBSD__)
+        char buffer1[PATH_MAX];
+        char* path = buffer1;
+
+#if defined(__NetBSD__)
+        int mib[4] = {CTL_KERN, KERN_PROC_ARGS, -1, KERN_PROC_PATHNAME};
+#else
+        int mib[4] = {CTL_KERN, KERN_PROC, KERN_PROC_PATHNAME, -1};
+#endif
+        size_t size = sizeof(buffer1);
+
+        if (sysctl(mib, (u_int)(sizeof(mib) / sizeof(mib[0])), path, &size, NULL, 0) != 0) {
+            return ProgramPath.c_str();
+        }
+
+        resolved = realpath(path, buffer);
+#endif
+        if (!resolved) {
+            return ProgramPath.c_str();
+        }
+
+        tmp = resolved;
+        ProgramPath = tmp.substr(0, tmp.find_last_of("/"));
+    }
+
+    return ProgramPath.c_str();
+}
+
+const char* PathsClass::Data_Path()
+{
+    if (DataPath.empty()) {
+        if (ProgramPath.empty()) {
+            // Init the program path first if it hasn't been done already.
+            Program_Path();
+        }
+
+        DataPath = ProgramPath.substr(0, ProgramPath.find_last_of("/")) + SEP + "share";
+
+        if (!Suffix.empty()) {
+            DataPath += SEP + Suffix;
+        }
+    }
+
+    return DataPath.c_str();
+}
+
+const char* PathsClass::User_Path()
+{
+    if (UserPath.empty()) {
+#ifdef TARGET_OS_MAC
+        UserPath = User_Home() + "/Library/Application Support/Vanilla-Conquer";
+#else
+        UserPath = Get_Posix_Default("XDG_CONFIG_HOME", ".config") + "/vanilla-conquer";
+#endif
+
+        if (!Suffix.empty()) {
+            UserPath += SEP + Suffix;
+        }
+
+        Create_Directory(UserPath.c_str());
+    }
+
+    return UserPath.c_str();
+}
+
+bool PathsClass::Create_Directory(const char* dirname)
+{
+    bool ret = true;
+
+    if (dirname == nullptr) {
+        return ret;
+    }
+
+    std::string temp = dirname;
+    size_t pos = 0;
+    do {
+        pos = temp.find_first_of("/", pos + 1);
+        if (mkdir(temp.substr(0, pos).c_str(), 0700) != 0) {
+            if (errno != EEXIST) {
+                ret = false;
+                break;
+            }
+        }
+    } while (pos != std::string::npos);
+
+    return ret;
+}
+
+bool PathsClass::Is_Absolute(const char* path)
+{
+    return path != nullptr && path[0] == '/';
+}
+
+std::string PathsClass::Argv_Path(const char* cmd_arg)
+{
+    std::string ret(PATH_MAX, '\0');
+    char arg_dir[PATH_MAX];
+    strncpy(arg_dir, cmd_arg, sizeof(arg_dir));
+
+    // remove the executable from path, if any
+    char* dir = strrchr(arg_dir, '/');
+    if (dir != nullptr) {
+        *dir = '\0';
+    }
+
+    if (realpath(arg_dir, &ret[0]) == nullptr) {
+        DBG_WARN("PathsClass::Argv_Path: realpath() failed");
+        ret = arg_dir;
+    } else {
+        ret.resize(strlen(&ret[0]));
+    }
+    return ret;
+}

--- a/common/paths_win.cpp
+++ b/common/paths_win.cpp
@@ -1,0 +1,190 @@
+// TiberianDawn.DLL and RedAlert.dll and corresponding source code is free
+// software: you can redistribute it and/or modify it under the terms of
+// the GNU General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+
+// TiberianDawn.DLL and RedAlert.dll and corresponding source code is distributed
+// in the hope that it will be useful, but with permitted additional restrictions
+// under Section 7 of the GPL. See the GNU General Public License in LICENSE.TXT
+// distributed with this program. You should have received a copy of the
+// GNU General Public License along with permitted additional restrictions
+// with this program. If not, see https://github.com/electronicarts/CnC_Remastered_Collection
+#define _WIN32_WINNT 0x0600
+#include "paths.h"
+#include "debugstring.h"
+#include "utf.h"
+#include <winerror.h>
+#include <shlobj.h>
+
+namespace
+{
+    class FreeCoTaskMemory
+    {
+        LPWSTR pointer = nullptr;
+
+    public:
+        explicit FreeCoTaskMemory(LPWSTR pointer)
+            : pointer(pointer){};
+        ~FreeCoTaskMemory()
+        {
+            CoTaskMemFree(pointer);
+        }
+    };
+} // namespace
+
+const char* PathsClass::Program_Path()
+{
+    if (ProgramPath.empty()) {
+        /*
+        ** Adapted from https://github.com/gpakosz/whereami
+        ** dual licensed under the WTFPL v2 and MIT licenses without any warranty. by Gregory Pakosz (@gpakosz)
+        */
+        wchar_t buffer1[MAX_PATH];
+        wchar_t buffer2[MAX_PATH];
+        wchar_t* path = NULL;
+        int length = -1;
+
+        while (true) {
+            DWORD size;
+
+            size = GetModuleFileNameW(nullptr, buffer1, sizeof(buffer1) / sizeof(buffer1[0]));
+
+            if (size == 0) {
+                break;
+            } else if (size == (DWORD)(sizeof(buffer1) / sizeof(buffer1[0]))) {
+                DWORD size_ = size;
+                do {
+                    wchar_t* path_ = (wchar_t*)realloc(path, sizeof(wchar_t) * size_ * 2);
+
+                    if (path_ == nullptr) {
+                        break;
+                    }
+
+                    size_ *= 2;
+                    path = path_;
+                    size = GetModuleFileNameW(nullptr, path, size_);
+                } while (size == size_);
+
+                if (size == size_) {
+                    break;
+                }
+            } else {
+                path = buffer1;
+            }
+
+            if (!_wfullpath(buffer2, path, MAX_PATH)) {
+                break;
+            }
+
+            std::string tmp(static_cast<const char*>(UTF16To8(buffer2)));
+            ProgramPath = tmp.substr(0, tmp.find_last_of("\\/"));
+
+            break;
+        }
+
+        if (path != buffer1) {
+            free(path);
+        }
+    }
+
+    return ProgramPath.c_str();
+}
+
+const char* PathsClass::Data_Path()
+{
+    if (DataPath.empty()) {
+        if (ProgramPath.empty()) {
+            // Init the program path first if it hasn't been done already.
+            Program_Path();
+        }
+
+        DataPath = ProgramPath.substr(0, ProgramPath.find_last_of("\\/")) + SEP + "share";
+
+        if (!Suffix.empty()) {
+            DataPath += SEP + Suffix;
+        }
+    }
+
+    return DataPath.c_str();
+}
+
+const char* PathsClass::User_Path()
+{
+    if (UserPath.empty()) {
+        LPWSTR path = nullptr;
+        HRESULT hr;
+        hr = SHGetKnownFolderPath(FOLDERID_RoamingAppData, KF_FLAG_CREATE, nullptr, &path);
+        FreeCoTaskMemory scope(path);
+
+        if (!SUCCEEDED(hr)) {
+            DBG_WARN("Failed to retrieve FOLDERID_RoamingAppData for PathsClass::User_Path()");
+        }
+
+        UserPath = static_cast<const char*>(UTF16To8(path));
+        UserPath += "\\Vanilla-Conquer";
+
+        if (!Suffix.empty()) {
+            UserPath += SEP + Suffix;
+        }
+
+        Create_Directory(UserPath.c_str());
+    }
+
+    return UserPath.c_str();
+}
+
+bool PathsClass::Create_Directory(const char* dirname)
+{
+    bool ret = true;
+
+    if (dirname == nullptr) {
+        return ret;
+    }
+
+    std::string temp = dirname;
+    size_t pos = 0;
+    do {
+        pos = temp.find_first_of("\\/", pos + 1);
+        if (CreateDirectoryW(UTF8To16(temp.substr(0, pos).c_str()), nullptr) == FALSE) {
+            if (GetLastError() != ERROR_ALREADY_EXISTS) {
+                ret = false;
+                break;
+            }
+        }
+    } while (pos != std::string::npos);
+
+    return ret;
+}
+
+bool PathsClass::Is_Absolute(const char* path)
+{
+    if (strlen(path) < 2) {
+        return false;
+    }
+
+    return path != nullptr && (path[1] == ':' || (path[0] == '\\' && path[1] == '\\'));
+}
+
+std::string PathsClass::Argv_Path(const char* cmd_arg)
+{
+    wchar_t base_buff[MAX_PATH];
+    wchar_t* buff = base_buff;
+    unsigned len = GetFullPathNameW(UTF8To16(cmd_arg), MAX_PATH, buff, nullptr);
+    std::string ret;
+
+    // If we have a path longer than the standard max path, allocate a buffer of the correct size.
+    if (len >= MAX_PATH) {
+        buff = new wchar_t[len];
+        len = GetFullPathNameW(UTF8To16(cmd_arg), len, buff, nullptr);
+
+        if (len > 0) {
+            ret = UTF16To8(buff);
+        }
+
+        delete[] buff;
+    } else if (len > 0) {
+        ret = UTF16To8(buff);
+    }
+
+    return ret;
+}

--- a/common/rawfile.cpp
+++ b/common/rawfile.cpp
@@ -59,7 +59,11 @@
 
 #ifndef _WIN32
 #include <unistd.h>
-#define _unlink unlink
+#define _unlink         unlink
+#define raw_fopen(x, y) fopen(x, y)
+#else
+#include "utf.h"
+#define raw_fopen(x, y) _wfopen(UTF8To16(x), UTF8To16(y))
 #endif
 
 #include <sys/stat.h>
@@ -256,15 +260,15 @@ int RawFileClass::Open(int rights)
             break;
 
         case READ:
-            Handle = fopen(Filename, "rb");
+            Handle = raw_fopen(Filename, "rb");
             break;
 
         case WRITE:
-            Handle = fopen(Filename, "wb");
+            Handle = raw_fopen(Filename, "wb");
             break;
 
         case READ | WRITE:
-            Handle = fopen(Filename, "rwb");
+            Handle = raw_fopen(Filename, "rwb");
             break;
         }
 
@@ -333,7 +337,7 @@ int RawFileClass::Is_Available(int forced)
     **	CD-ROM, this routine will return a failure condition. In all but the missing file
     **	condition, go through the normal error recover channels.
     */
-    Handle = fopen(Filename, "r");
+    Handle = raw_fopen(Filename, "r");
     if (Handle == nullptr) {
         return (false);
     }

--- a/common/utf.h
+++ b/common/utf.h
@@ -1,0 +1,101 @@
+// TiberianDawn.DLL and RedAlert.dll and corresponding source code is free
+// software: you can redistribute it and/or modify it under the terms of
+// the GNU General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+
+// TiberianDawn.DLL and RedAlert.dll and corresponding source code is distributed
+// in the hope that it will be useful, but with permitted additional restrictions
+// under Section 7 of the GPL. See the GNU General Public License in LICENSE.TXT
+// distributed with this program. You should have received a copy of the
+// GNU General Public License along with permitted additional restrictions
+// with this program. If not, see https://github.com/electronicarts/CnC_Remastered_Collection
+#ifndef COMMON_UTF_H
+#define COMMON_UTF_H
+
+#if defined _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#include <wchar.h>
+
+/**
+ *  @brief Conversion class for interaction between UTF8 APIs and the WINAPI.
+ * 
+ *  This class is intended to be used as a wrapper for calling WINAPI unicode
+ *  functions with UTF8 formatted strings to make them behave as if they took
+ *  char* rather than wchar_t* while still allowing access to the full unicode
+ *  character set.
+ * 
+ *  E.g Win32APIFuncW(UTF8To16(utf8_string));
+ * 
+ *  The class will act as a temporary here, doing the memory allocation and
+ *  conversion for you on the fly with the destructor cleaning up after the
+ *  function call when it goes out of scope.
+ */
+class UTF8To16
+{
+public:
+    UTF8To16(const char* utf8)
+        : m_buffer(nullptr)
+    {
+        int size = MultiByteToWideChar(CP_UTF8, 0, utf8, -1, nullptr, 0);
+        m_buffer = new wchar_t[size];
+        MultiByteToWideChar(CP_UTF8, 0, utf8, -1, m_buffer, size);
+    }
+
+    ~UTF8To16()
+    {
+        delete[] m_buffer;
+        m_buffer = nullptr;
+    }
+
+    operator const wchar_t*() const
+    {
+        return m_buffer;
+    }
+
+private:
+    wchar_t* m_buffer;
+};
+
+/**
+ *  @brief Conversion class for interaction between UTF8 APIs and the WINAPI.
+ * 
+ *  This class is intended to be used as a wrapper for interpreting unicode
+ *  strings provided by the WINAPI as UTF8 strings.
+ * 
+ *  E.g UTF8APIFunc(UTF16To8(utf16_string));
+ * 
+ *  The class will act as a temporary here, doing the memory allocation and
+ *  conversion for you on the fly with the destructor cleaning up after the
+ *  function call when it goes out of scope.
+ */
+class UTF16To8
+{
+public:
+    UTF16To8(const wchar_t* utf16)
+        : m_buffer(nullptr)
+    {
+        int size = WideCharToMultiByte(CP_UTF8, 0, utf16, -1, nullptr, 0, nullptr, nullptr);
+        m_buffer = new char[size];
+        WideCharToMultiByte(CP_UTF8, 0, utf16, -1, m_buffer, size, nullptr, nullptr);
+    }
+
+    ~UTF16To8()
+    {
+        delete[] m_buffer;
+        m_buffer = nullptr;
+    }
+
+    operator const char*() const
+    {
+        return m_buffer;
+    }
+
+private:
+    char* m_buffer;
+};
+#endif // _WIN32
+
+#endif // COMMON_UTF_H

--- a/redalert/init.cpp
+++ b/redalert/init.cpp
@@ -2280,23 +2280,12 @@ static void Init_CDROM_Access(void)
 
     /*
     **	Always try to look at the CD-ROM for data files.
+    **
+    **	This call is needed because of a side effect of this function. It will examine the
+    **	CD-ROMs attached to this computer and set the appropriate status values. Without this
+    **	call, the "?:\\" could not be filled in correctly.
     */
-    if (!CCFileClass::Is_There_Search_Drives()) {
-        /*
-        **	This call is needed because of a side effect of this function. It will examine the
-        **	CD-ROMs attached to this computer and set the appropriate status values. Without this
-        **	call, the "?:\\" could not be filled in correctly.
-        */
-        Force_CD_Available(-1);
-        RequiredCD = -1;
-    } else {
-
-        /*
-        ** If there are search drives specified then all files are to be
-        ** considered local.
-        */
-        RequiredCD = -2;
-    }
+    RequiredCD = Force_CD_Available(-1) ? -1 : -2;
 }
 
 /***********************************************************************************************

--- a/redalert/startup.cpp
+++ b/redalert/startup.cpp
@@ -271,7 +271,9 @@ int main(int argc, char* argv[])
     /*
     **	Remember the current working directory and drive.
     */
-    vc_chdir(PathsClass::Instance().Program_Path());
+    Paths.Init("vanillara", CONFIG_FILE_NAME, "REDALERT.MIX", argv[0]);
+    vc_chdir(Paths.Program_Path());
+    CDFileClass::Refresh_Search_Drives();
 
     if (Parse_Command_Line(argc, argv)) {
 

--- a/tiberiandawn/init.cpp
+++ b/tiberiandawn/init.cpp
@@ -2393,23 +2393,12 @@ void Init_CDROM_Access(void)
 
     /*
     **	Always try to look at the CD-ROM for data files.
+    **
+    **	This call is needed because of a side effect of this function. It will examine the
+    **	CD-ROMs attached to this computer and set the appropriate status values. Without this
+    **	call, the "?:\\" could not be filled in correctly.
     */
-    if (!CCFileClass::Is_There_Search_Drives()) {
-        /*
-        **	This call is needed because of a side effect of this function. It will examine the
-        **	CD-ROMs attached to this computer and set the appropriate status values. Without this
-        **	call, the "?:\\" could not be filled in correctly.
-        */
-        Force_CD_Available(-1);
-        RequiredCD = -1;
-    } else {
-
-        /*
-        ** If there are search drives specified then all files are to be
-        ** considered local.
-        */
-        RequiredCD = -2;
-    }
+    RequiredCD = Force_CD_Available(-1) ? -1 : -2;
 }
 
 /***************************************************************************

--- a/tiberiandawn/startup.cpp
+++ b/tiberiandawn/startup.cpp
@@ -36,14 +36,21 @@
 
 #include "function.h"
 #include "common/ini.h"
+#include "common/paths.h"
 #include "settings.h"
 
 bool Read_Private_Config_Struct(FileClass& file, NewConfigType* config);
 void Print_Error_End_Exit(char* string);
 void Print_Error_Exit(char* string);
 #ifdef _WIN32
+#include < direct.h>
+#include "common/utf.h"
+#define vc_chdir(x) _wchdir(UTF8To16(x))
 extern void Create_Main_Window(HANDLE instance, int width, int height);
 HINSTANCE ProgramInstance;
+#else
+#include <unistd.h>
+#define vc_chdir(x) chdir(x)
 #endif
 
 extern int ReadyToQuit;
@@ -187,23 +194,6 @@ int PASCAL WinMain(HINSTANCE instance, HINSTANCE, char* command_line, int comman
 
     } while (command_char != 0 && command_char != 13 && argc < 20);
 
-    /*
-    **	Remember the current working directory and drive.
-    */
-#ifndef REMASTER_BUILD
-    char path[MAX_PATH];
-    GetModuleFileNameA(GetModuleHandleA(nullptr), path, sizeof(path));
-
-    for (char* i = &path[strlen(path)]; i != path; --i) {
-        if (*i == '\\' || *i == '/') {
-            *i = '\0';
-            break;
-        }
-    }
-
-    SetCurrentDirectoryA(path);
-#endif
-
     return main(argc, argv);
 }
 
@@ -216,6 +206,12 @@ int main(int argc, char** argv)
 #ifdef JAPANESE
     ForceEnglish = false;
 #endif
+
+    /*
+    **	Remember the current working directory and drive.
+    */
+    vc_chdir(PathsClass::Instance().Program_Path());
+
     if (Parse_Command_Line(argc, argv)) {
 
         WinTimerClass::Init(60);

--- a/tiberiandawn/startup.cpp
+++ b/tiberiandawn/startup.cpp
@@ -43,7 +43,7 @@ bool Read_Private_Config_Struct(FileClass& file, NewConfigType* config);
 void Print_Error_End_Exit(char* string);
 void Print_Error_Exit(char* string);
 #ifdef _WIN32
-#include < direct.h>
+#include <direct.h>
 #include "common/utf.h"
 #define vc_chdir(x) _wchdir(UTF8To16(x))
 extern void Create_Main_Window(HANDLE instance, int width, int height);
@@ -210,7 +210,9 @@ int main(int argc, char** argv)
     /*
     **	Remember the current working directory and drive.
     */
-    vc_chdir(PathsClass::Instance().Program_Path());
+    Paths.Init("vanillatd", "CONQUER.INI", "CONQUER.MIX", argv[0]);
+    vc_chdir(Paths.Program_Path());
+    CDFileClass::Refresh_Search_Drives();
 
     if (Parse_Command_Line(argc, argv)) {
 


### PR DESCRIPTION
Currently WIP and open for comments.

Implemented:
RawFileClass now handles utf8 paths on windows.
Provisional PathsClass to use as a global and provide absolute paths to writeable and read only locations as well as the binary directory itself.

TODO:
Implement an ini file to override these paths if needed.
Implement command line options to override these paths.
Refactor CDFileClass to use these paths and differentiate between relative and absolute paths.