### PR TITLE
Set CI fetch depth for rev, checkout HEAD for hash

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -17,6 +17,8 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
         
     - name: Set Git Info
       id: gitinfo

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -13,6 +13,8 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
         
     - name: Set Git Info
       id: gitinfo
@@ -59,6 +61,8 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
         
     - name: Set Git Info
       id: gitinfo

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,6 +13,8 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
         
     - uses: ilammy/msvc-dev-cmd@v1.4.1
       with:
@@ -59,6 +61,8 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: 'true'
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
         
     - uses: ilammy/msvc-dev-cmd@v1.4.1
       with:

--- a/cmake/GitWatcher.cmake
+++ b/cmake/GitWatcher.cmake
@@ -197,6 +197,8 @@ function(GetGitState _working_dir)
     RunGitCommand(rev-list --count ${object})
     if(exit_code EQUAL 0)
         set(ENV{GIT_REV_LIST_COUNT} ${output})
+    else()
+        set(ENV{GIT_REV_LIST_COUNT} "0")
     endif()
 
     RunGitCommand(describe --tags ${object})


### PR DESCRIPTION
Not setting depth invalidated revision counting and the checkout workflow defaults to a merge commit so the hash was wrong in pull requests.