### PR TITLE
[RA}Evacuation logic enhancements and MP fix

### DIFF
--- a/redalert/aircraft.cpp
+++ b/redalert/aircraft.cpp
@@ -111,13 +111,10 @@
  *=============================================================================================*/
 static bool _Counts_As_Civ_Evac(ObjectClass const* candidate)
 {
-    if (Scen.DisableEvac) {
-        return false;
-    }
-
-    // If it's a multiplayer game and the scenario doesn't have 
-    // evacuate in multiplayer keyword defined, don't evacuate
-    if (Scen.EvacInMP == false && Session.Type != GAME_NORMAL) {
+    /*
+    **	If evac logic isn't enabled, no candidate can be evacuated.
+    */
+    if (!Scen.EnableEvac) {
         return false;
     }
 

--- a/redalert/aircraft.cpp
+++ b/redalert/aircraft.cpp
@@ -111,6 +111,16 @@
  *=============================================================================================*/
 static bool _Counts_As_Civ_Evac(ObjectClass const* candidate)
 {
+    if (Scen.DisableEvac) {
+        return false;
+    }
+
+    // If it's a multiplayer game and the scenario doesn't have 
+    // evacuate in multiplayer keyword defined, don't evacuate
+    if (Scen.EvacInMP == false && Session.Type != GAME_NORMAL) {
+        return false;
+    }
+
     /*
     **	If the candidate pointer is missing, then return with failure code.
     */

--- a/redalert/scenario.cpp
+++ b/redalert/scenario.cpp
@@ -164,7 +164,9 @@ ScenarioClass::ScenarioClass(void)
     , IsNoMapSel(false)
     , IsTruckCrate(false)
     , IsMoneyTiberium(false)
-    ,
+    , EvacInMP(false)
+    , DisableEvac(false)
+    , 
 #ifdef FIXIT_VERSION_3 //	For endgame auto-sonar pulse.
 #define AUTOSONAR_PERIOD TICKS_PER_SECOND * 40
     AutoSonarTimer(AUTOSONAR_PERIOD)
@@ -2302,6 +2304,8 @@ bool Read_Scenario_INI(char* fname, bool)
     Scen.IsTruckCrate = ini.Get_Bool(BASIC, "TruckCrate", Scen.IsTruckCrate);
     Scen.IsMoneyTiberium = ini.Get_Bool(BASIC, "FillSilos", Scen.IsMoneyTiberium);
     Scen.Percent = ini.Get_Int(BASIC, "Percent", Scen.Percent);
+    Scen.EvacInMP = ini.Get_Int(BASIC, "EvacInMP", Scen.EvacInMP);
+    Scen.DisableEvac = ini.Get_Int(BASIC, "DisableEvac", Scen.DisableEvac);
 
     /*
     **	Read in the specific information for each of the house types.  This creates

--- a/redalert/scenario.cpp
+++ b/redalert/scenario.cpp
@@ -784,6 +784,8 @@ void Clear_Scenario(void)
     Scen.CarryOverPercent = 0;
     Scen.TransitTheme = THEME_NONE;
     Scen.Percent = 0;
+    Scen.EvacInMP = false;
+    Scen.DisableEvac = false;
 
     memset(Scen.GlobalFlags, 0, sizeof(Scen.GlobalFlags));
 
@@ -2304,8 +2306,8 @@ bool Read_Scenario_INI(char* fname, bool)
     Scen.IsTruckCrate = ini.Get_Bool(BASIC, "TruckCrate", Scen.IsTruckCrate);
     Scen.IsMoneyTiberium = ini.Get_Bool(BASIC, "FillSilos", Scen.IsMoneyTiberium);
     Scen.Percent = ini.Get_Int(BASIC, "Percent", Scen.Percent);
-    Scen.EvacInMP = ini.Get_Int(BASIC, "EvacInMP", Scen.EvacInMP);
-    Scen.DisableEvac = ini.Get_Int(BASIC, "DisableEvac", Scen.DisableEvac);
+    Scen.EvacInMP = ini.Get_Bool(BASIC, "EvacInMP", Scen.EvacInMP);
+    Scen.DisableEvac = ini.Get_Bool(BASIC, "DisableEvac", Scen.DisableEvac);
 
     /*
     **	Read in the specific information for each of the house types.  This creates

--- a/redalert/scenario.cpp
+++ b/redalert/scenario.cpp
@@ -164,9 +164,8 @@ ScenarioClass::ScenarioClass(void)
     , IsNoMapSel(false)
     , IsTruckCrate(false)
     , IsMoneyTiberium(false)
-    , EvacInMP(false)
-    , DisableEvac(false)
-    , 
+    , EnableEvac(true)
+    ,
 #ifdef FIXIT_VERSION_3 //	For endgame auto-sonar pulse.
 #define AUTOSONAR_PERIOD TICKS_PER_SECOND * 40
     AutoSonarTimer(AUTOSONAR_PERIOD)
@@ -784,8 +783,10 @@ void Clear_Scenario(void)
     Scen.CarryOverPercent = 0;
     Scen.TransitTheme = THEME_NONE;
     Scen.Percent = 0;
-    Scen.EvacInMP = false;
-    Scen.DisableEvac = false;
+    /*
+    ** Default setting for evac depends on session type.
+    */
+    Scen.EnableEvac = Session.Type == GAME_NORMAL ? true : false;
 
     memset(Scen.GlobalFlags, 0, sizeof(Scen.GlobalFlags));
 
@@ -2306,8 +2307,7 @@ bool Read_Scenario_INI(char* fname, bool)
     Scen.IsTruckCrate = ini.Get_Bool(BASIC, "TruckCrate", Scen.IsTruckCrate);
     Scen.IsMoneyTiberium = ini.Get_Bool(BASIC, "FillSilos", Scen.IsMoneyTiberium);
     Scen.Percent = ini.Get_Int(BASIC, "Percent", Scen.Percent);
-    Scen.EvacInMP = ini.Get_Bool(BASIC, "EvacInMP", Scen.EvacInMP);
-    Scen.DisableEvac = ini.Get_Bool(BASIC, "DisableEvac", Scen.DisableEvac);
+    Scen.EnableEvac = ini.Get_Bool(BASIC, "EnableEvac", Scen.EnableEvac);
 
     /*
     **	Read in the specific information for each of the house types.  This creates

--- a/redalert/scenario.h
+++ b/redalert/scenario.h
@@ -249,7 +249,7 @@ public:
     unsigned IsToInherit : 1;
 
     /*
-    **	If Tanya or a civilian is to be automatically evacuated when they enter
+    **	If Tanya is to be automatically evacuated when they enter
     **	a transport vehicle, then this flag will be true.
     */
     unsigned IsTanyaEvac : 1;
@@ -309,6 +309,12 @@ public:
     **	this flag will be set to true.
     */
     unsigned IsMoneyTiberium : 1;
+
+    /* With this disabled the units will not be evacuated in single player*/
+    bool DisableEvac;
+
+    /* by default evacuate is disabled for multiplayer*/
+    bool EvacInMP;
 
     /*
     **	This is the fading countdown timer.  As this timer counts down, the

--- a/redalert/scenario.h
+++ b/redalert/scenario.h
@@ -310,11 +310,10 @@ public:
     */
     unsigned IsMoneyTiberium : 1;
 
-    /* With this disabled the units will not be evacuated in single player*/
-    bool DisableEvac;
-
-    /* by default evacuate is disabled for multiplayer*/
-    bool EvacInMP;
+    /* 
+    ** When set to false, units will not be evacuated no matter what
+    */
+    unsigned EnableEvac : 1;
 
     /*
     **	This is the fading countdown timer.  As this timer counts down, the


### PR DESCRIPTION
The game contains evacuation logic where certain units are hard-coded to evacuate when loaded into a Chinook.

this PR changes:
-Evacuation is now disabled by default for MP.
-You can now disable evacuation logic completely via the map file [BASIC]DisableEvac=true/false keyword. This is useful for single player
-You can enable MP evacuation completely via the map file [BASIC]EvacinMP=true/false keyword. This will be useful when coop mode is added.

In the future we should add a per-infantry unit option that can be modified in rules files and map file.