### PR TITLE
Fix IsActive != NULL assert crash because of Petroglyph 'units on top of buildings' fix

### DIFF
--- a/redalert/infantry.cpp
+++ b/redalert/infantry.cpp
@@ -3991,7 +3991,7 @@ void InfantryClass::Movement_AI(void)
             /*
             **	Scatter infantry off buildings in guard modes.
             */
-            if (!IsTethered && (Mission == MISSION_GUARD || Mission == MISSION_GUARD_AREA)
+            if (IsActive && !IsTethered && (Mission == MISSION_GUARD || Mission == MISSION_GUARD_AREA)
                 && MissionQueue == MISSION_NONE && Map[Coord].Cell_Building() != NULL) {
                 Scatter(0, true, true);
             }

--- a/redalert/unit.cpp
+++ b/redalert/unit.cpp
@@ -424,7 +424,7 @@ void UnitClass::AI(void)
     /*
     **	Scatter units off buildings in guard modes.
     */
-    if (!IsTethered && !IsFiring && !IsDriving && !IsRotating
+    if (IsActive && !IsTethered && !IsFiring && !IsDriving && !IsRotating
         && (Mission == MISSION_GUARD || Mission == MISSION_GUARD_AREA) && MissionQueue == MISSION_NONE
         && Map[Coord].Cell_Building() != NULL) {
         Scatter(0, true, true);


### PR DESCRIPTION
The  'units on top of buildings' fix is added for UnitClass and InfantryClass by Petrogylph. It gets triggered for InfantryClass in Movement_AI() as Doing_AI() (called just before Movement_AI) can free up the Infantry object if it detects the infantry unit is doing the fire death animation. Movement_AI() will call Scatter() which further down the call chain in ObjectClass::Select() has an assert for IsActive != null.

This fix adds the missing IsActive check for the Petroglpyh fix.