### PR TITLE
Set default radar zoom mode to zoomed out instead of zoomed in

### DIFF
--- a/redalert/radar.cpp
+++ b/redalert/radar.cpp
@@ -200,7 +200,7 @@ void RadarClass::Init_Clear(void)
     ** If we have a valid map lets make sure that we set it correctly
     */
     if (MapCellWidth || MapCellHeight) {
-        IsZoomed = false;
+        IsZoomed = true;
         Zoom_Mode(Coord_Cell(Map.TacticalCoord));
     }
 }

--- a/tiberiandawn/radar.cpp
+++ b/tiberiandawn/radar.cpp
@@ -182,7 +182,7 @@ void RadarClass::Init_Clear(void)
     ** If we have a valid map lets make sure that we set it correctly
     */
     if (MapCellWidth || MapCellHeight) {
-        IsZoomed = false;
+        IsZoomed = true;
         Zoom_Mode(Coord_Cell(Map.TacticalCoord));
     }
 }


### PR DESCRIPTION
After buying a Radar dome the radar mode is set to zoomed in, this changes it to zoomed out.

This is the same patch as the one Nyerguds made for C&C95 and the CnCNet patches for RA95 (this particular CnCnet radar zoom out patch is based off Nyerguds).

I have never heard anyone complain about this, but could easily be made a REDALERT.INI option in the future.

To test, start a new game and build a Radar Dome.