### PR TITLE
Fix rulesINI not resetting all data after loading mod map and then loading another map

### DIFF
--- a/redalert/aadata.cpp
+++ b/redalert/aadata.cpp
@@ -390,7 +390,7 @@ AircraftType AircraftTypeClass::From_Name(char const* name)
  * HISTORY:                                                                                    *
  *   07/26/1994 JLB : Created.                                                                 *
  *=============================================================================================*/
-void AircraftTypeClass::One_Time(void)
+void AircraftTypeClass::Init_Clear(void)
 {
     for (int index = AIRCRAFT_FIRST; index < AIRCRAFT_COUNT; index++) {
         char fullname[_MAX_FNAME + _MAX_EXT];

--- a/redalert/adata.cpp
+++ b/redalert/adata.cpp
@@ -2394,7 +2394,7 @@ void AnimTypeClass::Init_Heap(void)
  * HISTORY:                                                                                    *
  *   06/02/1994 JLB : Created.                                                                 *
  *=============================================================================================*/
-void AnimTypeClass::One_Time(void)
+void AnimTypeClass::Init_Clear(void)
 {
     for (int index = ANIM_FIRST; index < ANIM_COUNT; index++) {
         char fullname[_MAX_FNAME + _MAX_EXT];
@@ -2436,22 +2436,20 @@ void AnimTypeClass::One_Time(void)
  *=============================================================================================*/
 void AnimTypeClass::Init(TheaterType theater)
 {
-    if (theater != LastTheater) {
-        for (int index = ANIM_FIRST; index < ANIM_COUNT; index++) {
-            AnimTypeClass const& anim = As_Reference((AnimType)index);
+    for (int index = ANIM_FIRST; index < ANIM_COUNT; index++) {
+        AnimTypeClass const& anim = As_Reference((AnimType)index);
 
-            if (anim.IsTheater) {
-                char fullname[_MAX_FNAME + _MAX_EXT]; // Fully constructed iconset name.
-                _makepath(fullname, NULL, NULL, anim.IniName, Theaters[theater].Suffix);
-                ((void const*&)anim.ImageData) = MFCD::Retrieve(fullname);
-            }
+        if (anim.IsTheater) {
+            char fullname[_MAX_FNAME + _MAX_EXT]; // Fully constructed iconset name.
+            _makepath(fullname, NULL, NULL, anim.IniName, Theaters[theater].Suffix);
+            ((void const*&)anim.ImageData) = MFCD::Retrieve(fullname);
         }
+    }
 
 #ifdef REMASTER_BUILD
-        // Set up beacon image data manually since they're new animations only available in the virtual renderer
-        ((void const*&)As_Reference(ANIM_BEACON_VIRTUAL).ImageData) = As_Reference(ANIM_BEACON).ImageData;
+    // Set up beacon image data manually since they're new animations only available in the virtual renderer
+    ((void const*&)As_Reference(ANIM_BEACON_VIRTUAL).ImageData) = As_Reference(ANIM_BEACON).ImageData;
 #endif
-    }
 }
 
 /***********************************************************************************************

--- a/redalert/bbdata.cpp
+++ b/redalert/bbdata.cpp
@@ -194,7 +194,7 @@ void BulletTypeClass::Init_Heap(void)
  * HISTORY:                                                                                    *
  *   05/28/1994 JLB : Created.                                                                 *
  *=============================================================================================*/
-void BulletTypeClass::One_Time(void)
+void BulletTypeClass::Init_Clear(void)
 {
     /*
     **	Load the bullet shapes.

--- a/redalert/bdata.cpp
+++ b/redalert/bdata.cpp
@@ -2956,7 +2956,7 @@ void BuildingTypeClass::Init_Heap(void)
  *   05/28/1994 JLB : Created.                                                                 *
  *   06/11/1994 JLB : Updated construction time and frame count logic.                         *
  *=============================================================================================*/
-void BuildingTypeClass::One_Time(void)
+void BuildingTypeClass::Init_Clear(void)
 {
     static const struct
     {
@@ -3013,17 +3013,14 @@ void BuildingTypeClass::One_Time(void)
         /*
         **	Fetch the sidebar cameo image for this building.
         */
-        if (building.Level != -1) {
-            //		if (building.IsBuildable) {
-            sprintf(buffer, "%sICON", building.Graphic_Name());
+        sprintf(buffer, "%sICON", building.Graphic_Name());
 
-            if (building.IsFake) {
-                buffer[3] = 'F';
-            }
-
-            _makepath(fullname, NULL, NULL, buffer, ".SHP");
-            ((void const*&)building.CameoData) = MFCD::Retrieve(fullname);
+        if (building.IsFake) {
+            buffer[3] = 'F';
         }
+
+        _makepath(fullname, NULL, NULL, buffer, ".SHP");
+        ((void const*&)building.CameoData) = MFCD::Retrieve(fullname);
 
         /*
         **	Fetch the construction animation for this building.
@@ -3253,30 +3250,28 @@ void BuildingTypeClass::Init_Anim(BStateType state, int start, int count, int ra
  *=============================================================================================*/
 void BuildingTypeClass::Init(TheaterType theater)
 {
-    if (theater != LastTheater) {
-        char fullname[_MAX_FNAME + _MAX_EXT];
+    char fullname[_MAX_FNAME + _MAX_EXT];
 
-        for (int sindex = STRUCT_FIRST; sindex < STRUCT_COUNT; sindex++) {
-            BuildingTypeClass const* classptr = &As_Reference((StructType)sindex);
+    for (int sindex = STRUCT_FIRST; sindex < STRUCT_COUNT; sindex++) {
+        BuildingTypeClass const* classptr = &As_Reference((StructType)sindex);
 
-            if (classptr->IsTheater) {
-                _makepath(fullname, NULL, NULL, classptr->Graphic_Name(), Theaters[theater].Suffix);
-                ((void const*&)classptr->ImageData) = MFCD::Retrieve(fullname);
+        if (classptr->IsTheater) {
+            _makepath(fullname, NULL, NULL, classptr->Graphic_Name(), Theaters[theater].Suffix);
+            ((void const*&)classptr->ImageData) = MFCD::Retrieve(fullname);
 
-                /*
+            /*
                 **	Buildup data is probably theater specific as well. Fetch a pointer to the
                 **	data at this time as well.
                 */
-                sprintf(fullname, "%sMAKE.%s", classptr->Graphic_Name(), Theaters[theater].Suffix);
-                ((void const*&)classptr->BuildupData) = MFCD::Retrieve(fullname);
-                if (classptr->BuildupData) {
-                    int timedelay = 1;
-                    int count = Get_Build_Frame_Count(classptr->BuildupData);
-                    if (count != 0) {
-                        timedelay = (5 * TICKS_PER_SECOND) / count;
-                    }
-                    classptr->Init_Anim(BSTATE_CONSTRUCTION, 0, count, timedelay);
+            sprintf(fullname, "%sMAKE.%s", classptr->Graphic_Name(), Theaters[theater].Suffix);
+            ((void const*&)classptr->BuildupData) = MFCD::Retrieve(fullname);
+            if (classptr->BuildupData) {
+                int timedelay = 1;
+                int count = Get_Build_Frame_Count(classptr->BuildupData);
+                if (count != 0) {
+                    timedelay = (5 * TICKS_PER_SECOND) / count;
                 }
+                classptr->Init_Anim(BSTATE_CONSTRUCTION, 0, count, timedelay);
             }
         }
     }

--- a/redalert/cdata.cpp
+++ b/redalert/cdata.cpp
@@ -1298,7 +1298,7 @@ ObjectClass* TemplateTypeClass::Create_One_Of(HouseClass*) const
  * HISTORY:                                                                                    *
  *   08/12/1994 JLB : Created.                                                                 *
  *=============================================================================================*/
-void TemplateTypeClass::One_Time(void)
+void TemplateTypeClass::Init_Clear(void)
 {
 }
 

--- a/redalert/hdata.cpp
+++ b/redalert/hdata.cpp
@@ -403,7 +403,7 @@ HousesType HouseTypeClass::From_Name(char const* name)
  *   05/21/1994 JLB : Converted to member function.                                            *
  *   06/19/1996 JLB : Converted to regular heap class management.                              *
  *=============================================================================================*/
-void HouseTypeClass::One_Time(void)
+void HouseTypeClass::Init_Clear(void)
 {
 }
 

--- a/redalert/house.cpp
+++ b/redalert/house.cpp
@@ -253,7 +253,7 @@ HouseClass* HouseClass::As_Pointer(HousesType house)
  * HISTORY:                                                                                    *
  *   12/09/1994 JLB : Created.                                                                 *
  *=============================================================================================*/
-void HouseClass::One_Time(void)
+void HouseClass::Init_Clear(void)
 {
     BuildChoice.Set_Heap(STRUCT_COUNT);
 }

--- a/redalert/house.h
+++ b/redalert/house.h
@@ -817,7 +817,7 @@ public:
     };
 
     static void Init(void);
-    static void One_Time(void);
+    static void Init_Clear(void);
     static HouseClass* As_Pointer(HousesType house);
     static void Recalc_Attributes(void);
 

--- a/redalert/idata.cpp
+++ b/redalert/idata.cpp
@@ -1355,7 +1355,7 @@ InfantryType InfantryTypeClass::From_Name(char const* name)
  * HISTORY:                                                                                    *
  *   09/24/1994 JLB : Created.                                                                 *
  *=============================================================================================*/
-void InfantryTypeClass::One_Time(void)
+void InfantryTypeClass::Init_Clear(void)
 {
     for (InfantryType index = INFANTRY_FIRST; index < INFANTRY_COUNT; index++) {
         char fullname[_MAX_FNAME + _MAX_EXT];

--- a/redalert/init.cpp
+++ b/redalert/init.cpp
@@ -283,7 +283,7 @@ bool Init_Game(int, char*[])
     */
     CCFileClass rulesIniFile("RULES.INI");
     if (RuleINI.Load(rulesIniFile, false)) {
-        Rule.Process(RuleINI);
+        Rule.Process(RuleINI, true);
     }
 #ifdef FIXIT_CSII //	checked - ajw 9/28/98
     //  Aftermath runtime change 9/29/98
@@ -291,7 +291,7 @@ bool Init_Game(int, char*[])
     if (Is_Aftermath_Installed() == true) {
         CCFileClass aftermathIniFile("AFTRMATH.INI");
         if (AftermathINI.Load(aftermathIniFile, false)) {
-            Rule.Process(AftermathINI);
+            Rule.Process(AftermathINI, true);
         }
     }
 #endif
@@ -2171,21 +2171,6 @@ static void Init_One_Time_Systems(void)
     Logic.One_Time();
     Options.One_Time();
     Session.One_Time();
-
-    ObjectTypeClass::One_Time();
-    BuildingTypeClass::One_Time();
-    BulletTypeClass::One_Time();
-    HouseTypeClass::One_Time();
-    TemplateTypeClass::One_Time();
-    OverlayTypeClass::One_Time();
-    SmudgeTypeClass::One_Time();
-    TerrainTypeClass::One_Time();
-    UnitTypeClass::One_Time();
-    VesselTypeClass::One_Time();
-    InfantryTypeClass::One_Time();
-    AnimTypeClass::One_Time();
-    AircraftTypeClass::One_Time();
-    HouseClass::One_Time();
 }
 
 /***********************************************************************************************

--- a/redalert/object.cpp
+++ b/redalert/object.cpp
@@ -2329,7 +2329,7 @@ short const* ObjectTypeClass::Overlap_List(void) const
  * HISTORY:                                                                                    *
  *   11/01/1994 JLB : Created.                                                                 *
  *=============================================================================================*/
-void ObjectTypeClass::One_Time(void)
+void ObjectTypeClass::Init_Clear(void)
 {
     SelectShapes = MFCD::Retrieve("SELECT.SHP");
 

--- a/redalert/odata.cpp
+++ b/redalert/odata.cpp
@@ -614,7 +614,7 @@ void OverlayTypeClass::Init_Heap(void)
  * HISTORY:                                                                                    *
  *   08/12/1994 JLB : Created.                                                                 *
  *=============================================================================================*/
-void OverlayTypeClass::One_Time(void)
+void OverlayTypeClass::Init_Clear(void)
 {
 }
 
@@ -852,25 +852,22 @@ void OverlayTypeClass::Draw_It(int x, int y, int data) const
  *=============================================================================================*/
 void OverlayTypeClass::Init(TheaterType theater)
 {
-    if (theater != LastTheater) {
+    for (OverlayType index = OVERLAY_FIRST; index < OVERLAY_COUNT; index++) {
+        OverlayTypeClass& overlay = As_Reference(index);
+        char fullname[_MAX_FNAME + _MAX_EXT]; // Fully constructed iconset name.
 
-        for (OverlayType index = OVERLAY_FIRST; index < OVERLAY_COUNT; index++) {
-            OverlayTypeClass& overlay = As_Reference(index);
-            char fullname[_MAX_FNAME + _MAX_EXT]; // Fully constructed iconset name.
-
-            if (overlay.IsTheater) {
-                _makepath(fullname, NULL, NULL, overlay.IniName, Theaters[theater].Suffix);
-            } else {
-                _makepath(fullname, NULL, NULL, overlay.IniName, ".SHP");
-            }
-            overlay.ImageData = MFCD::Retrieve(fullname);
-
-            IsTheaterShape = overlay.IsTheater; // Tell Build_Frame if this is a theater specific shape
-            if (overlay.RadarIcon != NULL)
-                delete[](char*) overlay.RadarIcon;
-            overlay.RadarIcon = Get_Radar_Icon(overlay.Get_Image_Data(), 0, -1, 3);
-            IsTheaterShape = false;
+        if (overlay.IsTheater) {
+            _makepath(fullname, NULL, NULL, overlay.IniName, Theaters[theater].Suffix);
+        } else {
+            _makepath(fullname, NULL, NULL, overlay.IniName, ".SHP");
         }
+        overlay.ImageData = MFCD::Retrieve(fullname);
+
+        IsTheaterShape = overlay.IsTheater; // Tell Build_Frame if this is a theater specific shape
+        if (overlay.RadarIcon != NULL)
+            delete[](char*) overlay.RadarIcon;
+        overlay.RadarIcon = Get_Radar_Icon(overlay.Get_Image_Data(), 0, -1, 3);
+        IsTheaterShape = false;
     }
 }
 

--- a/redalert/rules.cpp
+++ b/redalert/rules.cpp
@@ -336,14 +336,16 @@ static void Difficulty_Get(CCINIClass& ini, DifficultyClass& diff, char const* s
  * HISTORY:                                                                                    *
  *   06/17/1996 JLB : Created.                                                                 *
  *=============================================================================================*/
-bool RulesClass::Process(CCINIClass& ini)
+bool RulesClass::Process(CCINIClass& ini, bool setheapmaximums)
 {
     BStart(BENCH_RULES);
 
     General(ini);
     MPlayer(ini);
     Recharge(ini);
-    Heap_Maximums(ini);
+    if (setheapmaximums) {
+        Heap_Maximums(ini);
+    }
     AI(ini);
     Powerups(ini);
     Land_Types(ini);

--- a/redalert/rules.h
+++ b/redalert/rules.h
@@ -61,7 +61,7 @@ class RulesClass
 public:
     RulesClass(void);
 
-    bool Process(CCINIClass& file);
+    bool Process(CCINIClass& file, bool setheapmaximums);
     bool General(CCINIClass& ini);
     bool MPlayer(CCINIClass& ini);
     bool Recharge(CCINIClass& ini);

--- a/redalert/scenario.cpp
+++ b/redalert/scenario.cpp
@@ -518,19 +518,6 @@ bool Read_Scenario(char* name)
                     Emergency_Exit(EXIT_FAILURE);
                 }
             }
-            CCINIClass ini;
-            CCFileClass mplayerIniFile("MPLAYER.INI");
-            if (ini.Load(mplayerIniFile, false)) {
-                Rule.General(ini);
-                Rule.Recharge(ini);
-                Rule.AI(ini);
-                Rule.Powerups(ini);
-                Rule.Land_Types(ini);
-                Rule.Themes(ini);
-                Rule.IQ(ini);
-                Rule.Objects(ini);
-                Rule.Difficulty(ini);
-            }
         }
 #endif
         Fill_In_Data();
@@ -2183,6 +2170,32 @@ bool Read_Scenario_INI(char* fname, bool)
     }
 #endif
 
+    HouseTypes.Set_Heap(HOUSE_COUNT);
+    BuildingTypes.Set_Heap(STRUCT_COUNT);
+    AircraftTypes.Set_Heap(AIRCRAFT_COUNT);
+    InfantryTypes.Set_Heap(INFANTRY_COUNT);
+    BulletTypes.Set_Heap(BULLET_COUNT);
+    AnimTypes.Set_Heap(ANIM_COUNT);
+    UnitTypes.Set_Heap(UNIT_COUNT);
+    VesselTypes.Set_Heap(VESSEL_COUNT);
+    TemplateTypes.Set_Heap(TEMPLATE_COUNT);
+    TerrainTypes.Set_Heap(TERRAIN_COUNT);
+    OverlayTypes.Set_Heap(OVERLAY_COUNT);
+    SmudgeTypes.Set_Heap(SMUDGE_COUNT);
+
+    HouseTypeClass::Init_Heap();
+    SmudgeTypeClass::Init_Heap();
+    BuildingTypeClass::Init_Heap();
+    AircraftTypeClass::Init_Heap();
+    InfantryTypeClass::Init_Heap();
+    BulletTypeClass::Init_Heap();
+    AnimTypeClass::Init_Heap();
+    UnitTypeClass::Init_Heap();
+    VesselTypeClass::Init_Heap();
+    TemplateTypeClass::Init_Heap();
+    TerrainTypeClass::Init_Heap();
+    OverlayTypeClass::Init_Heap();
+
 #ifdef FIXIT_ANTS
     Session.Messages.Reset();
     //	Session.Messages.Add_Message(NULL, 0, NULL, PCOLOR_GREEN, TPF_6PT_GRAD|TPF_USE_GRAD_PAL|TPF_FULLSHADOW, 1);
@@ -2206,26 +2219,14 @@ bool Read_Scenario_INI(char* fname, bool)
     BuildingTypeClass::As_Reference(STRUCT_LARVA2).Level = -1;
 #endif
 
-    Rule.General(RuleINI);
-    Rule.Recharge(RuleINI);
-    Rule.AI(RuleINI);
-    Rule.Powerups(RuleINI);
-    Rule.Land_Types(RuleINI);
-    Rule.Themes(RuleINI);
-    Rule.IQ(RuleINI);
-    Rule.Objects(RuleINI);
-    Rule.Difficulty(RuleINI);
-#ifdef FIXIT_CSII //	checked - ajw 9/28/98 - Except does this _change_ any rules, or just add to them? - Just adds.
-    Rule.General(AftermathINI);
-    Rule.Recharge(AftermathINI);
-    Rule.AI(AftermathINI);
-    Rule.Powerups(AftermathINI);
-    Rule.Land_Types(AftermathINI);
-    Rule.Themes(AftermathINI);
-    Rule.IQ(AftermathINI);
-    Rule.Objects(AftermathINI);
-    Rule.Difficulty(AftermathINI);
-#endif
+    Rule.Process(RuleINI, false);
+    Rule.Process(AftermathINI, false);
+
+    CCINIClass mpini;
+    CCFileClass mplayerIniFile("MPLAYER.INI");
+    if (mpini.Load(mplayerIniFile, false)) {
+        Rule.Process(mpini, false);
+    }
 
     /*
     **	For civilians, remove the graphics name override from the base rules (can still be overridden in
@@ -2242,15 +2243,22 @@ bool Read_Scenario_INI(char* fname, bool)
     **	Override any rules values specified in this
     **	particular scenario file.
     */
-    Rule.General(ini);
-    Rule.Recharge(ini);
-    Rule.AI(ini);
-    Rule.Powerups(ini);
-    Rule.Land_Types(ini);
-    Rule.Themes(ini);
-    Rule.IQ(ini);
-    Rule.Objects(ini);
-    Rule.Difficulty(ini);
+    Rule.Process(ini, false);
+
+    ObjectTypeClass::Init_Clear();
+    BuildingTypeClass::Init_Clear();
+    BulletTypeClass::Init_Clear();
+    HouseTypeClass::Init_Clear();
+    TemplateTypeClass::Init_Clear();
+    OverlayTypeClass::Init_Clear();
+    SmudgeTypeClass::Init_Clear();
+    TerrainTypeClass::Init_Clear();
+    UnitTypeClass::Init_Clear();
+    VesselTypeClass::Init_Clear();
+    InfantryTypeClass::Init_Clear();
+    AnimTypeClass::Init_Clear();
+    AircraftTypeClass::Init_Clear();
+    HouseClass::Init_Clear();
 
     /*
     **	- Use ore growth and spread values from the special settings.

--- a/redalert/sdata.cpp
+++ b/redalert/sdata.cpp
@@ -358,14 +358,12 @@ short const* SmudgeTypeClass::Occupy_List(bool) const
  *=============================================================================================*/
 void SmudgeTypeClass::Init(TheaterType theater)
 {
-    if (theater != LastTheater) {
-        for (SmudgeType index = SMUDGE_FIRST; index < SMUDGE_COUNT; index++) {
-            SmudgeTypeClass const& smudge = As_Reference(index);
-            char fullname[_MAX_FNAME + _MAX_EXT]; // Fully constructed smudge data set name.
+    for (SmudgeType index = SMUDGE_FIRST; index < SMUDGE_COUNT; index++) {
+        SmudgeTypeClass const& smudge = As_Reference(index);
+        char fullname[_MAX_FNAME + _MAX_EXT]; // Fully constructed smudge data set name.
 
-            _makepath(fullname, NULL, NULL, smudge.IniName, Theaters[theater].Suffix);
-            ((void const*&)smudge.ImageData) = MFCD::Retrieve(fullname);
-        }
+        _makepath(fullname, NULL, NULL, smudge.IniName, Theaters[theater].Suffix);
+        ((void const*&)smudge.ImageData) = MFCD::Retrieve(fullname);
     }
 }
 
@@ -516,7 +514,7 @@ void SmudgeTypeClass::Draw_It(int x, int y, int data) const
  * HISTORY:                                                                                    *
  *   08/12/1994 JLB : Created.                                                                 *
  *=============================================================================================*/
-void SmudgeTypeClass::One_Time(void)
+void SmudgeTypeClass::Init_Clear(void)
 {
 }
 

--- a/redalert/tdata.cpp
+++ b/redalert/tdata.cpp
@@ -571,7 +571,7 @@ void TerrainTypeClass::Init_Heap(void)
  * HISTORY:                                                                                    *
  *   07/19/1996 JLB : Created.                                                                 *
  *=============================================================================================*/
-void TerrainTypeClass::One_Time(void)
+void TerrainTypeClass::Init_Clear(void)
 {
 }
 
@@ -592,32 +592,29 @@ void TerrainTypeClass::One_Time(void)
  *=============================================================================================*/
 void TerrainTypeClass::Init(TheaterType theater)
 {
-    if (theater != LastTheater) {
+    for (TerrainType index = TERRAIN_FIRST; index < TERRAIN_COUNT; index++) {
+        TerrainTypeClass const& terrain = As_Reference(index);
+        char fullname[_MAX_FNAME + _MAX_EXT];
 
-        for (TerrainType index = TERRAIN_FIRST; index < TERRAIN_COUNT; index++) {
-            TerrainTypeClass const& terrain = As_Reference(index);
-            char fullname[_MAX_FNAME + _MAX_EXT];
-
-            /*
+        /*
             **	Clear any existing shape pointer. All terrain is theater specific, thus if
             **	it isn't loaded in this routine, it shouldn't exist at all.
             */
-            ((void const*&)terrain.ImageData) = NULL;
+        ((void const*&)terrain.ImageData) = NULL;
 
-            if (terrain.Theater & (1 << theater)) {
+        if (terrain.Theater & (1 << theater)) {
 
-                /*
+            /*
                 **	Load in the appropriate object shape data.
                 */
-                _makepath(fullname, NULL, NULL, terrain.IniName, Theaters[theater].Suffix);
-                ((void const*&)terrain.ImageData) = MFCD::Retrieve(fullname);
+            _makepath(fullname, NULL, NULL, terrain.IniName, Theaters[theater].Suffix);
+            ((void const*&)terrain.ImageData) = MFCD::Retrieve(fullname);
 
-                IsTheaterShape = true; // Let Build_Frame know that this is a theater specific shape
-                if (terrain.RadarIcon != NULL)
-                    delete[](char*) terrain.RadarIcon;
-                ((void const*&)terrain.RadarIcon) = Get_Radar_Icon(terrain.Get_Image_Data(), 0, 1, 3);
-                IsTheaterShape = false;
-            }
+            IsTheaterShape = true; // Let Build_Frame know that this is a theater specific shape
+            if (terrain.RadarIcon != NULL)
+                delete[](char*) terrain.RadarIcon;
+            ((void const*&)terrain.RadarIcon) = Get_Radar_Icon(terrain.Get_Image_Data(), 0, 1, 3);
+            IsTheaterShape = false;
         }
     }
 }

--- a/redalert/type.h
+++ b/redalert/type.h
@@ -187,7 +187,7 @@ public:
 
     static HousesType From_Name(char const* name);
     static HouseTypeClass& As_Reference(HousesType house);
-    static void One_Time(void);
+    static void Init_Clear(void);
     static void Init_Heap(void);
 
     virtual bool Read_INI(CCINIClass& ini);
@@ -307,7 +307,7 @@ public:
                     int fullname,
                     char const* name);
 
-    static void One_Time(void);
+    static void Init_Clear(void);
 
     bool Is_Foot(void) const
     {
@@ -831,7 +831,7 @@ public:
     static BuildingTypeClass& As_Reference(StructType type);
     static StructType From_Name(char const* name);
     static void Init(TheaterType theater);
-    static void One_Time(void);
+    static void Init_Clear(void);
     static void Prep_For_Add(void);
 
     int Width(void) const;
@@ -1046,7 +1046,7 @@ public:
     static UnitType From_Name(char const* name);
     static UnitTypeClass& As_Reference(UnitType type);
     static void Init(TheaterType){};
-    static void One_Time(void);
+    static void Init_Clear(void);
     static void Prep_For_Add(void);
 
     virtual bool Read_INI(CCINIClass& ini);
@@ -1156,7 +1156,7 @@ public:
     static VesselType From_Name(char const* name);
     static VesselTypeClass& As_Reference(VesselType type);
     static void Init(TheaterType){};
-    static void One_Time(void);
+    static void Init_Clear(void);
     static void Prep_For_Add(void);
 
     virtual void Dimensions(int& width, int& height) const;
@@ -1315,7 +1315,7 @@ public:
     static InfantryType From_Name(char const* name);
     static InfantryTypeClass& As_Reference(InfantryType type);
     static void Init(TheaterType){};
-    static void One_Time(void);
+    static void Init_Clear(void);
     static void Prep_For_Add(void);
 
     virtual bool Read_INI(CCINIClass& ini);
@@ -1421,7 +1421,7 @@ public:
     static AircraftType From_Name(char const* name);
     static AircraftTypeClass& As_Reference(AircraftType a);
     static void Init(TheaterType){};
-    static void One_Time(void);
+    static void Init_Clear(void);
     static void Prep_For_Add(void);
 
     virtual void Dimensions(int& width, int& height) const;
@@ -1607,7 +1607,7 @@ public:
     static void Init_Heap(void);
     static BulletTypeClass& As_Reference(BulletType type);
     static void Init(TheaterType){};
-    static void One_Time(void);
+    static void Init_Clear(void);
 
     virtual bool Read_INI(CCINIClass& ini);
     virtual bool Create_And_Place(CELL, HousesType = HOUSE_NONE) const
@@ -1680,7 +1680,7 @@ public:
     static TerrainType From_Name(char const* name);
     static TerrainTypeClass& As_Reference(TerrainType type);
     static void Init(TheaterType theater = THEATER_TEMPERATE);
-    static void One_Time(void);
+    static void Init_Clear(void);
     static void Prep_For_Add(void);
 
     virtual COORDINATE Coord_Fixup(COORDINATE coord) const;
@@ -1743,7 +1743,7 @@ public:
     static TemplateType From_Name(char const* name);
     static TemplateTypeClass& As_Reference(TemplateType type);
     static void Init(TheaterType theater);
-    static void One_Time(void);
+    static void Init_Clear(void);
     static void Prep_For_Add(void);
 
     virtual COORDINATE Coord_Fixup(COORDINATE coord) const;
@@ -1970,7 +1970,7 @@ public:
 
     static AnimTypeClass& As_Reference(AnimType type);
     static void Init(TheaterType theater);
-    static void One_Time(void);
+    static void Init_Clear(void);
 
     virtual bool Create_And_Place(CELL, HousesType = HOUSE_NONE) const
     {
@@ -2092,7 +2092,7 @@ public:
     static OverlayType From_Name(char const* name);
     static OverlayTypeClass& As_Reference(OverlayType type);
     static void Init(TheaterType);
-    static void One_Time(void);
+    static void Init_Clear(void);
     static void Prep_For_Add(void);
 
     virtual COORDINATE Coord_Fixup(COORDINATE coord) const;
@@ -2168,7 +2168,7 @@ public:
     static SmudgeType From_Name(char const* name);
     static SmudgeTypeClass& As_Reference(SmudgeType type);
     static void Init(TheaterType);
-    static void One_Time(void);
+    static void Init_Clear(void);
     static void Prep_For_Add(void);
 
     virtual bool Create_And_Place(CELL cell, HousesType house = HOUSE_NONE) const;

--- a/redalert/udata.cpp
+++ b/redalert/udata.cpp
@@ -1034,7 +1034,7 @@ void UnitTypeClass::Prep_For_Add(void)
  * HISTORY:                                                                                    *
  *   05/28/1994 JLB : Created.                                                                 *
  *=============================================================================================*/
-void UnitTypeClass::One_Time(void)
+void UnitTypeClass::Init_Clear(void)
 {
     for (UnitType index = UNIT_FIRST; index < UNIT_COUNT; index++) {
         char fullname[_MAX_FNAME + _MAX_EXT];

--- a/redalert/vdata.cpp
+++ b/redalert/vdata.cpp
@@ -525,26 +525,18 @@ void VesselTypeClass::Dimensions(int& width, int& height) const
  * HISTORY:                                                                                    *
  *   03/20/1996 JLB : Created.                                                                 *
  *=============================================================================================*/
-void VesselTypeClass::One_Time(void)
+void VesselTypeClass::Init_Clear(void)
 {
     for (VesselType index = VESSEL_FIRST; index < VESSEL_COUNT; index++) {
         char fullname[_MAX_FNAME + _MAX_EXT];
         char buffer[_MAX_FNAME + 4];
         VesselTypeClass const& uclass = As_Reference(index);
-#ifdef FIXIT_CARRIER //	checked - ajw 9/28/98
-        if (uclass.Level != -1 || index == VESSEL_CARRIER) {
-#else
-        if (uclass.Level != -1) {
-#endif
-            //		if (uclass.IsBuildable) {
-
-            /*
+        /*
             **	Fetch the supporting data files for the unit.
             */
-            sprintf(buffer, "%sICON", uclass.Graphic_Name());
-            _makepath(fullname, NULL, NULL, buffer, ".SHP");
-            ((void const*&)uclass.CameoData) = MFCD::Retrieve(fullname);
-        }
+        sprintf(buffer, "%sICON", uclass.Graphic_Name());
+        _makepath(fullname, NULL, NULL, buffer, ".SHP");
+        ((void const*&)uclass.CameoData) = MFCD::Retrieve(fullname);
 
         /*
         **	Fetch a pointer to the unit's shape data.


### PR DESCRIPTION
The issue is that RulesClass data isn't reset between map loads. The only data reset is the data defined in Rules.INI, Aftermath.INi and MPlayer.INI. Certain Counterstrike levels like 'Legacy of Tesla' give the Allies Mobile Radar Jammer unit a Tesla weapon. After playing the map the Mobile Radar Jammer will have Tesla weapon until the game is exited to desktop.

This code also fixes the issue of buildings and vessels with BuildLevel set to -1 not loading cameo data. It also fixes the issue that MPLAYER.INI rules changes overwrite map ones.