### PR TITLE
SDL2 music fixes

### DIFF
--- a/redalert/score.cpp
+++ b/redalert/score.cpp
@@ -1607,7 +1607,6 @@ void Call_Back_Delay(int time)
     if (time > 60)
         time = 60;
     CDTimerClass<SystemTimerClass> cd;
-    CDTimerClass<SystemTimerClass> callbackcd = 0;
 
     if (!ControlQ) {
         if (Keyboard->Down(KN_LCTRL) && Keyboard->Down(KN_Q)) {
@@ -1621,10 +1620,7 @@ void Call_Back_Delay(int time)
     cd = time;
     StreamLowImpact = true;
     do {
-        if (callbackcd == 0) {
-            Call_Back();
-            callbackcd = TIMER_SECOND / 4;
-        }
+        Call_Back();
         Animate_Score_Objs();
         Frame_Limiter();
     } while (cd);

--- a/redalert/theme.cpp
+++ b/redalert/theme.cpp
@@ -194,8 +194,7 @@ char const* ThemeClass::Full_Name(ThemeType theme) const
 void ThemeClass::AI(void)
 {
     if (SampleType && !Debug_Quiet) {
-        if (ScoresPresent && Options.ScoreVolume != 0 && !Still_Playing() && Pending != THEME_NONE) {
-
+        if (ScoresPresent && Options.ScoreVolume != 0 && !Still_Playing() && Pending != THEME_NONE && GameInFocus) {
             /*
             **	If the pending song needs to be picked, then pick it now.
             */

--- a/redalert/winstub.cpp
+++ b/redalert/winstub.cpp
@@ -81,12 +81,18 @@ unsigned long CCFocusMessage = WM_USER + 50; // Private message for receiving ap
 
 void Focus_Loss(void)
 {
+#ifdef SDL2_BUILD
+    GameInFocus = false;
+#endif
     Theme.Suspend();
     Stop_Primary_Sound_Buffer();
 }
 
 void Focus_Restore(void)
 {
+#ifdef SDL2_BUILD
+    GameInFocus = true;
+#endif
     Map.Flag_To_Redraw(true);
     Start_Primary_Sound_Buffer(true);
 

--- a/tiberiandawn/theme.cpp
+++ b/tiberiandawn/theme.cpp
@@ -182,7 +182,7 @@ char const* ThemeClass::Full_Name(ThemeType theme) const
 void ThemeClass::AI(void)
 {
     if (SampleType && !Debug_Quiet) {
-        if (ScoresPresent && Options.ScoreVolume && !Still_Playing() && Pending != THEME_NONE) {
+        if (ScoresPresent && Options.ScoreVolume && !Still_Playing() && Pending != THEME_NONE && GameInFocus) {
 
             /*
             **	If the pending song needs to be picked, then pick it now.
@@ -403,6 +403,16 @@ void ThemeClass::Stop(void)
             Score = THEME_NONE;
             Pending = THEME_NONE;
         }
+    }
+}
+
+void ThemeClass::Suspend(void)
+{
+    if (ScoresPresent && SampleType && !Debug_Quiet && Current != -1) {
+        Stop_Sample(Current);
+        Current = -1;
+        Pending = Score;
+        Score = THEME_NONE;
     }
 }
 

--- a/tiberiandawn/theme.h
+++ b/tiberiandawn/theme.h
@@ -82,6 +82,7 @@ public:
         return Score;
     };
     void Stop(void);
+    void Suspend(void);
     void Fade_Out(void)
     {
         Queue_Song(THEME_NONE);

--- a/tiberiandawn/winstub.cpp
+++ b/tiberiandawn/winstub.cpp
@@ -70,17 +70,25 @@ ThemeType OldTheme = THEME_NONE;
 
 void Focus_Loss(void)
 {
+#ifdef SDL2_BUILD
+    GameInFocus = false;
+    Theme.Suspend();
+#else
     if (SoundOn) {
         if (OldTheme == THEME_NONE) {
             OldTheme = Theme.What_Is_Playing();
         }
     }
     Theme.Stop();
+#endif
     Stop_Primary_Sound_Buffer();
 }
 
 void Focus_Restore(void)
 {
+#ifdef SDL2_BUILD
+    GameInFocus = true;
+#endif
     Map.Flag_To_Redraw(true);
     Start_Primary_Sound_Buffer(true);
 


### PR DESCRIPTION
```
commit f978db64a01d3ecb20e2121c53c46a14ead64225
Author: Toni Spets <toni.spets@iki.fi>
Date:   Sun Jan 24 21:17:55 2021 +0200

    Fix theme anomalities with focus and SDL2
    
    Copy ThemeClass::Suspend from RA to TD for proper theme restart
    after focus loss.

commit daa13bd0ebefa14267ab39d3b9e4da8e1b2328a8
Author: Toni Spets <toni.spets@iki.fi>
Date:   Sun Jan 24 21:03:42 2021 +0200

    [RA] Fix score screen music restarting
```
Music should work fairly consistently with focus loss now with both games. Hella annoying it stops and restarts but I'll fix it later so it just mutes the score channel so it can continue if it's still playing when focus is restored.