### PR TITLE
Show health bar + pips on mouse hover over object

### DIFF
--- a/redalert/display.cpp
+++ b/redalert/display.cpp
@@ -269,6 +269,7 @@ void DisplayClass::Init_Clear(void)
     /*
     ** Clear any object being placed
     */
+    HoverObject = 0;
     PendingObjectPtr = 0;
     PendingObject = 0;
     PendingHouse = HOUSE_NONE;
@@ -3072,6 +3073,11 @@ int DisplayClass::TacticalClass::Action(unsigned flags, KeyNumType& key)
     ObjectClass* object = 0;
     ActionType action = ACTION_NONE; // Action possible with currently selected object.
 
+    // If the previous hover obj is no longer hovered over, force a redraw so the health bar disappears
+    if (Map.HoverObject != NULL) {
+        Map.HoverObject->Mark();
+    }
+
     /*
     **	Set some working variables that depend on the mouse position. For the press
     **	or release event, special mouse queuing storage variables are used. Other
@@ -3114,6 +3120,8 @@ int DisplayClass::TacticalClass::Action(unsigned flags, KeyNumType& key)
             if (object != NULL && object->Is_Techno() && ((TechnoClass*)object)->Is_Cloaked(PlayerPtr, true)) {
                 object = NULL;
             }
+
+            Map.HoverObject = object;
         }
 
         /*

--- a/redalert/display.h
+++ b/redalert/display.h
@@ -92,6 +92,10 @@ public:
     short const* CursorSize;
     short CursorShapeSave[256]; // For save/load
     bool ProximityCheck;        // Is proximity check ok?
+    
+    // Current object the mouse is hovering over, used for healthbar on hover functionality
+    // Needs to be saved to detect no longer hovering (and thus redrawing the unit without health bar)
+    ObjectClass* HoverObject;
 
     /*
     ** This holds the building type that is about to be placed upon the map.

--- a/redalert/techno.cpp
+++ b/redalert/techno.cpp
@@ -1142,11 +1142,7 @@ void TechnoClass::Draw_It(int x, int y, WindowNumberType window) const
     int width, height;
     Class_Of().Dimensions(width, height);
 
-    const bool show_health_bar =
-        (Strength > 0) && !Is_Cloaked(PlayerPtr)
-        && (Is_Selected_By_Player()
-            || ((Rule.HealthBarDisplayMode == RulesClass::HB_DAMAGED) && (Strength < Techno_Type_Class()->MaxStrength))
-            || (Rule.HealthBarDisplayMode == RulesClass::HB_ALWAYS));
+    const bool show_health_bar = ((TechnoClass*)this)->Should_Show_Health_Bar();
 
     /*
     **	Draw the selected object graphic.
@@ -1243,9 +1239,26 @@ void TechnoClass::Draw_It(int x, int y, WindowNumberType window) const
     // if ((window == WINDOW_VIRTUAL) || (Is_Selected_By_Player() && (House->Is_Ally(PlayerPtr) || (Spied_By() & (1 <<
     // (PlayerPtr->Class->House))))))
     if ((window == WINDOW_VIRTUAL)
-        || (selected && (House->Is_Ally(PlayerPtr) || (Spied_By() & (1 << (PlayerPtr->Class->House)))))) {
+        || ((selected || Map.HoverObject == this) && (House->Is_Ally(PlayerPtr) || (Spied_By() & (1 << (PlayerPtr->Class->House)))))) {
         Draw_Pips((x - lx) + 5, y + ly - 3, window);
     }
+}
+
+bool TechnoClass::Should_Show_Health_Bar()
+{
+    if ((Strength <= 0) || Is_Cloaked(PlayerPtr)) {
+        return false;
+    }
+    if (Map.HoverObject && Map.HoverObject->Is_Techno() && (TechnoClass*)Map.HoverObject == (TechnoClass*)this) {
+        return true;
+    }
+    if ((Is_Selected_By_Player()
+         || ((Rule.HealthBarDisplayMode == RulesClass::HB_DAMAGED) && (Strength < Techno_Type_Class()->MaxStrength))
+         || (Rule.HealthBarDisplayMode == RulesClass::HB_ALWAYS))) {
+        return true;
+    }
+
+    return false;
 }
 
 /***********************************************************************************************

--- a/redalert/techno.h
+++ b/redalert/techno.h
@@ -440,6 +440,7 @@ public:
                                     const char* shape_name = NULL) const;
 
     virtual void Draw_It(int x, int y, WindowNumberType window) const;
+    bool Should_Show_Health_Bar();
     virtual void Draw_Pips(int x, int y, WindowNumberType window) const;
     virtual void Hidden(void);
     virtual bool Mark(MarkType mark = MARK_CHANGE);


### PR DESCRIPTION
Show healthbar + pips on mouse hover over object

This is a port of the ts-patches code with an extra check to mark sure the object health bar is no longer drawn when the mouse is no longer hovered over the object.