### PR TITLE
Workaround transparency issues with color key

### DIFF
--- a/common/video_sdl2.cpp
+++ b/common/video_sdl2.cpp
@@ -420,6 +420,12 @@ void Set_DD_Palette(void* rpalette)
         colors[i].a = 0xFF;
     }
 
+    /*
+    ** First color is transparent. This needs to be set so that hardware cursor has transparent
+    ** surroundings when converting from 8-bit to 32-bit.
+    */
+    colors[0].a = 0;
+
     SDL_SetPaletteColors(palette, colors, 0, 256);
 
     /*


### PR DESCRIPTION
The previous fix for Intel (or older SDL2 on Linux) was only
partial and instead of having a completely invisible cursor because
the alpha was zero it had an opaque black background.

This does not happen to me on AMDGPU on Ubuntu 20.10 so I'm
guessing it's a slight change in SDL2 behavior how to handle
transparency when converting form 8-bit paletted surface to
ARGB8888.

We now enforce the first color in the palette to be truly
transparent and when converting the surface regardless which way
the SDL2 library prefers alpha to be handled both are set.