### PR TITLE
Fix for issue-528, Fix crash when loading GDI mission 3

### DIFF
--- a/tiberiandawn/teamtype.cpp
+++ b/tiberiandawn/teamtype.cpp
@@ -354,11 +354,13 @@ void TeamTypeClass::Fill_In(const char* name, const char* entry)
     */
     MissionCount = atoi(strtok(NULL, ","));
 
+    // Some missions may have an incorrect MissionCount e.g. GDI SCG03EA.INI
+    // So this needs to be handled
     for (i = 0; i < MissionCount; i++) {
         p1 = strtok(NULL, ",:");
         p2 = strtok(NULL, ",:");
         mission.Mission = Mission_From_Name(p1);
-        mission.Argument = atoi(p2);
+        mission.Argument = p2 ? atoi(p2) : 0;
         MissionList[i] = mission;
     }
 


### PR DESCRIPTION
In teamtype.cpp, the Mission Count is encoded before the list of missions / arguments
but SCG03EA.INI has a Mission Count of 13, rather than 11
DEBUG: SCG03EA.INI
strlen 122, data - BadGuy,1,0,0,0,0,22,1,0,0,2,E1:1,E3:2,13,Move:0,Guard:1,Move:7,Guard:1,Move:6,Guard:1,Move:7,Guard:1,Move:0,Guard:1,Move:8

![image](https://user-images.githubusercontent.com/10485456/107160794-54921900-6990-11eb-84d5-76c33a20e34a.png)

This means on 12 and 13 iterations, p2 is NULL, which causes atoi() to crash unless your implementation can tolerate it - it relies on implementation specific stuff to work.

An adjustment like this fixes it

![image](https://user-images.githubusercontent.com/10485456/107160797-5eb41780-6990-11eb-96c7-00351bf157fc.png)


