### PR TITLE
Remove use of UINT16_MAX

### DIFF
--- a/common/wwkeyboard.h
+++ b/common/wwkeyboard.h
@@ -768,7 +768,7 @@ private:
     /*
     ** Large bit array to hold which keys are held down
     */
-    uint8_t DownState[(UINT16_MAX / 8) + 1];
+    uint8_t DownState[0x2000]; // (UINT16_MAX / 8) + 1
     int DownSkip;
 };
 


### PR DESCRIPTION
When building as C++ for RISC OS, UnixLib only defines `UINT16_MAX` when `__STDC_LIMIT_MACROS` is defined, an issue inherited from older versions of glibc. I've submitted a patch to fix this in UnixLib, but since `UINT16_MAX` is only used once, it makes sense to remove it here as well.

http://www.riscos.info/pipermail/gcc/2021-January/007081.html
https://sourceware.org/bugzilla/show_bug.cgi?id=15366