### PR TITLE
Implements a common Debug_String_Log function.

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -26,6 +26,7 @@ set(COMMON_SRC
     crc.cpp
     crew.cpp
     cstraw.cpp
+    debugstring.cpp
     delay.cpp
     dipthong.cpp
     drawbuff.cpp

--- a/common/debugstring.cpp
+++ b/common/debugstring.cpp
@@ -1,0 +1,77 @@
+#include <assert.h>
+#include <stdarg.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+static class DebugStateClass
+{
+public:
+    DebugStateClass()
+        : File(nullptr)
+    {
+        /* Windows doesn't attach to the console by default so printing to stderr does nothing. */
+#ifdef _WIN32
+        /* Attach to the console that started us if any */
+        if (AttachConsole(ATTACH_PARENT_PROCESS)) {
+            /* We attached successfully, lets redirect IO to the consoles handles */
+            freopen("CONIN$", "r", stdin);
+            freopen("CONOUT$", "w", stdout);
+            freopen("CONOUT$", "w", stderr);
+        }
+#endif
+    }
+
+    ~DebugStateClass()
+    {
+        if (File != nullptr) {
+            fclose(File);
+        }
+
+        File = nullptr;
+    }
+
+    FILE* File;
+} DebugState;
+
+/**
+ * Main log function, intended to be used from behind macros that pass in file and line details.
+ */
+void Debug_String_Log(unsigned level, const char* file, int line, const char* fmt, ...)
+{
+    static const char* levels[] = {"NONE", "FATAL", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"};
+    assert(level <= 6);
+
+    /* If we have a file pointer set we are logging to a file */
+    if (DebugState.File != nullptr) {
+        va_list args;
+        fprintf(DebugState.File, "%-5s %s:%d: ", levels[level], file, line);
+        va_start(args, fmt);
+        vfprintf(DebugState.File, fmt, args);
+        fprintf(DebugState.File, "\n");
+        va_end(args);
+        fflush(DebugState.File);
+    }
+
+    /* Don't print file and line numbers to stderr to avoid clogging it up with too much info */
+    va_list args;
+    fprintf(stderr, "%-5s: ", levels[level]);
+    va_start(args, fmt);
+    vfprintf(stderr, fmt, args);
+    fprintf(stderr, "\n");
+    va_end(args);
+    fflush(stderr);
+}
+
+void Debug_String_File(const char* file)
+{
+    if (DebugState.File != nullptr) {
+        fclose(DebugState.File);
+    }
+
+    DebugState.File = fopen(file, "w");
+}

--- a/common/debugstring.h
+++ b/common/debugstring.h
@@ -1,0 +1,80 @@
+// TiberianDawn.DLL and RedAlert.dll and corresponding source code is free
+// software: you can redistribute it and/or modify it under the terms of
+// the GNU General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+
+// TiberianDawn.DLL and RedAlert.dll and corresponding source code is distributed
+// in the hope that it will be useful, but with permitted additional restrictions
+// under Section 7 of the GPL. See the GNU General Public License in LICENSE.TXT
+// distributed with this program. You should have received a copy of the
+// GNU General Public License along with permitted additional restrictions
+// with this program. If not, see https://github.com/electronicarts/CnC_Remastered_Collection
+#ifndef COMMON_DEBUGSTRING_H
+#define COMMON_DEBUGSTRING_H
+
+/*
+** If we aren't building a debug build, then don't even expose the logging interface.
+*/
+#ifdef _DEBUG
+void Debug_String_Log(unsigned level, const char* file, int line, const char* fmt, ...);
+void Debug_String_File(const char* file);
+#else
+#define Debug_String_Log(level, file, line, fmt, ...) ((void)0)
+#define Debug_String_File(file)                       ((void)0)
+#endif
+
+/* Default to debug logging */
+#ifndef LOGGING_LEVEL
+#define LOGGING_LEVEL 5
+#endif
+
+#define LOGLEVEL_NONE  0
+#define LOGLEVEL_FATAL 1
+#define LOGLEVEL_ERROR 2
+#define LOGLEVEL_WARN  3
+#define LOGLEVEL_INFO  4
+#define LOGLEVEL_DEBUG 5
+#define LOGLEVEL_TRACE 6
+
+/* Conditionally define the function like macros for logging levels, allows only certain logging to be compiled into client program. */
+#if LOGLEVEL_TRACE <= LOGGING_LEVEL && defined _DEBUG
+#define DBG_TRACE(x, ...) Debug_String_Log(LOGLEVEL_TRACE, __FILE__, __LINE__, ##__VA_ARGS__)
+#else
+#define DBG_TRACE(x, ...) ((void)0)
+#endif
+
+#if LOGLEVEL_DEBUG <= LOGGING_LEVEL && defined _DEBUG
+#define DBG_LOG(x, ...) Debug_String_Log(LOGLEVEL_DEBUG, __FILE__, __LINE__, x, ##__VA_ARGS__)
+#else
+#define DBG_LOG(x, ...) ((void)0)
+#endif
+
+#if LOGLEVEL_INFO <= LOGGING_LEVEL && defined _DEBUG
+#define DBG_INFO(x, ...) Debug_String_Log(LOGLEVEL_INFO, __FILE__, __LINE__, x, ##__VA_ARGS__)
+#else
+#define DBG_INFO(x, ...) ((void)0)
+#endif
+
+#if LOGLEVEL_WARN <= LOGGING_LEVEL && defined _DEBUG
+#define DBG_WARN(x, ...) Debug_String_Log(LOGLEVEL_WARN, __FILE__, __LINE__, x, ##__VA_ARGS__)
+#else
+#define DBG_WARN(x, ...) ((void)0)
+#endif
+
+#if LOGLEVEL_ERROR <= LOGGING_LEVEL && defined _DEBUG
+#define DBG_ERROR(x, ...) Debug_String_Log(LOGLEVEL_ERROR, __FILE__, __LINE__, x, ##__VA_ARGS__)
+#else
+#define DBG_ERROR(x, ...) ((void)0)
+#endif
+
+#if LOGLEVEL_FATAL <= LOGGING_LEVEL && defined _DEBUG
+#define DBG_FATAL(x, ...)                                                                                              \
+    do {                                                                                                               \
+        Debug_String_Log(LOGLEVEL_FATAL, __FILE__, __LINE__, x, ##__VA_ARGS__);                                        \
+        exit(1);                                                                                                       \
+    } while (false)
+#else
+#define DBG_FATAL(x, ...) (exit(1))
+#endif
+
+#endif

--- a/redalert/externs.h
+++ b/redalert/externs.h
@@ -427,9 +427,10 @@ void Do_Vortex(int x, int y, int frame);
 extern int ReadyToQuit;          // Are we about to exit cleanly
 extern bool InDebugger;          // Are we being run from a debugger
 void Memory_Error_Handler(void); // Memory error handler function
-void WWDebugString(const char* string);
+#include "common/debugstring.h"
+#define WWDebugString(x) DBG_LOG(x)
 #ifndef REMASTER_BUILD
-#define GlyphX_Debug_Print(x) WWDebugString(x)
+#define GlyphX_Debug_Print(x) DBG_LOG(x)
 #endif
 
 /*************************************************************

--- a/redalert/function.h
+++ b/redalert/function.h
@@ -787,10 +787,12 @@ extern CCPtr<TerrainTypeClass> y25;
 extern CCPtr<OverlayTypeClass> y26;
 extern CCPtr<SmudgeTypeClass> y27;
 
+#ifdef REMASTER_BUILD
 /*
 ** Debug output. ST - 6/27/2019 10:00PM
 */
 void GlyphX_Debug_Print(const char* debug_text);
+#endif
 
 void Disable_Uncompressed_Shapes(void);
 void Enable_Uncompressed_Shapes(void);

--- a/redalert/winstub.cpp
+++ b/redalert/winstub.cpp
@@ -338,52 +338,6 @@ HANDLE DebugFile = INVALID_HANDLE_VALUE;
 #endif
 
 /***********************************************************************************************
- * WWDebugString -- sends a string to the debugger and echos it to disk                        *
- *                                                                                             *
- *                                                                                             *
- *                                                                                             *
- * INPUT:    string                                                                            *
- *                                                                                             *
- * OUTPUT:   Nothing                                                                           *
- *                                                                                             *
- * WARNINGS: None                                                                              *
- *                                                                                             *
- * HISTORY:                                                                                    *
- *    10/28/96 12:48PM ST : Created                                                              *
- *=============================================================================================*/
-void WWDebugString(const char* string)
-{
-#if (0)
-    char outstr[256];
-
-    sprintf(outstr, "%s", string);
-
-    DWORD actual;
-    if (DebugFile == INVALID_HANDLE_VALUE) {
-        DebugFile = CreateFile("debug.txt", GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
-    } else {
-        DebugFile = CreateFile("debug.txt", GENERIC_WRITE, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-    }
-
-    if (DebugFile != INVALID_HANDLE_VALUE) {
-        SetFilePointer(DebugFile, 0, NULL, FILE_END);
-        WriteFile(DebugFile, outstr, strlen(outstr) + 1, &actual, NULL);
-        CloseHandle(DebugFile);
-    }
-
-    OutputDebugString(string);
-#else //(0)
-
-#ifndef _WIN32
-    fprintf(stderr, "%s", string);
-#else
-    string = string;
-#endif
-
-#endif //(0)
-}
-
-/***********************************************************************************************
  * Create_Main_Window -- opens the MainWindow for C&C                                          *
  *                                                                                             *
  *                                                                                             *

--- a/tiberiandawn/externs.h
+++ b/tiberiandawn/externs.h
@@ -414,9 +414,10 @@ void Memory_Error_Handler(void);
 extern bool GameStatisticsPacketSent;
 extern bool ConnectionLost;
 extern bool InMainLoop; // True if in game state rather than menu state
-void CCDebugString(const char* string);
+#include "common/debugstring.h"
+#define CCDebugString(x) DBG_LOG(x)
 #ifndef REMASTER_BUILD
-#define GlyphX_Debug_Print(x) CCDebugString(x)
+#define GlyphX_Debug_Print(x) DBG_LOG(x)
 #endif
 extern void* PacketLater;
 void Load_Title_Screen(char* name, GraphicViewPortClass* video_page, unsigned char* palette);

--- a/tiberiandawn/function.h
+++ b/tiberiandawn/function.h
@@ -1057,10 +1057,12 @@ void WWDOS_Shutdown(void);
 
 #endif
 
+#ifdef REMASTER_BUILD
 /*
 ** Debug output. ST - 6/27/2019 10:00PM
 */
 void GlyphX_Debug_Print(const char* debug_text);
+#endif
 
 /*
 ** Achievement event. ST - 11/11/2019 11:39AM

--- a/tiberiandawn/winstub.cpp
+++ b/tiberiandawn/winstub.cpp
@@ -405,58 +405,6 @@ bool Any_Locked()
     }
 }
 
-#ifdef _WIN32
-HANDLE DebugFile = INVALID_HANDLE_VALUE;
-#endif
-
-/***********************************************************************************************
- * CCDebugString -- sends a string to the debugger and echos it to disk                        *
- *                                                                                             *
- *                                                                                             *
- *                                                                                             *
- * INPUT:    string                                                                            *
- *                                                                                             *
- * OUTPUT:   Nothing                                                                           *
- *                                                                                             *
- * WARNINGS: None                                                                              *
- *                                                                                             *
- * HISTORY:                                                                                    *
- *    10/28/96 12:48PM ST : Created                                                            *
- *=============================================================================================*/
-void CCDebugString(const char* string)
-{
-#ifndef REMASTER_BUILD
-
-#ifdef _WIN32
-    char outstr[256];
-
-    sprintf(outstr, "%s", string);
-
-    DWORD actual;
-    if (DebugFile == INVALID_HANDLE_VALUE) {
-        DebugFile = CreateFile("debug.txt", GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL, NULL);
-    } else {
-        DebugFile = CreateFile("debug.txt", GENERIC_WRITE, 0, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, NULL);
-    }
-
-    if (DebugFile != INVALID_HANDLE_VALUE) {
-        SetFilePointer(DebugFile, 0, NULL, FILE_END);
-        WriteFile(DebugFile, outstr, strlen(outstr) + 1, &actual, NULL);
-        CloseHandle(DebugFile);
-    }
-
-    OutputDebugString(string);
-#else
-    fprintf(stderr, "%s", string);
-#endif
-
-#else
-
-    string = string;
-
-#endif
-}
-
 //
 // Miscellaneous stubs. Mainly for multi player stuff
 //


### PR DESCRIPTION
Provides Debug_String macro to capture line and file info.
Provides macros replacing WWDebugString and CCDebugString.
Attaches to console on windows if started from command line.