### PR TITLE
[RA]Add support for skirmish savegames

### DIFF
--- a/redalert/function.h
+++ b/redalert/function.h
@@ -505,7 +505,7 @@ bool Load_Misc_Values(Straw& file);
 bool Save_Misc_Values(Pipe& file);
 bool Load_MPlayer_Values(Straw& file);
 bool Save_MPlayer_Values(Pipe& file);
-bool Get_Savefile_Info(int id, char* buf, unsigned* scenp, HousesType* housep);
+bool Get_Savefile_Info(int id, char* buf, unsigned* scenp, HousesType* housep, GameType *session_type);
 bool Load_Game(int id);
 bool Load_Game(const char* file_name);
 // bool Read_Object (void * ptr, int base_size, int class_size, FileClass & file, void * vtable);  // Original

--- a/redalert/goptions.cpp
+++ b/redalert/goptions.cpp
@@ -129,16 +129,20 @@ void GameOptionsClass::Process(void)
         int text = _constants[index].Text;
         buttonsel[index] = NULL;
 
-        if (Session.Type != GAME_NORMAL && !_constants[index].Multiplay) {
+        if (!(Session.Type == GAME_NORMAL || Session.Type == GAME_SKIRMISH) && !_constants[index].Multiplay) {
             continue;
         }
 
-        if ((Session.Type == GAME_SKIRMISH || Session.Type == GAME_INTERNET) && text == TXT_SAVE_MISSION) {
+        if (Session.Type == GAME_SKIRMISH && text == TXT_RESTATE_MISSION) {
+            continue;
+        }
+
+        if ((Session.Type == GAME_INTERNET) && text == TXT_SAVE_MISSION) {
             continue;
         }
 
 #ifdef FIXIT_VERSION_3
-        if (Session.Type != GAME_NORMAL && (num_players < 2) && text == TXT_SAVE_MISSION) {
+        if (!(Session.Type == GAME_NORMAL || Session.Type == GAME_SKIRMISH) && (num_players < 2) && text == TXT_SAVE_MISSION) {
             continue;
         }
 #else
@@ -150,11 +154,7 @@ void GameOptionsClass::Process(void)
 #endif // FIXIT_MULTI_SAVE
 #endif
 
-        if (Session.Type == GAME_SKIRMISH && text == TXT_DELETE_MISSION) {
-            continue;
-        }
-
-        if (Session.Type != GAME_NORMAL && text == TXT_DELETE_MISSION) {
+        if ( !(Session.Type == GAME_NORMAL || Session.Type == GAME_SKIRMISH)  && text == TXT_DELETE_MISSION) {
             text = TXT_RESIGN;
         }
 
@@ -468,7 +468,7 @@ void GameOptionsClass::Process(void)
 
             case (BUTTON_SAVE):
                 display = true;
-                if (Session.Type == GAME_NORMAL) {
+                if (Session.Type == GAME_NORMAL || Session.Type == GAME_SKIRMISH) {
                     LoadOptionsClass(LoadOptionsClass::SAVE).Process();
 
                 } else {
@@ -479,7 +479,7 @@ void GameOptionsClass::Process(void)
 
             case (BUTTON_DELETE):
                 display = true;
-                if (Session.Type != GAME_NORMAL) {
+                if (! (Session.Type == GAME_NORMAL || Session.Type == GAME_SKIRMISH)) {
                     if (Surrender_Dialog(TXT_SURRENDER)) {
                         OutList.Add(EventClass(EventClass::DESTRUCT));
                     }

--- a/redalert/loaddlg.cpp
+++ b/redalert/loaddlg.cpp
@@ -638,6 +638,7 @@ void LoadOptionsClass::Fill_List(ListClass* list)
     char descr[DESCRIP_MAX + 32];
     unsigned scenario; // scenario #
     HousesType house;  // house
+    GameType session_type;
     Find_File_Data* ff = nullptr;
     int id;
 
@@ -673,7 +674,7 @@ void LoadOptionsClass::Fill_List(ListClass* list)
             /*
             ** get the game's info; if success, add it to the list
             */
-            bool ok = Get_Savefile_Info(id, descr, &scenario, &house);
+            bool ok = Get_Savefile_Info(id, descr, &scenario, &house, &session_type);
 
             fdata = new FileEntryClass;
 
@@ -681,8 +682,10 @@ void LoadOptionsClass::Fill_List(ListClass* list)
             if (!ok) {
                 strcpy(fdata->Descr, Text_String(TXT_OLD_GAME));
             } else {
-                if (house == HOUSE_USSR || house == HOUSE_UKRAINE) {
+                if (house == HOUSE_BAD ||  house == HOUSE_USSR || house == HOUSE_UKRAINE) {
                     sprintf(fdata->Descr, "(%s) ", Text_String(TXT_SOVIET));
+                } else if (session_type == GAME_SKIRMISH) {
+                    sprintf(fdata->Descr, "(%s) ", "Skirmish");
                 } else {
                     sprintf(fdata->Descr, "(%s) ", Text_String(TXT_ALLIES));
                 }

--- a/redalert/saveload.cpp
+++ b/redalert/saveload.cpp
@@ -397,6 +397,7 @@ bool Save_Game(const char* file_name, const char* descr)
     fpipe.Put(&scenario, sizeof(scenario));
 
     fpipe.Put(&house, sizeof(house));
+    fpipe.Put(&Session.Type, sizeof(Session.Type));
 
     /*
     **	Save the save-game version, for loading verification
@@ -513,6 +514,7 @@ bool Load_Game(const char* file_name)
     int i;
     unsigned scenario;
     HousesType house;
+    GameType session_type;
     char descr_buf[DESCRIP_MAX];
     int load_net = 0; // 1 = save network/modem game
 
@@ -547,6 +549,10 @@ bool Load_Game(const char* file_name)
     }
 
     if (fstraw.Get(&house, sizeof(house)) != sizeof(house)) {
+        return (false);
+    }
+
+    if (fstraw.Get(&session_type, sizeof(session_type)) != sizeof(session_type)) {
         return (false);
     }
 
@@ -613,6 +619,10 @@ bool Load_Game(const char* file_name)
     bstraw.Key(&FastKey, BlowfishEngine::MAX_KEY_LENGTH);
     bstraw.Get_From(fstraw);
     straw.Get_From(bstraw);
+
+    /* set the correct session type, as loaded from the header
+        this is needed for skirmish games */
+    Session.Type = session_type;
 
     /*
     **	Clear the scenario so we start fresh; this calls the Init_Clear() routine
@@ -1429,7 +1439,7 @@ void Decode_All_Pointers(void)
  * HISTORY:                                                                *
  *   01/12/1995 BR : Created.                                              *
  *=========================================================================*/
-bool Get_Savefile_Info(int id, char* buf, unsigned* scenp, HousesType* housep)
+bool Get_Savefile_Info(int id, char* buf, unsigned* scenp, HousesType* housep, GameType* session_type)
 {
     char name[_MAX_FNAME + _MAX_EXT];
     unsigned long version;
@@ -1458,6 +1468,10 @@ bool Get_Savefile_Info(int id, char* buf, unsigned* scenp, HousesType* housep)
     }
 
     if (straw.Get(housep, sizeof(HousesType)) != sizeof(HousesType)) {
+        return (false);
+    }
+
+    if (straw.Get(session_type, sizeof(GameType)) != sizeof(GameType)) {
         return (false);
     }
 


### PR DESCRIPTION
The game supports multiplayer saves for the 'emergency' save feature, but has no support for Skirmish. This code changes:

-Save/Load code to load the session gametype, else the gametype gets set to GAME_NORMAL (single player) for skirmish savegames.
-Adds a GameType field to the savegame header so in the menu it can prepend (Skirmish) to the savegame name, like is done with (Allies) and (Soviet) for single player missions
-Modifies the ingame options menu to show the save/load/delete mission buttons.