### PR TITLE
Fix Tesla Coil building crew spawning one cell above foundation

### DIFF
--- a/redalert/building.cpp
+++ b/redalert/building.cpp
@@ -3794,6 +3794,12 @@ int BuildingClass::Mission_Deconstruction(void)
                     if (infantry != NULL) {
                         ScenarioInit++;
                         COORDINATE coord = Coord_Add(Center_Coord(), XYP_COORD(0, -12));
+
+                        /* extra check to prevent building crew for Tesla Coil spawning
+                           one cell above building foundation */
+                        if (*this == STRUCT_TESLA) {
+                            coord = Map[coord].Adjacent_Cell(FACING_S)->Cell_Coord();
+                        }
                         coord = Map[coord].Closest_Free_Spot(coord, false);
 
                         if (infantry->Unlimbo(coord, DIR_N)) {

--- a/tiberiandawn/building.cpp
+++ b/tiberiandawn/building.cpp
@@ -4104,6 +4104,12 @@ int BuildingClass::Mission_Deconstruction(void)
                     if (infantry) {
                         ScenarioInit++;
                         COORDINATE coord = Coord_Add(Center_Coord(), XYP_COORD(0, -12));
+
+                        /* extra check to prevent building crew for Obelisk or AGT spawning
+                           one cell above building foundation */
+                        if (*this == STRUCT_ATOWER || *this == STRUCT_OBELISK) {
+                            coord = Map[coord].Adjacent_Cell(FACING_S)->Cell_Coord();
+                        }
                         coord = Map[Coord_Cell(coord)].Closest_Free_Spot(coord, false);
 
                         if (infantry->Unlimbo(coord, DIR_N)) {


### PR DESCRIPTION
Building crew spawn one cell above building, so they can get stuck in cliffs and walls.