### PR TITLE
[RA1]Unlimited tutorial text size + map specific tutorial text

### DIFF
--- a/redalert/conquer.cpp
+++ b/redalert/conquer.cpp
@@ -4857,6 +4857,10 @@ bool Force_Scenario_Available(const char* szName)
 
 void Load_Tutorial_Text(INIClass &ini, DynamicVectorClass<const char*> &TutorialText)
 {
+    for (int i = 0; i < TutorialText.Count(); i++) {
+        free((void*)TutorialText[i]);
+    }
+
     TutorialText.Clear();
 
     // Because of special reading logic entries can overwrite older ones because

--- a/redalert/conquer.cpp
+++ b/redalert/conquer.cpp
@@ -4854,3 +4854,28 @@ bool Force_Scenario_Available(const char* szName)
     return true;
 }
 #endif
+
+void Load_Tutorial_Text(INIClass &ini, DynamicVectorClass<const char*> &TutorialText)
+{
+    TutorialText.Clear();
+
+    // Because of special reading logic entries can overwrite older ones because
+    // the entry name is used as id and the first id starts at 1 and not zero
+
+    int entries = ini.Entry_Count("Tutorial") + 1;
+    
+    // Add all the empty entries as NULL strings
+    for (int i = 0; i < entries; i++) {
+        TutorialText.Add(NULL);
+    }
+    
+    // Now set the entries based on ID
+    for (int index = 0; index < entries; index++) {
+        char buffer[256];
+        char num[10];
+        sprintf(num, "%d", index);
+        if (ini.Get_String("Tutorial", num, "", buffer, sizeof(buffer))) {
+            TutorialText[index] = (strdup(buffer));
+        }
+    }
+}

--- a/redalert/conquer.cpp
+++ b/redalert/conquer.cpp
@@ -4861,7 +4861,7 @@ void Load_Tutorial_Text(INIClass &ini, DynamicVectorClass<const char*> &Tutorial
 
     // Because of special reading logic entries can overwrite older ones because
     // the entry name is used as id and the first id starts at 1 and not zero
-
+    // in conquer.ini 
     int entries = ini.Entry_Count("Tutorial") + 1;
     
     // Add all the empty entries as NULL strings

--- a/redalert/externs.h
+++ b/redalert/externs.h
@@ -141,7 +141,8 @@ extern GraphicBufferClass ModeXBuff;
 **	Dynamic global variables (these change or are initialized at run time).
 */
 extern MissionControlClass MissionControl[MISSION_COUNT];
-extern char const* TutorialText[225];
+extern DynamicVectorClass<const char*> TutorialText;
+extern DynamicVectorClass<const char*> MapTutorialText;
 extern Buffer* TheaterBuffer;
 extern CCINIClass RuleINI;
 #ifdef FIXIT_CSII //	checked - ajw 9/28/98

--- a/redalert/function.h
+++ b/redalert/function.h
@@ -318,6 +318,8 @@ bool Is_Counterstrike_Installed(void);
 bool Is_Aftermath_Installed(void);
 #endif
 
+void Load_Tutorial_Text(INIClass& ini, DynamicVectorClass<const char*>& TutorialText);
+
 #define ALWAYS_RELOAD_CD 1000
 
 void Center_About_Objects(void);

--- a/redalert/globals.cpp
+++ b/redalert/globals.cpp
@@ -221,7 +221,8 @@ MissionControlClass MissionControl[MISSION_COUNT];
 **	There are various tutorial messages that can appear in the game. These
 **	are called upon by number and pointed to by this array.
 */
-char const* TutorialText[225];
+DynamicVectorClass<const char*> TutorialText;
+DynamicVectorClass<const char*> MapTutorialText;
 
 /***************************************************************************
 **	This holds the rules database. The rules database won't change during the

--- a/redalert/init.cpp
+++ b/redalert/init.cpp
@@ -2793,16 +2793,7 @@ static void Init_Bulk_Data(void)
     INIClass ini;
     CCFileClass tutorialIniFile("TUTORIAL.INI");
     ini.Load(tutorialIniFile);
-    for (int index = 0; index < ARRAY_SIZE(TutorialText); index++) {
-        TutorialText[index] = NULL;
-
-        char buffer[128];
-        char num[10];
-        sprintf(num, "%d", index);
-        if (ini.Get_String("Tutorial", num, "", buffer, sizeof(buffer))) {
-            TutorialText[index] = strdup(buffer);
-        }
-    }
+    Load_Tutorial_Text(ini, TutorialText);
 
     /*
     **	Perform one-time game system initializations.

--- a/redalert/scenario.cpp
+++ b/redalert/scenario.cpp
@@ -161,6 +161,7 @@ ScenarioClass::ScenarioClass(void)
     , IsNoMapSel(false)
     , IsTruckCrate(false)
     , IsMoneyTiberium(false)
+    , UseMapTutorialText(false)
     ,
 #ifdef FIXIT_VERSION_3 //	For endgame auto-sonar pulse.
 #define AUTOSONAR_PERIOD TICKS_PER_SECOND * 40
@@ -2260,6 +2261,13 @@ bool Read_Scenario_INI(char* fname, bool)
         Add_CRC(&ScenarioCRC, (unsigned long)val);
     }
 #endif
+
+    if (ini.Section_Present("Tutorial")) {
+        Load_Tutorial_Text(ini, MapTutorialText);
+        Scen.UseMapTutorialText = true;
+    } else {
+        Scen.UseMapTutorialText = false;
+    }
 
     /*
     **	Fetch the appropriate movie names from the INI file.

--- a/redalert/scenario.h
+++ b/redalert/scenario.h
@@ -327,6 +327,8 @@ public:
     bool bLocalProposesDraw; //	True if the local player in a 2-player game has a draw offer extended.
     bool bOtherProposesDraw; //	True if the other player in a 2-player game has a draw offer extended.
 #endif
+
+    bool UseMapTutorialText;
 };
 
 #endif

--- a/redalert/taction.cpp
+++ b/redalert/taction.cpp
@@ -364,14 +364,16 @@ bool TActionClass::operator()(HousesType house, ObjectClass* object, int id, CEL
     **	Display a text message overlayed onto the tactical map.
     */
     case TACTION_TEXT_TRIGGER: {
-        const char* txt = Scen.UseMapTutorialText ? MapTutorialText[Data.Value] : TutorialText[Data.Value];
-        Session.Messages.Add_Message(NULL,
-                                     Data.Value,
-                                     txt,
-                                     PCOLOR_GREEN,
-                                     TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_FULLSHADOW,
-                                     Rule.MessageDelay * TICKS_PER_MINUTE);
-        break;
+        DynamicVectorClass<const char*>& TextVector = Scen.UseMapTutorialText ? MapTutorialText : TutorialText;
+        if (Data.Value < TextVector.Count() && TextVector[Data.Value] != NULL) {
+            Session.Messages.Add_Message(NULL,
+                                         Data.Value,
+                                         TextVector[Data.Value],
+                                         PCOLOR_GREEN,
+                                         TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_FULLSHADOW,
+                                         Rule.MessageDelay * TICKS_PER_MINUTE);
+            break;
+        }
     }
 
     /*

--- a/redalert/taction.cpp
+++ b/redalert/taction.cpp
@@ -363,14 +363,16 @@ bool TActionClass::operator()(HousesType house, ObjectClass* object, int id, CEL
     /*
     **	Display a text message overlayed onto the tactical map.
     */
-    case TACTION_TEXT_TRIGGER:
+    case TACTION_TEXT_TRIGGER: {
+        const char* txt = Scen.UseMapTutorialText ? MapTutorialText[Data.Value] : TutorialText[Data.Value];
         Session.Messages.Add_Message(NULL,
                                      Data.Value,
-                                     (char*)TutorialText[Data.Value],
+                                     txt,
                                      PCOLOR_GREEN,
                                      TPF_6PT_GRAD | TPF_USE_GRAD_PAL | TPF_FULLSHADOW,
                                      Rule.MessageDelay * TICKS_PER_MINUTE);
         break;
+    }
 
     /*
     ** Launch nuclear missiles (duds) from all mslo's


### PR DESCRIPTION
These change allow for:
-unlimited size of tutorial.ini text (normally limited to 225 lines)
-adding custom tutorial text to your map, overwrites the default tutorial text. Add a [Tutorial] section to your map with <num>=<text> as entries, e.g.:

[Tutorial]
1=Hi this is line 1
2=This is line 2

This text will, when activated via a map trigger action, be displayed in the top left of the screen.