### PR TITLE
Fix monster tank mission (Remaster bug)

### DIFF
--- a/redalert/techno.cpp
+++ b/redalert/techno.cpp
@@ -3404,12 +3404,6 @@ bool TechnoClass::Evaluate_Object(ThreatType method,
             */
             Mark(MARK_CHANGE);
 
-            /*
-            **	If a projectile was fired from a unit that is hidden in the darkness,
-            **	reveal that unit and a little area around it.
-            ** For multiplayer games, only reveal the unit if the target is the
-            ** local player.
-            */
 #if (0)
             if ((!IsOwnedByPlayer && !IsDiscoveredByPlayer)
                 || (!Map[Center_Coord()].IsMapped && (What_Am_I() != RTTI_AIRCRAFT || !IsOwnedByPlayer))) {
@@ -3429,6 +3423,16 @@ bool TechnoClass::Evaluate_Object(ThreatType method,
 
 #else
 
+        // If a projectile was fired from a unit that is hidden in the darkness,
+        //reveal that unit and a little area around it.
+        if ((!IsOwnedByPlayer && !IsDiscoveredByPlayer)
+            || (!Map[Center_Coord()].IsMapped && (What_Am_I() != RTTI_AIRCRAFT || !IsOwnedByPlayer))) {
+            if (Session.Type == GAME_NORMAL) {
+                Map.Sight_From(Coord_Cell(Center_Coord()), 2, PlayerPtr, false);
+            }
+        }
+
+        //For multiplayer games, only reveal the unit if the target is the **local player.
         /*
         ** For client/server multiplayer, we need to reveal for any human player that is the target. ST - 3/13/2019
         *5:43PM


### PR DESCRIPTION
This fixes the Monster Tank Madness Aftermath mission not working correctly in VanillaRA. The issue is that a group of Soviet soldiers which are supposed to get killed by the Monster Tanks walk into your base instead and destroy your Weapons Factory too soon for you to respond because your base isn't discovered by you yet. The Monster Tanks don't attack these soldiers because the player has not unshrouded the Monster Tanks causing the threat code to not consider anything the Monster Tanks try to attack a threat. In 3.03 there's special single player logic to unshroud a very small part of the map if an enemy unit is firing from shroud, the remaster doesn't have this logic.

The Remaster changed the map reveal code but they forgot to port some special logic for single player. Works like this:

a single player check for revealing a small part of the shroud for the human player in single player even if the target is not a object (I think when its an overlay)

in multiplayer it checks if the target is an object

whats happening is that it reveals the monster tanks a bit on mission start after they start firing either the ground or overlays or something

which causes them to be discovered, which makes sure the threat code works correctly and the monster tanks and the soviet players will attack each other (the code looks at whether the human player has discovered the monster tanks

and that causes the riflemen to get kiled by monster tanks instead of moving into your base and killing wf