### PR TITLE
Fix New Construction Options bug 

### DIFF
--- a/redalert/building.cpp
+++ b/redalert/building.cpp
@@ -2418,8 +2418,17 @@ void BuildingClass::Update_Buildables(void)
 
         case RTTI_AIRCRAFTTYPE:
             for (a = AIRCRAFT_FIRST; a < AIRCRAFT_COUNT; a++) {
+
                 if (PlayerPtr->Can_Build(&AircraftTypeClass::As_Reference((AircraftType)a), ActLike)) {
-                    Map.Add(RTTI_AIRCRAFTTYPE, a);
+                    if (AircraftTypeClass::As_Reference((AircraftType)a).IsFixedWing) {
+                        if (*this == STRUCT_AIRSTRIP) {
+                            Map.Add(RTTI_AIRCRAFTTYPE, a);
+                        }
+                    } else {
+                        if (*this == STRUCT_HELIPAD) {
+                            Map.Add(RTTI_AIRCRAFTTYPE, a);
+                        }
+                    }
                 }
             }
             break;


### PR DESCRIPTION
If playing as Allies capturing Soviet Conyard, Helipad and Airfield causes the game to think there are new construction options constantly

Allen262 made a test map, replaces first Allies campaign mission. Unzip the attached file to the game directory.

To Test: Capture the Sov ConYard than build a Airfield and the NCO bug will be active.

If you build any new buildings after the bug is active you will hear "New Construction Options".

[scg01ea.zip](https://github.com/TheAssemblyArmada/Vanilla-Conquer/files/5809639/scg01ea.zip)


This is a bug from original.

The issue is that StripClass::Recalc() does a proper check and sees that Hind and Transport Helicopter (the latter only in single player) aren't buildable and removes it from the sidebar. Then the game calls BuildingClass::Update_Buildables() and the check is glitched and it adds Hind & Transport Helicopter to sidebar because it checks for Airstrip or Helipad instead of checking Airstrip for fixed wing (Yak, Mig) and helipad for Helicopters (e.g. Hind & Transport & Longbow). 

This code fixes BuildingClass::Update_Buildables(). The game does have the correct logic for Barracks/Kennel distinction for Dogs.

