### PR TITLE
Do not crash if critical file is not found

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -104,6 +104,7 @@ else()
 endif()
 
 set(COMMONR_SRC
+    debugstring.cpp
     framelimit.cpp
     gbuffer.cpp
     interpal.cpp
@@ -115,6 +116,7 @@ set(COMMONR_SRC
 )
 
 set(COMMONV_SRC
+    debugstring.cpp
     framelimit.cpp
     gbuffer.cpp
     interpal.cpp

--- a/common/bfiofile.cpp
+++ b/common/bfiofile.cpp
@@ -235,7 +235,7 @@ bool BufferIOFileClass::Cache(long size, void* ptr)
                 readsize = BufferSize;
             }
 
-            if (Is_Open()) {
+            if (BufferIOFileClass::Is_Open()) {
                 //
                 // get previous file position
                 //
@@ -568,8 +568,8 @@ long BufferIOFileClass::Write(void const* buffer, long size)
 {
     int opened = false;
 
-    if (!Is_Open()) {
-        if (!Open(WRITE)) {
+    if (!BufferIOFileClass::Is_Open()) {
+        if (!BufferIOFileClass::Open(WRITE)) {
             return (0);
         }
         TrueFileStart = RawFileClass::Seek(0);
@@ -710,8 +710,8 @@ long BufferIOFileClass::Read(void* buffer, long size)
 {
     int opened = false;
 
-    if (!Is_Open()) {
-        if (Open()) {
+    if (!BufferIOFileClass::Is_Open()) {
+        if (BufferIOFileClass::Open()) {
             TrueFileStart = RawFileClass::Seek(0);
             opened = true;
         }

--- a/common/debugstring.cpp
+++ b/common/debugstring.cpp
@@ -6,6 +6,9 @@
 
 #ifdef _WIN32
 #include <windows.h>
+#include <winuser.h>
+#elif defined(SDL2_BUILD)
+#include <SDL_messagebox.h>
 #endif
 
 static class DebugStateClass
@@ -74,4 +77,22 @@ void Debug_String_File(const char* file)
     }
 
     DebugState.File = fopen(file, "w");
+}
+
+int FatalErrorMessageBox(const char* fmt, ...)
+{
+    char buffer[256];
+    va_list args;
+    va_start(args, fmt);
+    vsnprintf(buffer, 256, fmt, args);
+    va_end(args);
+
+    /* Prefer WinAPI MessageBoxA on Windows.  */
+#ifdef _WIN32
+    return MessageBoxA(NULL, (LPCSTR) "Fatal Error", (LPCSTR)buffer, MB_OK | MB_ICONERROR);
+#elif defined(SDL2_BUILD)
+    return SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Fatal Error", buffer, NULL);
+#else
+    return 0;
+#endif
 }

--- a/common/debugstring.h
+++ b/common/debugstring.h
@@ -23,6 +23,8 @@ void Debug_String_File(const char* file);
 #define Debug_String_File(file)                       ((void)0)
 #endif
 
+int FatalErrorMessageBox(const char* fmt, ...);
+
 /* Default to debug logging */
 #ifndef LOGGING_LEVEL
 #define LOGGING_LEVEL 5
@@ -70,7 +72,7 @@ void Debug_String_File(const char* file);
 #define _DBG_FATAL_COMMON(x, ...)                                                                                      \
     do {                                                                                                               \
         fprintf(stdout, x, ##__VA_ARGS__);                                                                             \
-        SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Fatal Error", buffer, NULL);                                   \
+        FatalErrorMessageBox(x, ##__VA_ARGS__);                                                                        \
         exit(1);                                                                                                       \
     } while (false)
 

--- a/common/debugstring.h
+++ b/common/debugstring.h
@@ -67,14 +67,21 @@ void Debug_String_File(const char* file);
 #define DBG_ERROR(x, ...) ((void)0)
 #endif
 
+#define _DBG_FATAL_COMMON(x, ...)                                                                                      \
+    do {                                                                                                               \
+        fprintf(stdout, x, ##__VA_ARGS__);                                                                             \
+        SDL_ShowSimpleMessageBox(SDL_MESSAGEBOX_ERROR, "Fatal Error", buffer, NULL);                                   \
+        exit(1);                                                                                                       \
+    } while (false)
+
 #if LOGLEVEL_FATAL <= LOGGING_LEVEL && defined _DEBUG
 #define DBG_FATAL(x, ...)                                                                                              \
     do {                                                                                                               \
         Debug_String_Log(LOGLEVEL_FATAL, __FILE__, __LINE__, x, ##__VA_ARGS__);                                        \
-        exit(1);                                                                                                       \
+        _DBG_FATAL_COMMON(x, ##__VA_ARGS__);                                                                           \
     } while (false)
 #else
-#define DBG_FATAL(x, ...) (exit(1))
+#define DBG_FATAL(x, ...) _DBG_FATAL_COMMON(x, ##__VA_ARGS__)
 #endif
 
 #endif

--- a/common/rawfile.cpp
+++ b/common/rawfile.cpp
@@ -93,11 +93,11 @@ void RawFileClass::Error(int error, int canretry, char const* filename)
 {
     char buffer[64];
     const char* errorstr = strerror(error);
+    const char* fmtstring = "Error on file %s: %s\n";
 
-    snprintf(buffer, 64, "Error on file %s: %s\n", filename, errorstr);
-    fprintf(stdout, buffer);
+    printf(fmtstring, filename, errorstr);
     if (!canretry) {
-        DBG_FATAL(buffer);
+        DBG_FATAL(fmtstring, filename, errorstr);
     }
 }
 
@@ -323,7 +323,7 @@ int RawFileClass::Is_Available(int forced)
     **	If the file is already open, then is must have already passed the availability check.
     **	Return true in this case.
     */
-    if (Is_Open())
+    if (RawFileClass::Is_Open())
         return (true);
 
     /*
@@ -395,7 +395,7 @@ void RawFileClass::Close(void)
     **	If the file is open, then close it. If the file is already closed, then just return. This
     **	isn't considered an error condition.
     */
-    if (Is_Open()) {
+    if (RawFileClass::Is_Open()) {
         /*
         **	Try to close the file. If there was an error (who knows what that could be), then
         **	call the error routine.
@@ -448,12 +448,12 @@ long RawFileClass::Read(void* buffer, long size)
     **	If the file isn't opened, open it. This serves as a convenience
     **	for the programmer.
     */
-    if (!Is_Open()) {
+    if (!RawFileClass::Is_Open()) {
 
         /*
         **	The error check here is moot. Open will never return unless it succeeded.
         */
-        if (!Open(READ)) {
+        if (!RawFileClass::Open(READ)) {
             return (0);
         }
         opened = true;
@@ -522,8 +522,8 @@ long RawFileClass::Write(void const* buffer, long size)
     **	it. Otherwise, open the file for writing and then close the file when the
     **	output is finished.
     */
-    if (!Is_Open()) {
-        if (!Open(WRITE)) {
+    if (!RawFileClass::Is_Open()) {
+        if (!RawFileClass::Open(WRITE)) {
             return (0);
         }
         opened = true;
@@ -660,7 +660,7 @@ long RawFileClass::Size(void)
     /*
     **	If the file is open, then proceed normally.
     */
-    if (Is_Open()) {
+    if (RawFileClass::Is_Open()) {
 
         /*
         ** With stdio we seek to end to obtain the length, then reset the position back.
@@ -691,14 +691,14 @@ long RawFileClass::Size(void)
         **	If the file wasn't open, then open the file and call this routine again. Count on
         **	the fact that the open function must succeed.
         */
-        if (Open()) {
+        if (RawFileClass::Open()) {
             size = Size();
 
             /*
             **	Since we needed to open the file we must remember to close the file when the
             **	size has been determined.
             */
-            Close();
+            RawFileClass::Close();
         }
     }
 
@@ -843,7 +843,7 @@ void RawFileClass::Bias(int start, int length)
     **	Move the current file offset to a legal position if necessary and the
     **	file was open.
     */
-    if (Is_Open()) {
+    if (RawFileClass::Is_Open()) {
         RawFileClass::Seek(0, SEEK_SET);
     }
 }

--- a/common/rawfile.cpp
+++ b/common/rawfile.cpp
@@ -64,7 +64,6 @@
 #endif
 
 #include <sys/stat.h>
-#include <SDL_messagebox.h>
 
 /***********************************************************************************************
  * RawFileClass::Error -- Handles displaying a file error message.                             *


### PR DESCRIPTION
I am opening a new PR because the previous was automatically closed when I was cleaning my main branch.

If a critical file (such as temperat.pal) is not found in the MIX
files, the game crashes. This commit fixes this by checking if
opened file is not NULL.

The original crash reason was because an incorrect version of Is_Open
was being called. This was fixed by explicit calling the correct
function.

We also change DBG_FATAL_COMMON to call ShowSimpleMessageBox.

Closes #486