### PR TITLE
Fix magic build exploit

### DIFF
--- a/redalert/display.cpp
+++ b/redalert/display.cpp
@@ -879,13 +879,6 @@ CELL DisplayClass::Set_Cursor_Pos(CELL pos)
         y = Coord_YCell(TacticalCoord) + Lepton_To_Cell(TacLeptonHeight) - h;
     pos = XY_Cell(x, y) - ZoneOffset;
 
-    /*
-    ** This checks to see if NO animation or drawing is to occur and, if so,
-    **	exits.
-    */
-    if (pos == ZoneCell)
-        return (pos);
-
     prevpos = ZoneCell;
 
     /*
@@ -3098,9 +3091,7 @@ int DisplayClass::TacticalClass::Action(unsigned flags, KeyNumType& key)
         /*
         ** Cause any displayed cursor to move along with the mouse cursor.
         */
-        if (cell != Map.ZoneCell) {
-            Map.Set_Cursor_Pos(cell);
-        }
+        Map.Set_Cursor_Pos(cell);
 
         /*
         **	Determine the object that the mouse is currently over.


### PR DESCRIPTION
If a nearby building is destroyed you can still place the building if you got the white placement overlay before that building your building off from is destroyed because the building placement check is only updated when you move your mouse.

To test: Tell your units to attack one of your buildings and build a building in the sidebar. Select the building and find an area next to the building that is being attacked so you get the white placement marker.

Without the fix after the units have destroyed the building you are trying to build next to your placement marker will still be white and you can still build there.

With this fix the building marker will turn red and you will be unable to build there.

This is a port of the CnCnet fix that has been in use for more than 7 years.