### PR TITLE
SDL2 video driver configurability, boxing, raw input, new defaults

### DIFF
--- a/common/ini.cpp
+++ b/common/ini.cpp
@@ -968,6 +968,11 @@ bool INIClass::Put_String(char const* section, char const* entry, char const* st
     return (true);
 }
 
+bool INIClass::Put_String(char const* section, char const* entry, std::string const& string)
+{
+    return Put_String(section, entry, string.c_str());
+}
+
 /***********************************************************************************************
  * INIClass::Get_String -- Fetch the value of a particular entry in a specified section.       *
  *                                                                                             *
@@ -1033,6 +1038,13 @@ int INIClass::Get_String(char const* section, char const* entry, char const* def
         strtrim(buffer);
         return ((int)strlen(buffer));
     }
+}
+
+std::string INIClass::Get_String(char const* section, char const* entry, std::string const& defvalue) const
+{
+    std::string buffer(MAX_LINE_LENGTH, '\0');
+    buffer.resize(Get_String(section, entry, defvalue.c_str(), &buffer[0], static_cast<int>(buffer.capacity())));
+    return buffer;
 }
 
 /***********************************************************************************************

--- a/common/ini.h
+++ b/common/ini.h
@@ -35,6 +35,7 @@
 #ifndef INI_H
 #define INI_H
 
+#include <string>
 #include <stdlib.h>
 #include <string.h>
 #include "listnode.h"
@@ -105,6 +106,7 @@ public:
     **	Get the various data types from the section and entry specified.
     */
     int Get_String(char const* section, char const* entry, char const* defvalue, char* buffer, int size) const;
+    std::string Get_String(char const* section, char const* entry, std::string const& defvalue) const;
     int Get_Int(char const* section, char const* entry, int defvalue = 0) const;
     int Get_Hex(char const* section, char const* entry, int defvalue = 0) const;
     bool Get_Bool(char const* section, char const* entry, bool defvalue = false) const;
@@ -118,6 +120,7 @@ public:
     */
     bool Put_Fixed(char const* section, char const* entry, fixed value);
     bool Put_String(char const* section, char const* entry, char const* string);
+    bool Put_String(char const* section, char const* entry, std::string const& string);
     bool Put_Hex(char const* section, char const* entry, int number);
     bool Put_Int(char const* section, char const* entry, int number, int format = 0);
     bool Put_Bool(char const* section, char const* entry, bool value);

--- a/common/settings.cpp
+++ b/common/settings.cpp
@@ -10,6 +10,7 @@ SettingsClass::SettingsClass()
     Video.Windowed = false;
     Video.Width = 0;
     Video.Height = 0;
+    Video.Boxing = false;
     Video.FrameLimit = 120;
     Video.HardwareCursor = true;
     Video.Scaler = "nearest";
@@ -22,6 +23,7 @@ void SettingsClass::Load(INIClass& ini)
     Video.WindowWidth = ini.Get_Int("Video", "WindowWidth", Video.WindowWidth);
     Video.WindowHeight = ini.Get_Int("Video", "WindowHeight", Video.WindowHeight);
     Video.Windowed = ini.Get_Bool("Video", "Windowed", Video.Windowed);
+    Video.Boxing = ini.Get_Bool("Video", "Boxing", Video.Boxing);
     Video.Width = ini.Get_Int("Video", "Width", Video.Width);
     Video.Height = ini.Get_Int("Video", "Height", Video.Height);
     Video.FrameLimit = ini.Get_Int("Video", "FrameLimit", Video.FrameLimit);
@@ -29,6 +31,13 @@ void SettingsClass::Load(INIClass& ini)
     Video.Scaler = ini.Get_String("Video", "Scaler", Video.Scaler);
     Video.Driver = ini.Get_String("Video", "Driver", Video.Driver);
     Video.PixelFormat = ini.Get_String("Video", "PixelFormat", Video.PixelFormat);
+
+    /*
+    ** Boxing requires software cursor.
+    */
+    if (Video.Boxing) {
+        Video.HardwareCursor = false;
+    }
 }
 
 void SettingsClass::Save(INIClass& ini)
@@ -36,6 +45,7 @@ void SettingsClass::Save(INIClass& ini)
     ini.Put_Int("Video", "WindowWidth", Video.WindowWidth);
     ini.Put_Int("Video", "WindowHeight", Video.WindowHeight);
     ini.Put_Bool("Video", "Windowed", Video.Windowed);
+    ini.Put_Bool("Video", "Boxing", Video.Boxing);
     ini.Put_Int("Video", "Width", Video.Width);
     ini.Put_Int("Video", "Height", Video.Height);
     ini.Put_Int("Video", "FrameLimit", Video.FrameLimit);

--- a/common/settings.cpp
+++ b/common/settings.cpp
@@ -12,6 +12,9 @@ SettingsClass::SettingsClass()
     Video.Height = 0;
     Video.FrameLimit = 120;
     Video.HardwareCursor = true;
+    Video.Scaler = "nearest";
+    Video.Driver = "default";
+    Video.PixelFormat = "default";
 }
 
 void SettingsClass::Load(INIClass& ini)
@@ -23,6 +26,9 @@ void SettingsClass::Load(INIClass& ini)
     Video.Height = ini.Get_Int("Video", "Height", Video.Height);
     Video.FrameLimit = ini.Get_Int("Video", "FrameLimit", Video.FrameLimit);
     Video.HardwareCursor = ini.Get_Bool("Video", "HardwareCursor", Video.HardwareCursor);
+    Video.Scaler = ini.Get_String("Video", "Scaler", Video.Scaler);
+    Video.Driver = ini.Get_String("Video", "Driver", Video.Driver);
+    Video.PixelFormat = ini.Get_String("Video", "PixelFormat", Video.PixelFormat);
 }
 
 void SettingsClass::Save(INIClass& ini)
@@ -34,4 +40,7 @@ void SettingsClass::Save(INIClass& ini)
     ini.Put_Int("Video", "Height", Video.Height);
     ini.Put_Int("Video", "FrameLimit", Video.FrameLimit);
     ini.Put_Bool("Video", "HardwareCursor", Video.HardwareCursor);
+    ini.Put_String("Video", "Scaler", Video.Scaler);
+    ini.Put_String("Video", "Driver", Video.Driver);
+    ini.Put_String("Video", "PixelFormat", Video.PixelFormat);
 }

--- a/common/settings.cpp
+++ b/common/settings.cpp
@@ -8,7 +8,7 @@ SettingsClass::SettingsClass()
     /*
     ** Mouse settings
     */
-    Mouse.RawInput = false;
+    Mouse.RawInput = true;
     Mouse.Sensitivity = 100;
 
     /*
@@ -19,9 +19,9 @@ SettingsClass::SettingsClass()
     Video.Windowed = false;
     Video.Width = 0;
     Video.Height = 0;
-    Video.Boxing = false;
+    Video.Boxing = true;
     Video.FrameLimit = 120;
-    Video.HardwareCursor = true;
+    Video.HardwareCursor = false;
     Video.Scaler = "nearest";
     Video.Driver = "default";
     Video.PixelFormat = "default";

--- a/common/settings.cpp
+++ b/common/settings.cpp
@@ -5,6 +5,15 @@ SettingsClass Settings;
 
 SettingsClass::SettingsClass()
 {
+    /*
+    ** Mouse settings
+    */
+    Mouse.RawInput = false;
+    Mouse.Sensitivity = 100;
+
+    /*
+    ** Video settings
+    */
     Video.WindowWidth = 640;
     Video.WindowHeight = 400;
     Video.Windowed = false;
@@ -20,6 +29,15 @@ SettingsClass::SettingsClass()
 
 void SettingsClass::Load(INIClass& ini)
 {
+    /*
+    ** Mouse settings
+    */
+    Mouse.RawInput = ini.Get_Bool("Mouse", "RawInput", Mouse.RawInput);
+    Mouse.Sensitivity = ini.Get_Int("Mouse", "Sensitivity", Mouse.Sensitivity);
+
+    /*
+    ** Video settings
+    */
     Video.WindowWidth = ini.Get_Int("Video", "WindowWidth", Video.WindowWidth);
     Video.WindowHeight = ini.Get_Int("Video", "WindowHeight", Video.WindowHeight);
     Video.Windowed = ini.Get_Bool("Video", "Windowed", Video.Windowed);
@@ -33,15 +51,24 @@ void SettingsClass::Load(INIClass& ini)
     Video.PixelFormat = ini.Get_String("Video", "PixelFormat", Video.PixelFormat);
 
     /*
-    ** Boxing requires software cursor.
+    ** Boxing and raw input require software cursor.
     */
-    if (Video.Boxing) {
+    if (Video.Boxing || Mouse.RawInput) {
         Video.HardwareCursor = false;
     }
 }
 
 void SettingsClass::Save(INIClass& ini)
 {
+    /*
+    ** Mouse settings
+    */
+    ini.Put_Bool("Mouse", "RawInput", Mouse.RawInput);
+    ini.Put_Int("Mouse", "Sensitivity", Mouse.Sensitivity);
+
+    /*
+    ** Video settings
+    */
     ini.Put_Int("Video", "WindowWidth", Video.WindowWidth);
     ini.Put_Int("Video", "WindowHeight", Video.WindowHeight);
     ini.Put_Bool("Video", "Windowed", Video.Windowed);

--- a/common/settings.h
+++ b/common/settings.h
@@ -17,6 +17,7 @@ public:
         int WindowWidth;
         int WindowHeight;
         bool Windowed;
+        bool Boxing;
         int Width;
         int Height;
         int FrameLimit;

--- a/common/settings.h
+++ b/common/settings.h
@@ -14,6 +14,12 @@ public:
 
     struct
     {
+        bool RawInput;
+        int Sensitivity;
+    } Mouse;
+
+    struct
+    {
         int WindowWidth;
         int WindowHeight;
         bool Windowed;

--- a/common/settings.h
+++ b/common/settings.h
@@ -1,6 +1,7 @@
 #ifndef SETTINGS_H
 #define SETTINGS_H
 
+#include <string>
 class INIClass;
 
 class SettingsClass
@@ -20,6 +21,9 @@ public:
         int Height;
         int FrameLimit;
         bool HardwareCursor;
+        std::string Scaler;
+        std::string Driver;
+        std::string PixelFormat;
     } Video;
 };
 

--- a/common/video.h
+++ b/common/video.h
@@ -56,6 +56,8 @@ extern SurfaceMonitorClass& AllSurfaces; // List of all surfaces
 bool Set_Video_Mode(int w, int h, int bits_per_pixel);
 void Get_Video_Scale(float& x, float& y);
 void Set_Video_Cursor_Clip(bool clipped);
+void Move_Video_Mouse(int xrel, int yrel);
+void Get_Video_Mouse(int& x, int& y);
 void Toggle_Video_Fullscreen();
 void Reset_Video_Mode();
 unsigned Get_Free_Video_Memory();

--- a/common/video_sdl2.cpp
+++ b/common/video_sdl2.cpp
@@ -65,6 +65,8 @@ static struct
     int H;
     int HotX;
     int HotY;
+    float X;
+    float Y;
     SDL_Cursor* Pending;
     SDL_Cursor* Current;
     SDL_Surface* Surface;
@@ -327,6 +329,8 @@ bool Set_Video_Mode(int w, int h, int bits_per_pixel)
     */
     hwcursor.GameW = w;
     hwcursor.GameH = h;
+    hwcursor.X = w / 2;
+    hwcursor.Y = h / 2;
     Update_HWCursor_Settings();
 
     return true;
@@ -362,11 +366,54 @@ void Set_Video_Cursor_Clip(bool clipped)
     hwcursor.Clip = clipped;
 
     if (window) {
+        int relative;
+
         if (Settings.Video.Windowed) {
             SDL_SetWindowGrab(window, hwcursor.Clip ? SDL_TRUE : SDL_FALSE);
+            relative = SDL_SetRelativeMouseMode(Settings.Mouse.RawInput && hwcursor.Clip ? SDL_TRUE : SDL_FALSE);
         } else {
             SDL_SetWindowGrab(window, SDL_TRUE);
+            relative = SDL_SetRelativeMouseMode(Settings.Mouse.RawInput ? SDL_TRUE : SDL_FALSE);
         }
+
+        if (relative < 0) {
+            DBG_ERROR("Raw input not supported, disabling.");
+            Settings.Mouse.RawInput = false;
+        }
+    }
+}
+
+void Move_Video_Mouse(int xrel, int yrel)
+{
+    if (hwcursor.Clip || !Settings.Video.Windowed) {
+        hwcursor.X += xrel * (Settings.Mouse.Sensitivity / 100.0f);
+        hwcursor.Y += yrel * (Settings.Mouse.Sensitivity / 100.0f);
+    }
+
+    if (hwcursor.X > hwcursor.GameW) {
+        hwcursor.X = hwcursor.GameW;
+    } else if (hwcursor.X < 0) {
+        hwcursor.X = 0;
+    }
+
+    if (hwcursor.Y > hwcursor.GameH) {
+        hwcursor.Y = hwcursor.GameH;
+    } else if (hwcursor.Y < 0) {
+        hwcursor.Y = 0;
+    }
+}
+
+void Get_Video_Mouse(int& x, int& y)
+{
+    if (Settings.Mouse.RawInput && (hwcursor.Clip || !Settings.Video.Windowed)) {
+        x = hwcursor.X;
+        y = hwcursor.Y;
+    } else {
+        float scale_x, scale_y;
+        Get_Video_Scale(scale_x, scale_y);
+        SDL_GetMouseState(&x, &y);
+        x /= scale_x;
+        y /= scale_y;
     }
 }
 
@@ -735,10 +782,10 @@ public:
             int x, y;
             SDL_Rect dst;
 
-            SDL_GetMouseState(&x, &y);
+            Get_Video_Mouse(x, y);
 
-            dst.x = (x / hwcursor.ScaleX) - (hwcursor.HotX);
-            dst.y = (y / hwcursor.ScaleY) - (hwcursor.HotY);
+            dst.x = x - hwcursor.HotX;
+            dst.y = y - hwcursor.HotY;
             dst.w = hwcursor.Surface->w;
             dst.h = hwcursor.Surface->h;
 

--- a/common/wwkeyboard.cpp
+++ b/common/wwkeyboard.cpp
@@ -59,6 +59,7 @@
 #include <SDL.h>
 #include "sdl_keymap.h"
 #endif
+#include "settings.h"
 
 #define ARRAY_SIZE(x) int(sizeof(x) / sizeof(x[0]))
 
@@ -549,9 +550,13 @@ void WWKeyboardClass::Fill_Buffer_From_System(void)
                 Put_Key_Message(event.key.keysym.scancode, true);
             }
             break;
+        case SDL_MOUSEMOTION:
+            Move_Video_Mouse(event.motion.xrel, event.motion.yrel);
+            break;
         case SDL_MOUSEBUTTONDOWN:
         case SDL_MOUSEBUTTONUP: {
-            float scale_x = 1.0f, scale_y = 1.0f;
+            int x, y;
+
             switch (event.button.button) {
             case SDL_BUTTON_LEFT:
             default:
@@ -564,11 +569,17 @@ void WWKeyboardClass::Fill_Buffer_From_System(void)
                 key = VK_MBUTTON;
                 break;
             }
-            Get_Video_Scale(scale_x, scale_y);
-            Put_Mouse_Message(key,
-                              event.button.x / scale_x,
-                              event.button.y / scale_y,
-                              event.type == SDL_MOUSEBUTTONDOWN ? false : true);
+
+            if (Settings.Mouse.RawInput) {
+                Get_Video_Mouse(x, y);
+            } else {
+                float scale_x = 1.0f, scale_y = 1.0f;
+                Get_Video_Scale(scale_x, scale_y);
+                x = event.button.x / scale_x;
+                y = event.button.y / scale_y;
+            }
+
+            Put_Mouse_Message(key, x, y, event.type == SDL_MOUSEBUTTONDOWN ? false : true);
         } break;
         case SDL_WINDOWEVENT:
             switch (event.window.event) {

--- a/common/wwmouse.cpp
+++ b/common/wwmouse.cpp
@@ -618,11 +618,7 @@ int WWMouseClass::Get_Mouse_Y(void)
 void WWMouseClass::Get_Mouse_XY(int& x, int& y)
 {
 #if defined(SDL2_BUILD)
-    float scale_x, scale_y;
-    Get_Video_Scale(scale_x, scale_y);
-    SDL_GetMouseState(&x, &y);
-    x /= scale_x;
-    y /= scale_y;
+    Get_Video_Mouse(x, y);
 #elif defined(_WIN32)
     POINT pt;
 

--- a/redalert/conquer.cpp
+++ b/redalert/conquer.cpp
@@ -1688,6 +1688,11 @@ FacingType KN_To_Facing(int input)
 static void Sync_Delay(void)
 {
     /*
+    ** Slow down with frame limiter first.
+    */
+    Frame_Limiter();
+
+    /*
     **	Accumulate the number of 'spare' ticks that are frittered away here.
     */
     SpareTicks += FrameTimer;

--- a/tiberiandawn/conquer.cpp
+++ b/tiberiandawn/conquer.cpp
@@ -1387,6 +1387,11 @@ FacingType KN_To_Facing(int input)
 static void Sync_Delay(void)
 {
     /*
+    ** Slow down with frame limiter first.
+    */
+    Frame_Limiter();
+
+    /*
     **	Delay one tick and keep a record that one tick was "wasted" here.
     **	This accumulates into a running histogram of performance.
     */


### PR DESCRIPTION
```
commit abf0b1247dc145931ad515124b2cf313103ba1e5
Author: Toni Spets <toni.spets@iki.fi>
Date:   Sat Jan 23 21:05:50 2021 +0200

    Change SDL2 default configuration
    
     - use boxing by default
     - use raw mouse input by default
     - use software cursor by default
    
    Boxing is likely the expected default how the game should function
    when going fullscreen aka not stretch the image. It also requires
    software cursor to be used as hardware cursor would be off so that
    needs to change as well.
    
    While boxing does not strictly require raw input as the mouse
    position is automatically scaled to match the visible area it does
    create a scaling artifact where your horizontal or vertical cursor
    speed is slower than it should be.
    
    Even with raw input enabled it doesn't affect cursor grabbing in
    windowed mode where when not in-game it will act like raw input
    was not enabled and is free to exit the window.

commit a0f631b7ba55b72f04c73fe7c1790f4fe8d3171d
Author: Toni Spets <toni.spets@iki.fi>
Date:   Fri Jan 22 22:01:21 2021 +0200

    SDL2 raw input and sensitivity control

commit 11b7dabaf02e4f37a9b96dc8063de3d0039fdb28
Author: Toni Spets <toni.spets@iki.fi>
Date:   Sat Jan 23 18:31:03 2021 +0200

    Automatic boxing for SDL2

commit 6b092fbf4bea8bef1c1a7ca2923643b0b8fb05b6
Author: Toni Spets <toni.spets@iki.fi>
Date:   Fri Jan 22 12:30:28 2021 +0200

    Improve SDL2 video driver configurability
    
     - don't force accelerated renderer, they are preferred anyway
     - default to first supported texture format
     - proper initialization prints
     - allow force pixel format
     - allow selecting low level video driver
     - allow setting scaling quality

commit 433f315a929d7dab0a588c60ec041dcdba237ecb
Author: Toni Spets <toni.spets@iki.fi>
Date:   Fri Jan 22 14:34:49 2021 +0200

    Add std::string support to INIClass

commit 5a7dc7c999e75e73bc5fb20c8ae813c4f2be1959
Author: Toni Spets <toni.spets@iki.fi>
Date:   Fri Jan 22 12:38:17 2021 +0200

    Call Frame_Limiter before calculating frame delay
    
    This makes the rendering time part of the per-frame delay calc
    when using SDL2 driver.
```