### PR TITLE
Fix Chrono vortex staying active in certain cases

### DIFF
--- a/redalert/scenario.cpp
+++ b/redalert/scenario.cpp
@@ -749,6 +749,7 @@ void Post_Load_Game(int load_multi)
 void Clear_Scenario(void)
 {
     // TCTCTC -- possibly just use in-place new of scenario object?
+    ChronalVortex.Stop();
 
     Scen.MissionTimer = 0;
     Scen.MissionTimer.Stop();


### PR DESCRIPTION
For example if you play a mission, then via the Abort Mission menu restart the mission the Chrono Vortex stays active.

You can test it via this custom mission that replaces Allies mission 1. Use the Chronosphere a few times and then the Chrono Vortex appears (it's modded to increase the percentage chance to 90%).

[scg01ea.zip](https://github.com/TheAssemblyArmada/Vanilla-Conquer/files/5822549/scg01ea.zip)
