### PR TITLE
Fix wrong color remaps for standalone

### DIFF
--- a/redalert/defines.h
+++ b/redalert/defines.h
@@ -1196,8 +1196,13 @@ typedef enum PlayerColorType : char
     PCOLOR_RED,
     PCOLOR_GREEN,
     PCOLOR_ORANGE,
+#ifdef REMASTER_BUILD
     PCOLOR_BLUE, // This is actually the red scheme used in the dialogs
     PCOLOR_GREY,
+#else
+    PCOLOR_GREY,
+    PCOLOR_BLUE,
+#endif
     PCOLOR_BROWN,
     PCOLOR_TYPE,
     PCOLOR_REALLY_BLUE,

--- a/redalert/init.cpp
+++ b/redalert/init.cpp
@@ -1993,6 +1993,7 @@ static void Init_Color_Remaps(void)
         ColorRemaps[pcolor].Box = HidPage.Get_Pixel(4, pcolor);
     }
 
+#ifdef REMASTER_BUILD
     /* 12/9/2019 SKY - Swap Blue and Grey color remaps */
     {
         RemapControlType temp;
@@ -2000,6 +2001,7 @@ static void Init_Color_Remaps(void)
         memcpy(&ColorRemaps[PCOLOR_BLUE], &ColorRemaps[PCOLOR_GREY], sizeof(RemapControlType));
         memcpy(&ColorRemaps[PCOLOR_GREY], &temp, sizeof(RemapControlType));
     }
+#endif
 
     /*
     ** Now do the special dim grey scheme

--- a/redalert/scenario.cpp
+++ b/redalert/scenario.cpp
@@ -324,6 +324,11 @@ bool Start_Scenario(char* name, bool briefing)
         return (false);
     }
 
+    /*
+    ** This was added in the Sept 16th 2020 update, causes colors to alternate for both in standalone.
+    ** Seems likely it would affect the remaster classic renderer as well?
+    */
+#ifdef REMASTER_BUILD
     /* Swap Lt. Blue and Blue color remaps in skirmish/multiplayer */
     if (Session.Type != GAME_NORMAL) {
         RemapControlType temp;
@@ -331,6 +336,7 @@ bool Start_Scenario(char* name, bool briefing)
         memcpy(&ColorRemaps[PCOLOR_LTBLUE], &ColorRemaps[PCOLOR_BLUE], sizeof(RemapControlType));
         memcpy(&ColorRemaps[PCOLOR_BLUE], &temp, sizeof(RemapControlType));
     }
+#endif
 
     /*
     **	Play the winning movie and then start the next scenario.


### PR DESCRIPTION
Fixes:
-Blue & green color remaps being swapped
-Wrong color for dead player info text in sidebar radar area in multiplayer.

Has remaster build guards but not tested with remaster.