### PR TITLE
Fix graphical glitching by setting correct drawing macros for non-remaster builds

### DIFF
--- a/redalert/defines.h
+++ b/redalert/defines.h
@@ -130,8 +130,13 @@
 #endif
 
 // Test to see if partial object drawing is any faster.
+#ifdef REMASTER_BUILD
 //#define	PARTIAL
 #define SORTDRAW
+#else
+#define PARTIAL
+//#define SORTDRAW
+#endif
 
 /**********************************************************************
 **	If the scenario editor to to be active in this build then uncomment

--- a/redalert/function.h
+++ b/redalert/function.h
@@ -133,6 +133,7 @@ bool PlayMpegMovie(const char* name);
 #endif
 
 #include "externs.h"
+#include "keyframe.h"
 
 extern int Get_CD_Drive(void);
 extern void Fatal(char const* message, ...);


### PR DESCRIPTION
This fixes corpses drawing over units and most of the graphical glitching with chrono vortex, see issue  #456.

There still is some minor redraw glitching with Chrono Vortex when it moves and the sidebar area around the sell/repair/map icons still glitch up when you move  your cursor around them or open the options menu.

Looks like some redrawing logic still needs to be fixed.