### PR TITLE
Fix ListClass negative index and crashes related to empty lists in RA

### DIFF
--- a/redalert/expand.cpp
+++ b/redalert/expand.cpp
@@ -475,26 +475,21 @@ bool Expansion_Dialog(void)
 
         KeyNumType input = buttons->Input();
         switch (input) {
+        case (KN_RETURN):
         case 200 | KN_BUTTON:
-            Whom = list.Current_Object()->House;
-            Scen.Scenario = list.Current_Object()->Scenario;
-            strcpy(Scen.ScenarioName, list.Current_Object()->FullName);
-            process = false;
-            okval = true;
+            if (list.Current_Object()) {
+                Whom = list.Current_Object()->House;
+                Scen.Scenario = list.Current_Object()->Scenario;
+                strcpy(Scen.ScenarioName, list.Current_Object()->FullName);
+                process = false;
+                okval = true;
+            }
             break;
 
         case KN_ESC:
         case 201 | KN_BUTTON:
             process = false;
             okval = false;
-            break;
-
-        case (KN_RETURN):
-            Whom = list.Current_Object()->House;
-            Scen.Scenario = list.Current_Object()->Scenario;
-            strcpy(Scen.ScenarioName, list.Current_Object()->FullName);
-            process = false;
-            okval = true;
             break;
 
         default:

--- a/redalert/list.cpp
+++ b/redalert/list.cpp
@@ -881,17 +881,20 @@ GadgetClass* ListClass::Remove(void)
  *=============================================================================================*/
 void ListClass::Set_Selected_Index(int index)
 {
-    if (index < List.Count()) {
-        SelectedIndex = index;
-        Flag_To_Redraw();
-        if (SelectedIndex < CurrentTopIndex) {
-            Set_View_Index(SelectedIndex);
-        }
-        if (SelectedIndex >= CurrentTopIndex + LineCount) {
-            Set_View_Index(SelectedIndex - (LineCount - 1));
-        }
-    } else {
+    if (List.Count() == 0 || index >= List.Count()) {
         SelectedIndex = 0;
+    } else if (index < 0) {
+        SelectedIndex = List.Count() - 1;
+    } else {
+        SelectedIndex = index;
+    }
+
+    Flag_To_Redraw();
+    if (SelectedIndex < CurrentTopIndex) {
+        Set_View_Index(SelectedIndex);
+    }
+    if (SelectedIndex >= CurrentTopIndex + LineCount) {
+        Set_View_Index(SelectedIndex - (LineCount - 1));
     }
 }
 

--- a/redalert/nulldlg.cpp
+++ b/redalert/nulldlg.cpp
@@ -878,17 +878,19 @@ int Com_Scenario_Dialog(bool skirmish)
             //
             // make sure we got a game options packet from the other player
             //
-            if (gameoptions) {
-                rc = true;
-                process = false;
+            if (Session.Scenarios.Count() > 0) {
+                if (gameoptions) {
+                    rc = true;
+                    process = false;
 
-                // force transmitting of game options packet one last time
+                    // force transmitting of game options packet one last time
 
-                transmit = true;
-                transmittime = 0;
-            } else {
-                WWMessageBox().Process(TXT_ONLY_ONE, TXT_OOPS, NULL);
-                display = REDRAW_ALL;
+                    transmit = true;
+                    transmittime = 0;
+                } else {
+                    WWMessageBox().Process(TXT_ONLY_ONE, TXT_OOPS, NULL);
+                    display = REDRAW_ALL;
+                }
             }
             if (input == (BUTTON_LOAD | KN_BUTTON))
                 load_game = true;

--- a/tiberiandawn/list.cpp
+++ b/tiberiandawn/list.cpp
@@ -850,15 +850,20 @@ GadgetClass* ListClass::Remove(void)
  *=============================================================================================*/
 void ListClass::Set_Selected_Index(int index)
 {
-    if (index < List.Count()) {
+    if (List.Count() == 0 || index >= List.Count()) {
+        SelectedIndex = 0;
+    } else if (index < 0) {
+        SelectedIndex = List.Count() - 1;
+    } else {
         SelectedIndex = index;
-        Flag_To_Redraw();
-        if (SelectedIndex < CurrentTopIndex) {
-            Set_View_Index(SelectedIndex);
-        }
-        if (SelectedIndex >= CurrentTopIndex + LineCount) {
-            Set_View_Index(SelectedIndex - (LineCount - 1));
-        }
+    }
+
+    Flag_To_Redraw();
+    if (SelectedIndex < CurrentTopIndex) {
+        Set_View_Index(SelectedIndex);
+    }
+    if (SelectedIndex >= CurrentTopIndex + LineCount) {
+        Set_View_Index(SelectedIndex - (LineCount - 1));
     }
 }
 


### PR DESCRIPTION
```
commit 49ea437ed28fafda292572000947ecdbac1e1273
Author: Toni Spets <toni.spets@iki.fi>
Date:   Tue Jan 26 07:35:45 2021 +0200

    [RA] Fix crashes with empty mission lists
    
    Counterstrike, Aftermath and empty skirmish list (demo).

commit 383c684d823ce58ffc29bbb0de281a572b912673
Author: Toni Spets <toni.spets@iki.fi>
Date:   Tue Jan 26 07:22:38 2021 +0200

    ListClass: Handle negative index correctly
    
    Fixes crashes when using up arrow key in lists in both games when
    first item is selected.
    
    Closes #500
```

Fixes #500 