### PR TITLE
Add support for settings house color and country inside map file

### DIFF
--- a/redalert/ccini.cpp
+++ b/redalert/ccini.cpp
@@ -967,6 +967,30 @@ bool CCINIClass::Put_VQType(char const* section, char const* entry, VQType value
     return (Put_String(section, entry, VQName[value]));
 }
 
+PlayerColorType CCINIClass::Get_PlayerColorType(char const* section, char const* entry, PlayerColorType defvalue) const
+{
+    char buffer[128];
+
+    if (Get_String(section, entry, "", buffer, sizeof(buffer))) {
+        for (PlayerColorType c = PCOLOR_FIRST; c < 8; c++) {
+            if (stricmp(buffer, ColorNames[c]) == 0) {
+                return (c);
+            }
+        }
+    }
+    return (defvalue);
+}
+
+
+bool CCINIClass::Put_PlayerColorType(char const* section, char const* entry, PlayerColorType value)
+{
+    if (value == PCOLOR_NONE) {
+        return (Put_String(section, entry, "<none>"));
+    }
+    return (Put_String(section, entry, ColorNames[value]));
+}
+
+
 /***********************************************************************************************
  * CCINIClass::Get_TheaterType -- Fetch the theater type from the INI database.                *
  *                                                                                             *

--- a/redalert/ccini.h
+++ b/redalert/ccini.h
@@ -74,6 +74,7 @@ public:
     ThemeType Get_ThemeType(char const* section, char const* entry, ThemeType defvalue) const;
     TriggerTypeClass* Get_TriggerType(char const* section, char const* entry) const;
     VQType Get_VQType(char const* section, char const* entry, VQType defvalue) const;
+    PlayerColorType Get_PlayerColorType(char const* section, char const* entry, PlayerColorType defvalue) const;
     VocType Get_VocType(char const* section, char const* entry, VocType defvalue) const;
     WarheadType Get_WarheadType(char const* section, char const* entry, WarheadType defvalue) const;
     WeaponType Get_WeaponType(char const* section, char const* entry, WeaponType defvalue) const;
@@ -89,6 +90,7 @@ public:
     bool Put_Lepton(char const* section, char const* entry, LEPTON value);
     bool Put_MPHType(char const* section, char const* entry, MPHType value);
     bool Put_VQType(char const* section, char const* entry, VQType value);
+    bool Put_PlayerColorType(char const* section, char const* entry, PlayerColorType value);
     bool Put_OverlayType(char const* section, char const* entry, OverlayType value);
     bool Put_Owners(char const* section, char const* entry, long value);
     bool Put_SourceType(char const* section, char const* entry, SourceType value);

--- a/redalert/externs.h
+++ b/redalert/externs.h
@@ -416,6 +416,8 @@ extern bool LogDump_Print;
 
 extern unsigned int IsTheaterShape;
 
+extern char* ColorNames[8];
+
 extern void Reset_Theater_Shapes(void);
 extern TheaterType LastTheater;
 void Coordinate_Remap(GraphicViewPortClass* inbuffer, int x, int y, int width, int height, unsigned char* remap_table);

--- a/redalert/globals.cpp
+++ b/redalert/globals.cpp
@@ -713,3 +713,5 @@ bool bAutoSonarPulse = false;
 // ST - 5/14/2019
 bool RunningAsDLL = false;
 bool RunningFromEditor = false;
+
+char* ColorNames[8] = {"Yellow", "LtBlue", "Red", "Green", "Orange", "Grey", "Blue", "Brown"};

--- a/redalert/house.cpp
+++ b/redalert/house.cpp
@@ -7434,6 +7434,8 @@ void HouseClass::Read_INI(CCINIClass& ini)
         hname = HouseTypeClass::As_Reference(index).IniName;
 
         p = new HouseClass(index);
+        p->RemapColor = ini.Get_PlayerColorType(hname, "Color", p->RemapColor);
+        p->ActLike = ini.Get_HousesType(hname, "Country", p->ActLike);
         p->Control.TechLevel = ini.Get_Int(hname, "TechLevel", Scen.Scenario);
         p->Control.MaxBuilding = ini.Get_Int(hname, "MaxBuilding", p->Control.MaxBuilding);
         p->Control.MaxUnit = ini.Get_Int(hname, "MaxUnit", p->Control.MaxUnit);

--- a/redalert/queue.cpp
+++ b/redalert/queue.cpp
@@ -96,7 +96,6 @@ bool bReconnectDialogCancelled;
 static unsigned long GameCRC;
 static unsigned long CRC[32] = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
                                 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
-static char* ColorNames[8] = {"Yellow", "LtBlue", "Red", "Green", "Orange", "Grey", "Blue", "Brown"};
 
 //...........................................................................
 // Mono debugging variables:

--- a/redalert/score.cpp
+++ b/redalert/score.cpp
@@ -360,7 +360,8 @@ void ScoreClass::Presentation(void)
     struct Fame hallfame[NUMFAMENAMES];
     void* oldfont;
     int oldfontxspacing = FontXSpacing;
-    int house = (PlayerPtr->Class->House == HOUSE_USSR || PlayerPtr->Class->House == HOUSE_UKRAINE); // 0 or 1
+    int house = (PlayerPtr->Class->House == HOUSE_USSR || PlayerPtr->Class->House == HOUSE_UKRAINE
+                 || PlayerPtr->Class->House == HOUSE_BAD); // 0  for allies, 1 for soviet
     char inter_pal[15];
     sprintf(inter_pal, "SCORPAL1.PAL");
 
@@ -459,7 +460,12 @@ void ScoreClass::Presentation(void)
     int leadership = 0;
     for (int index = 0; index < Logic.Count(); index++) {
         ObjectClass* object = Logic[index];
-        HousesType owner = object->Owner();
+        if (object->Owner() == HOUSE_NONE) {
+            continue;
+        }
+        // for the player we get his actual house, for other houses we get their ActLike value (country
+        HousesType owner = object->Owner() == PlayerPtr->Class.Raw() ? object->Owner()
+                                                                     : HouseClass::As_Pointer(object->Owner())->ActLike;
         if ((house) && (owner == HOUSE_USSR || owner == HOUSE_BAD || owner == HOUSE_UKRAINE)) {
             leadership++;
         } else {
@@ -472,6 +478,8 @@ void ScoreClass::Presentation(void)
 
     for (HousesType hous = HOUSE_SPAIN; hous <= HOUSE_BAD; hous++) {
         HouseClass* hows = HouseClass::As_Pointer(hous);
+        // for the player we get his actual house, for other houses we get their ActLike value (country
+        hows = hows == PlayerPtr ? hows : HouseClass::As_Pointer(hows->ActLike);
         if (hous == HOUSE_USSR || hous == HOUSE_BAD || hous == HOUSE_UKRAINE) {
             NKilled += hows->UnitsLost;
             NBKilled += hows->BuildingsLost;


### PR DESCRIPTION
This change affects single player houses only because Assign_Houses overwrites the color and country for multiplayer houses.

This change adds reading [<house_name>]Color=<PlayerColorType> and [<house_name>]Country=<HousesType> to the game. Example:

[Greece]
TechLevel=12
Credits=555
Color=Orange
Country=BadGuy

Country is controlled by HouseClass->ActLike and Color by HouseClass->RemapColor.

This change also adds CCINIClass functions to read and write PlayerColorType and it updates the single player score screen logic so the actual house is used for the player and the country (ActLike) is used for the other houses. This can be used for missions where you are Soviet but play as Allies. Might need to update the sidebar logic for that. Example:

House is Soviet, country is Spain:
-Set sidebar, briefing screen, savegame info header, score screen to soviet
-Set actual ingame build options and stuff like unit response sounds to allies.
