### PR TITLE
Fix frame limiter

### DIFF
--- a/common/framelimit.cpp
+++ b/common/framelimit.cpp
@@ -15,21 +15,41 @@ extern WWMouseClass* WWMouse;
 void Video_Render_Frame();
 #endif
 
-void Frame_Limiter()
+void Frame_Limiter(bool force_render)
 {
     static auto frame_start = std::chrono::steady_clock::now();
 #ifdef SDL2_BUILD
+    static auto render_avg = 0;
+
+    auto render_start = std::chrono::steady_clock::now();
+    auto render_remaining = std::chrono::duration_cast<std::chrono::milliseconds>(frame_start - render_start).count();
+
+    if (force_render == false && render_remaining > render_avg) {
+        ms_sleep(unsigned(render_remaining));
+        return;
+    }
+
     Video_Render_Frame();
+
+    auto render_end = std::chrono::steady_clock::now();
+    auto render_time = std::chrono::duration_cast<std::chrono::milliseconds>(render_end - render_start).count();
+
+    // keep up some average so we have an idea if we need to skip a frame or not
+    render_avg = (render_avg + render_time) / 2;
 #endif
 
     if (Settings.Video.FrameLimit > 0) {
+#ifdef SDL2_BUILD
+        auto frame_end = render_end;
+#else
         auto frame_end = std::chrono::steady_clock::now();
+#endif
         int64_t _ms_per_tick = 1000 / Settings.Video.FrameLimit;
         auto remaining =
             _ms_per_tick - std::chrono::duration_cast<std::chrono::milliseconds>(frame_end - frame_start).count();
         if (remaining > 0) {
             ms_sleep(unsigned(remaining));
         }
-        frame_start = frame_end;
+        frame_start = std::chrono::steady_clock::now();
     }
 }

--- a/common/framelimit.h
+++ b/common/framelimit.h
@@ -1,6 +1,6 @@
 #ifndef FRAMELIMIT_H
 #define FRAMELIMIT_H
 
-void Frame_Limiter();
+void Frame_Limiter(bool force_render = true);
 
 #endif /* FRAMELIMIT_H */

--- a/redalert/conquer.cpp
+++ b/redalert/conquer.cpp
@@ -1717,7 +1717,7 @@ static void Sync_Delay(void)
             Map.Render();
         }
 
-        Frame_Limiter();
+        Frame_Limiter(false);
     }
     Color_Cycle();
     Call_Back();

--- a/tiberiandawn/conquer.cpp
+++ b/tiberiandawn/conquer.cpp
@@ -1413,7 +1413,7 @@ static void Sync_Delay(void)
             Map.Render();
         }
 
-        Frame_Limiter();
+        Frame_Limiter(false);
     }
     Color_Cycle();
     Call_Back();


### PR DESCRIPTION
Fixed an issue where the frametime was incorrectly calculated before sleeping making the games get less accurate ticks when the frame limit was low. This also caused the renders to happen erratically and fps being doubled.
    
Introduced frame dropping concept where non-critical frames can be dropped but game ticks force render. This should smoothen out lower specced systems.

Frametimes before:
![image](https://user-images.githubusercontent.com/106598/107879016-12605e80-6edf-11eb-9080-f871c4b9f0a3.png)

Frametimes now:
![image](https://user-images.githubusercontent.com/106598/107879026-17bda900-6edf-11eb-9584-b8eb938f274e.png)
