### PR TITLE
Restore 3.03 MP unit spawn behavior for official maps.

### DIFF
--- a/redalert/scenario.cpp
+++ b/redalert/scenario.cpp
@@ -3104,7 +3104,11 @@ static void Create_Units(bool official)
     **	loop verifies that.
     */
 
+#ifdef REMASTER_BUILD
     const unsigned int MAX_STORED_WAYPOINTS = 26;
+#else
+    const unsigned int MAX_STORED_WAYPOINTS = 8;
+#endif
 
     bool taken[MAX_STORED_WAYPOINTS];
     CELL waypts[MAX_STORED_WAYPOINTS];
@@ -3129,8 +3133,14 @@ static void Create_Units(bool official)
     int look_for = Session.Players.Count();
 #endif
 
+#ifdef REMASTER_BUILD
     for (int waycount = 0; waycount < 26; waycount++) {
-        //	for (int waycount = 0; waycount < max(4, Session.Players.Count()+Session.Options.AIPlayers); waycount++) {
+#else
+    // This is needed for original game behavior, for example in original game you only spawn at corner spawns
+    // in 1vs1 on A Path Beyond as the corner spawns are the first 4, with the remaster logic you also spawn at
+    // the other 4 spawns in 1vs1 randomly
+    for (int waycount = 0; waycount < max(4, Session.Players.Count() + Session.Options.AIPlayers); waycount++) {
+#endif
         if (Scen.Waypoint[waycount] != -1) {
             waypts[num_waypts] = Scen.Waypoint[waycount];
             taken[num_waypts] = false;


### PR DESCRIPTION
The remaster code change the MP unit spawn logic even in non-remaster build.

This patch restores 3.03 before (checked via diassembly). Currently for all maps 26 waypoints are considered for spawn locations, with patch only 8 waypoints are considered max and for official maps only the first 4 spawn locations are considered first. The old behavior is kept for remaster.

This fix spawning on official maps like A Path Beyond. In the original game you only spawn at the corner positions in a 1vs1 game because the first 4 spawn waypoints are corner positions. Currently you also spawn at other spawn points (spawn point 5-8). This breaks pro play as pros have build orders for the corner positions only.

if players want to play at the non-corner positions in 1vs1 they can set [BASIC]Official=false in the map file or a copy of the map file, this will make the game randomly consider the first 8 and not just 4 spawn points.