### PR TITLE
[TD] Fix for issue-536. Fix crash when building a communication centre

### DIFF
--- a/tiberiandawn/radar.cpp
+++ b/tiberiandawn/radar.cpp
@@ -811,7 +811,7 @@ void RadarClass::Plot_Radar_Pixel(CELL cell)
         if (color == TBLACK) {
             if (ZoomFactor > 1) {
                 void const* ptr;
-                long offset;
+                int32_t offset;
                 int icon;
 
                 if (cellptr->TType != TEMPLATE_NONE) {


### PR DESCRIPTION
Offset is stored as a 32bit number. As code was designed for 32bit, long is not the same value on Linux compared to Windows.

Changed to int32_t, which fixes crash.

![image](https://user-images.githubusercontent.com/10485456/107190361-a2377180-69e2-11eb-8495-9cce7bbb5be9.png)

![image](https://user-images.githubusercontent.com/10485456/107190415-b24f5100-69e2-11eb-9752-8d1125dce7b3.png)

