### PR TITLE
Option to build with CrashPad as a crash handler.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -56,7 +56,7 @@ jobs:
           CC: ${{ steps.vars.outputs.cc }}
           CXX: ${{ steps.vars.outputs.cxx }}
       run: |
-        cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DMAP_EDITORTD=ON -DMAP_EDITORRA=ON -DBUILD_TOOLS=ON -DNETWORKING=ON -DBUILD_TESTS=ON -B build
+        cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DMAP_EDITORTD=ON -DMAP_EDITORRA=ON -DBUILD_TOOLS=ON -DUSE_CRASHPAD=ON -DNETWORKING=ON -DBUILD_TESTS=ON -B build
 
     - name: Check formatting
       if: ${{ matrix.platform }} == clang
@@ -70,12 +70,15 @@ jobs:
         cp ./build/vanillatd ./build/vanillatd.dbg
         cp ./build/vanillara ./build/vanillara.dbg
         cp ./build/vanillamix ./build/vanillamix.dbg
+        cp ./build/vc_crashhandler ./build/vc_crashhandler.dbg
         strip --strip-all ./build/vanillatd
         strip --strip-all ./build/vanillara
         strip --strip-all ./build/vanillamix
+        strip --strip-all ./build/vc_crashhandler
         objcopy --add-gnu-debuglink=./build/vanillatd.dbg ./build/vanillatd
         objcopy --add-gnu-debuglink=./build/vanillara.dbg ./build/vanillara
         objcopy --add-gnu-debuglink=./build/vanillamix.dbg ./build/vanillamix
+        objcopy --add-gnu-debuglink=./build/vc_crashhandler.dbg ./build/vc_crashhandler
 
     - name: Run unit tests
       run: |
@@ -85,8 +88,8 @@ jobs:
     - name: Create archives
       run: |
         mkdir artifact
-        7z a artifact/vanilla-conquer-linux-${{ matrix.platform }}-x86_64-${{ steps.gitinfo.outputs.sha_short }}.zip ./build/vanillatd ./build/vanillara ./build/vanillamix
-        7z a artifact/vanilla-conquer-linux-${{ matrix.platform }}-x86_64-${{ steps.gitinfo.outputs.sha_short }}-debug.zip ./build/vanillatd.dbg ./build/vanillara.dbg ./build/vanillamix.dbg
+        7z a artifact/vanilla-conquer-linux-${{ matrix.platform }}-x86_64-${{ steps.gitinfo.outputs.sha_short }}.zip ./build/vanillatd ./build/vanillara ./build/vanillamix ./build/vc_crashhandler
+        7z a artifact/vanilla-conquer-linux-${{ matrix.platform }}-x86_64-${{ steps.gitinfo.outputs.sha_short }}-debug.zip ./build/vanillatd.dbg ./build/vanillara.dbg ./build/vanillamix.dbg ./build/vc_crashhandler.dbg
 
     - name: Upload artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -94,7 +94,7 @@ jobs:
         
     - name: Configure Vanilla Conquer
       run: |
-        cmake -DCMAKE_TOOLCHAIN_FILE=cmake/${{ steps.vars.outputs.arc_path }}-mingw-w64-toolchain.cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DSDL2=ON -DSDL2_ROOT_DIR=/tmp/SDL2-2.0.12 -DSDL2_INCLUDE_DIR=/tmp/SDL2-2.0.12/${{ steps.vars.outputs.arc_path }}-w64-mingw32/include/SDL2 -DSDL2_LIBRARY=/tmp/SDL2-2.0.12/${{ steps.vars.outputs.arc_path }}-w64-mingw32/lib/libSDL2.dll.a -DSDL2_SDLMAIN_LIBRARY=/tmp/SDL2-2.0.12/${{ steps.vars.outputs.arc_path }}-w64-mingw32/lib/libSDL2main.a -DSDL2_RUNTIME_LIBRARY=/tmp/SDL2-2.0.12/${{ steps.vars.outputs.arc_path }}-w64-mingw32/bin/SDL2.dll -DOPENAL=ON -DOPENAL_ROOT=/tmp/openal-soft-1.21.0-bin -DOPENAL_INCLUDE_DIR=/tmp/openal-soft-1.21.0-bin/include/AL -DOPENAL_LIBRARY=/tmp/openal-soft-1.21.0-bin/libs/${{ steps.vars.outputs.oal_path }}/libOpenAL32.dll.a -DOPENAL_RUNTIME_LIBRARY=/tmp/openal-soft-1.21.0-bin/bin/${{ steps.vars.outputs.oal_path }}/OpenAL32.dll -DBUILD_TOOLS=ON -DBUILD_REMASTERTD=OFF -DBUILD_REMASTERRA=OFF -DMAP_EDITORTD=ON -DMAP_EDITORRA=ON -DNETWORKING=ON -DImageMagick_convert_EXECUTABLE=/usr/bin/convert -DImageMagick_convert_FOUND=TRUE -B build
+        cmake -DCMAKE_TOOLCHAIN_FILE=cmake/${{ steps.vars.outputs.arc_path }}-mingw-w64-toolchain.cmake -DCMAKE_BUILD_TYPE=RelWithDebInfo -DCRASHPAD_ZLIB_SYSTEM=OFF -DUSE_CRASHPAD=ON -DSDL2=ON -DSDL2_ROOT_DIR=/tmp/SDL2-2.0.12 -DSDL2_INCLUDE_DIR=/tmp/SDL2-2.0.12/${{ steps.vars.outputs.arc_path }}-w64-mingw32/include/SDL2 -DSDL2_LIBRARY=/tmp/SDL2-2.0.12/${{ steps.vars.outputs.arc_path }}-w64-mingw32/lib/libSDL2.dll.a -DSDL2_SDLMAIN_LIBRARY=/tmp/SDL2-2.0.12/${{ steps.vars.outputs.arc_path }}-w64-mingw32/lib/libSDL2main.a -DSDL2_RUNTIME_LIBRARY=/tmp/SDL2-2.0.12/${{ steps.vars.outputs.arc_path }}-w64-mingw32/bin/SDL2.dll -DOPENAL=ON -DOPENAL_ROOT=/tmp/openal-soft-1.21.0-bin -DOPENAL_INCLUDE_DIR=/tmp/openal-soft-1.21.0-bin/include/AL -DOPENAL_LIBRARY=/tmp/openal-soft-1.21.0-bin/libs/${{ steps.vars.outputs.oal_path }}/libOpenAL32.dll.a -DOPENAL_RUNTIME_LIBRARY=/tmp/openal-soft-1.21.0-bin/bin/${{ steps.vars.outputs.oal_path }}/OpenAL32.dll -DBUILD_TOOLS=ON -DBUILD_REMASTERTD=OFF -DBUILD_REMASTERRA=OFF -DMAP_EDITORTD=ON -DMAP_EDITORRA=ON -DNETWORKING=ON -DImageMagick_convert_EXECUTABLE=/usr/bin/convert -DImageMagick_convert_FOUND=TRUE -B build
 
     - name: Build Vanilla Conquer
       run: |
@@ -102,18 +102,21 @@ jobs:
         cp ./build/vanillatd.exe ./build/vanillatd.dbg
         cp ./build/vanillara.exe ./build/vanillara.dbg
         cp ./build/vanillamix.exe ./build/vanillamix.dbg
+        cp ./build/vc_crashhandler.exe ./build/vc_crashhandler.dbg
         ${{ steps.vars.outputs.arc_path }}-w64-mingw32-strip --strip-all ./build/vanillatd.exe
         ${{ steps.vars.outputs.arc_path }}-w64-mingw32-strip --strip-all ./build/vanillara.exe
         ${{ steps.vars.outputs.arc_path }}-w64-mingw32-strip --strip-all ./build/vanillamix.exe
+        ${{ steps.vars.outputs.arc_path }}-w64-mingw32-strip --strip-all ./build/vc_crashhandler.exe
         ${{ steps.vars.outputs.arc_path }}-w64-mingw32-objcopy --add-gnu-debuglink=./build/vanillatd.dbg ./build/vanillatd.exe
         ${{ steps.vars.outputs.arc_path }}-w64-mingw32-objcopy --add-gnu-debuglink=./build/vanillara.dbg ./build/vanillara.exe
         ${{ steps.vars.outputs.arc_path }}-w64-mingw32-objcopy --add-gnu-debuglink=./build/vanillamix.dbg ./build/vanillamix.exe
+        ${{ steps.vars.outputs.arc_path }}-w64-mingw32-objcopy --add-gnu-debuglink=./build/vc_crashhandler.dbg ./build/vc_crashhandler.exe
 
     - name: Create archives
       run: |
         mkdir artifact
-        7z a artifact/vanilla-conquer-win-gcc-${{ steps.vars.outputs.arc_path }}-${{ steps.gitinfo.outputs.sha_short }}.zip ./build/vanillatd.exe ./build/vanillara.exe ./build/vanillamix.exe /tmp/SDL2-2.0.12/${{ steps.vars.outputs.arc_path }}-w64-mingw32/bin/SDL2.dll /tmp/openal-soft-1.21.0-bin/bin/${{ steps.vars.outputs.oal_path }}/OpenAL32.dll
-        7z a artifact/vanilla-conquer-win-gcc-${{ steps.vars.outputs.arc_path }}-${{ steps.gitinfo.outputs.sha_short }}-debug.zip ./build/vanillatd.dbg ./build/vanillara.dbg ./build/vanillamix.dbg
+        7z a artifact/vanilla-conquer-win-gcc-${{ steps.vars.outputs.arc_path }}-${{ steps.gitinfo.outputs.sha_short }}.zip ./build/vanillatd.exe ./build/vanillara.exe ./build/vanillamix.exe ./build/vc_crashhandler.exe /tmp/SDL2-2.0.12/${{ steps.vars.outputs.arc_path }}-w64-mingw32/bin/SDL2.dll /tmp/openal-soft-1.21.0-bin/bin/${{ steps.vars.outputs.oal_path }}/OpenAL32.dll
+        7z a artifact/vanilla-conquer-win-gcc-${{ steps.vars.outputs.arc_path }}-${{ steps.gitinfo.outputs.sha_short }}-debug.zip ./build/vanillatd.dbg ./build/vanillara.dbg ./build/vanillamix.dbg ./build/vc_crashhandler.dbg
 
     - name: Upload artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -123,7 +123,7 @@ jobs:
         
     - name: Configure Vanilla Conquer
       run: |
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TOOLS=ON -DBUILD_TESTS=ON -DSDL2=ON "-DSDL2_ROOT_DIR=$($Env:TEMP)\SDL2-2.0.12" -DOPENAL=ON "-DOPENAL_ROOT=C:\Program Files (x86)\OpenAL 1.1 SDK" -DBUILD_REMASTERTD=OFF -DBUILD_REMASTERRA=OFF -DMAP_EDITORTD=ON -DMAP_EDITORRA=ON -DNETWORKING=ON "-DImageMagick_convert_EXECUTABLE=C:\Program Files\ImageMagick-7.0.10-Q16-HDRI\magick.exe" -DImageMagick_convert_FOUND=TRUE -B build
+        cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DBUILD_TOOLS=ON -DUSE_CRASHPAD=ON -DBUILD_TESTS=ON -DSDL2=ON "-DSDL2_ROOT_DIR=$($Env:TEMP)\SDL2-2.0.12" -DOPENAL=ON "-DOPENAL_ROOT=C:\Program Files (x86)\OpenAL 1.1 SDK" -DBUILD_REMASTERTD=OFF -DBUILD_REMASTERRA=OFF -DMAP_EDITORTD=ON -DMAP_EDITORRA=ON -DNETWORKING=ON "-DImageMagick_convert_EXECUTABLE=C:\Program Files\ImageMagick-7.0.10-Q16-HDRI\magick.exe" -DImageMagick_convert_FOUND=TRUE -B build
 
     - name: Build Vanilla Conquer
       run: |
@@ -139,8 +139,8 @@ jobs:
       shell: bash
       run: |
         mkdir artifact
-        7z a artifact/vanilla-conquer-win-msvc-${{ steps.vars.outputs.arc_path }}-${{ steps.gitinfo.outputs.sha_short }}.zip ./build/vanillatd.exe ./build/vanillara.exe ./build/vanillamix.exe $TEMP/SDL2-2.0.12/lib/${{ steps.vars.outputs.sdl_path }}/SDL2.dll $TEMP/openal-soft-1.21.0-bin/bin/${{ steps.vars.outputs.oal_path }}/OpenAL32.dll
-        7z a artifact/vanilla-conquer-win-msvc-${{ steps.vars.outputs.arc_path }}-${{ steps.gitinfo.outputs.sha_short }}-debug.zip ./build/vanillatd.pdb ./build/vanillara.pdb ./build/vanillamix.pdb
+        7z a artifact/vanilla-conquer-win-msvc-${{ steps.vars.outputs.arc_path }}-${{ steps.gitinfo.outputs.sha_short }}.zip ./build/vanillatd.exe ./build/vanillara.exe ./build/vanillamix.exe ./build/vc_crashhandler.exe $TEMP/SDL2-2.0.12/lib/${{ steps.vars.outputs.sdl_path }}/SDL2.dll $TEMP/openal-soft-1.21.0-bin/bin/${{ steps.vars.outputs.oal_path }}/OpenAL32.dll
+        7z a artifact/vanilla-conquer-win-msvc-${{ steps.vars.outputs.arc_path }}-${{ steps.gitinfo.outputs.sha_short }}-debug.zip ./build/vanillatd.pdb ./build/vanillara.pdb ./build/vanillamix.pdb ./build/vc_crashhandler.pdb
 
     - name: Upload artifact
       uses: actions/upload-artifact@v2

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,7 @@ option(SDL2 "Enable SDL2 video backend." ON)
 option(OPENAL "Enable OpenAL audio backend." ON)
 option(BUILD_TESTS "Build unit tests." OFF)
 option(BUILD_TOOLS "Build modding utilities." OFF)
+option(USE_CRASHPAD "Build CrashPad to use as the crash handler." OFF)
 
 add_feature_info(RemasterTD BUILD_REMASTERTD, "Remastered Tiberian Dawn dll")
 add_feature_info(RemasterRA BUILD_REMASTERRA "Remastered Red Alert dll")
@@ -36,6 +37,7 @@ add_feature_info(SDL2 SDL2 "SDL2 video backend")
 add_feature_info(OpenAL OPENAL "OpenAL audio backend")
 add_feature_info(Tests BUILD_TESTS "Unit tests")
 add_feature_info(Tools BUILD_TOOLS "Mod developer tools")
+add_feature_info(CrashPad USE_CRASHPAD "CrashPad exception handler")
 
 if(NOT BUILD_VANILLATD AND NOT BUILD_VANILLARA)
     set(DSOUND OFF)
@@ -115,6 +117,51 @@ if(OPENAL)
     find_package(OpenAL REQUIRED)
     list(APPEND VANILLA_LIBS OpenAL::OpenAL)
     set(DSOUND OFF)
+endif()
+
+if(USE_CRASHPAD)
+    include(FetchContent)
+    # Disables zlib tests from being run when they aren't built if CrashPad builds its own zlib.
+    configure_file(${CMAKE_CURRENT_SOURCE_DIR}/cmake/CTestCustom.cmake ${CMAKE_BINARY_DIR})
+
+    FetchContent_Declare(
+        crashpad_cmake
+        GIT_REPOSITORY https://github.com/TheAssemblyArmada/crashpad.git
+        GIT_TAG        4949a4cee5f321d248829d70f8600762f8e43f88
+    )
+
+    # We don't use FetchContent_MakeAvailable here because we don't want all crashpad targets including, just our dependencies.
+    FetchContent_GetProperties(crashpad_cmake)
+    if(NOT crashpad_cmake_POPULATED)
+        FetchContent_Populate(crashpad_cmake)
+        add_subdirectory(${crashpad_cmake_SOURCE_DIR} ${crashpad_cmake_BINARY_DIR} EXCLUDE_FROM_ALL)
+    endif()
+
+    if(WIN32 OR CMAKE_SYSTEM_NAME STREQUAL "Windows")
+        include(BuildIcons)
+        include(ProductVersion)
+        make_icon(INPUT "${CMAKE_SOURCE_DIR}/resources/vanillacrash_icon.svg" OUTPUT VANILLACRASH_ICON)
+        generate_product_version(
+            CRASHPAD_RC
+            NAME "Vanilla Conquer Crash Handler"
+            BUNDLE "Vanilla-Conquer"
+            VERSION_MAJOR 1
+            VERSION_MINOR 0
+            COMPANY_NAME "Vanilla-Conquer"
+            COMPANY_COPYRIGHT "Based on code released by Google under the Apache 2.0 license."
+            ORIGINAL_FILENAME "crashpad_handler.exe"
+            RCFILE_PREFIX "CrashPad"
+            ICON "${VANILLACRASH_ICON}"
+        )
+
+        target_sources(crashpad_handler PRIVATE ${CRASHPAD_RC})
+        # Hack to make the icon generate.
+        add_custom_target(crash_icon DEPENDS ${VANILLACRASH_ICON})
+        add_dependencies(crashpad_handler crash_icon)
+    endif()
+
+    set_target_properties(crashpad_handler PROPERTIES OUTPUT_NAME vc_crashhandler)
+    list(APPEND VANILLA_DEFS BUILD_WITH_CRASHPAD)
 endif()
 
 add_subdirectory(common)

--- a/cmake/CTestCustom.cmake
+++ b/cmake/CTestCustom.cmake
@@ -1,0 +1,17 @@
+set(CTEST_CUSTOM_TESTS_IGNORE
+    example
+    example64
+    SystemSnapshotWinTest.TimeZone
+    FileReaderHTTPBodyStream.ReadASCIIFile
+    FileReaderHTTPBodyStream.ReadBinaryFile
+    HTTPMultipartBuilder.ThreeFileAttachments
+    HTTPMultipartBuilder.OverwriteFileAttachment
+    HTTPMultipartBuilder.SharedFormDataAndAttachmentKeyNamespace
+    VariableBufferSize/CompositeHTTPBodyStreamBufferSize.StringsAndFile/1
+    VariableBufferSize/CompositeHTTPBodyStreamBufferSize.StringsAndFile/2
+    VariableBufferSize/CompositeHTTPBodyStreamBufferSize.StringsAndFile/9
+    VariableBufferSize/CompositeHTTPBodyStreamBufferSize.StringsAndFile/16
+    VariableBufferSize/CompositeHTTPBodyStreamBufferSize.StringsAndFile/31
+    VariableBufferSize/CompositeHTTPBodyStreamBufferSize.StringsAndFile/128
+    VariableBufferSize/CompositeHTTPBodyStreamBufferSize.StringsAndFile/1024
+)

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -108,6 +108,7 @@ else()
 endif()
 
 set(COMMONR_SRC
+    crashpad.cpp
     framelimit.cpp
     gbuffer.cpp
     interpal.cpp
@@ -119,6 +120,7 @@ set(COMMONR_SRC
 )
 
 set(COMMONV_SRC
+    crashpad.cpp
     framelimit.cpp
     gbuffer.cpp
     interpal.cpp
@@ -157,6 +159,10 @@ if(DSOUND OR DDRAW)
     list(APPEND VANILLA_LIBS dxguid)
 endif()
 
+if(USE_CRASHPAD)
+    list(APPEND VANILLA_LIBS crashpad_client)
+endif()
+
 file(GLOB_RECURSE COMMON_HEADERS "*.h")
 
 add_library(common STATIC ${COMMON_SRC} ${COMMON_HEADERS})
@@ -185,5 +191,10 @@ if(BUILD_VANILLATD OR BUILD_VANILLARA)
     endif()
     if(SDL2)
         target_compile_definitions(commonv PUBLIC SDL2_BUILD)
+    endif()
+    if(USE_CRASHPAD)
+        add_dependencies(commonv crashpad_handler)
+        target_include_directories(commonv PRIVATE ${crashpad_git_SOURCE_DIR})
+        message("crashpad_client directory is at ${crashpad_git_SOURCE_DIR}")
     endif()
 endif()

--- a/common/crashpad.cpp
+++ b/common/crashpad.cpp
@@ -1,0 +1,83 @@
+// TiberianDawn.DLL and RedAlert.dll and corresponding source code is free
+// software: you can redistribute it and/or modify it under the terms of
+// the GNU General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+
+// TiberianDawn.DLL and RedAlert.dll and corresponding source code is distributed
+// in the hope that it will be useful, but with permitted additional restrictions
+// under Section 7 of the GPL. See the GNU General Public License in LICENSE.TXT
+// distributed with this program. You should have received a copy of the
+// GNU General Public License along with permitted additional restrictions
+// with this program. If not, see https://github.com/electronicarts/CnC_Remastered_Collection
+#include "crashpad.h"
+#include "ccfile.h"
+#include "gitinfo.h"
+#include "ini.h"
+#include "paths.h"
+#include "utf.h"
+#ifdef BUILD_WITH_CRASHPAD
+#include <client/crash_report_database.h>
+#include <client/settings.h>
+#include <client/crashpad_client.h>
+#endif
+
+bool Init_Crash_Handler(const char* config_file)
+{
+    bool success = false;
+#ifdef BUILD_WITH_CRASHPAD
+    // Minichromiums api for paths is retarded and requires utf16 for windows, utf8 everywhere else.
+#ifdef _WIN32
+    std::wstring homedir = UTF8To16(Paths.User_Path());
+    homedir += L"crashlogs";
+    std::wstring handler_path = L"vc_crashhandler.exe";
+#else
+    std::string homedir = Paths.User_Path();
+    homedir += "crashlogs";
+    std::string handler_path = "vc_crashhandler";
+#endif
+
+    // Cache directory that will store crashpad information and minidumps
+    base::FilePath database(homedir);
+    // Path to the out-of-process handler executable
+    base::FilePath handler(handler_path);
+    // URL used to submit minidumps to
+    std::string url = "";
+    // Optional annotations passed via --annotations to the handler
+    std::map<std::string, std::string> annotations = {{"commit", GitSHA1}};
+    // Optional arguments to pass to the handler
+    std::vector<std::string> arguments;
+    // Optional attachments to upload with crash reports
+    std::vector<base::FilePath> attachments;
+    // Do we allow crash logs to be uploaded if we have a url to upload to?
+    bool allow_upload = false;
+
+    if (config_file != nullptr) {
+        const char section[] = "CrashReporting";
+        CCFileClass fc(config_file);
+        INIClass ini;
+        ini.Load(fc);
+
+        allow_upload = ini.Get_Bool(section, "AllowUpload", allow_upload);
+        url = ini.Get_String(section, "UploadURL", url);
+    }
+
+    std::unique_ptr<crashpad::CrashReportDatabase> db = crashpad::CrashReportDatabase::Initialize(database);
+
+    if (db != nullptr && db->GetSettings() != nullptr) {
+        db->GetSettings()->SetUploadsEnabled(allow_upload);
+    }
+
+    crashpad::CrashpadClient client;
+
+    success = client.StartHandler(handler,
+                                  database,
+                                  database,
+                                  url,
+                                  annotations,
+                                  arguments,
+                                  /* restartable */ true,
+                                  /* asynchronous_start */ false,
+                                  attachments);
+#endif
+    return success;
+}

--- a/common/crashpad.h
+++ b/common/crashpad.h
@@ -1,0 +1,18 @@
+// TiberianDawn.DLL and RedAlert.dll and corresponding source code is free
+// software: you can redistribute it and/or modify it under the terms of
+// the GNU General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+
+// TiberianDawn.DLL and RedAlert.dll and corresponding source code is distributed
+// in the hope that it will be useful, but with permitted additional restrictions
+// under Section 7 of the GPL. See the GNU General Public License in LICENSE.TXT
+// distributed with this program. You should have received a copy of the
+// GNU General Public License along with permitted additional restrictions
+// with this program. If not, see https://github.com/electronicarts/CnC_Remastered_Collection
+
+#ifndef CRASHPAD_H
+#define CRASHPAD_H
+
+bool Init_Crash_Handler(const char* config_file = nullptr);
+
+#endif

--- a/redalert/startup.cpp
+++ b/redalert/startup.cpp
@@ -37,6 +37,7 @@
 #include "function.h"
 #include "language.h"
 #include "settings.h"
+#include "common/crashpad.h"
 #include "common/paths.h"
 #include "common/utfargs.h"
 
@@ -260,6 +261,7 @@ int main(int argc, char* argv[])
     Paths.Init("vanillara", CONFIG_FILE_NAME, "REDALERT.MIX", args.ArgV[0]);
     vc_chdir(Paths.Data_Path());
     CDFileClass::Refresh_Search_Drives();
+    Init_Crash_Handler(CONFIG_FILE_NAME);
 
     if (Parse_Command_Line(args.ArgC, args.ArgV)) {
 

--- a/resources/vanillacrash_icon.svg
+++ b/resources/vanillacrash_icon.svg
@@ -1,0 +1,304 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   id="SVGRoot"
+   version="1.1"
+   viewBox="0 0 1024.0 1024.0"
+   height="1024.0px"
+   width="1024.0px"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <title
+     id="title4960">Vanilla Conquer</title>
+  <defs
+     id="defs3036">
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       id="filter4621"
+       x="-0.06104745"
+       y="-0.051833988"
+       width="1.1566668"
+       height="1.1541048">
+      <feFlood
+         flood-opacity="0.498039"
+         flood-color="rgb(0,0,0)"
+         result="flood"
+         id="feFlood4611" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite4613" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="6.58683"
+         result="blur"
+         id="feGaussianBlur4615" />
+      <feOffset
+         dx="23.9521"
+         dy="14.9701"
+         result="offset"
+         id="feOffset4617" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite4619" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       id="filter4647">
+      <feFlood
+         flood-opacity="0.498039"
+         flood-color="rgb(0,0,0)"
+         result="flood"
+         id="feFlood4637" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite4639" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="6.58683"
+         result="blur"
+         id="feGaussianBlur4641" />
+      <feOffset
+         dx="23.9521"
+         dy="14.9701"
+         result="offset"
+         id="feOffset4643" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite4645" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       id="filter4663">
+      <feFlood
+         flood-opacity="0.498039"
+         flood-color="rgb(0,0,0)"
+         result="flood"
+         id="feFlood4653" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite4655" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="6.58683"
+         result="blur"
+         id="feGaussianBlur4657" />
+      <feOffset
+         dx="23.9521"
+         dy="14.9701"
+         result="offset"
+         id="feOffset4659" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite4661" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       id="filter4919">
+      <feFlood
+         flood-opacity="0.498039"
+         flood-color="rgb(0,0,0)"
+         result="flood"
+         id="feFlood4909" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite4911" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="6.58683"
+         result="blur"
+         id="feGaussianBlur4913" />
+      <feOffset
+         dx="15.2695"
+         dy="10.1796"
+         result="offset"
+         id="feOffset4915" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite4917" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB;"
+       id="filter932"
+       x="-0.022604129"
+       y="-0.023767389"
+       width="1.0670418"
+       height="1.0628395">
+      <feFlood
+         flood-opacity="0.498039"
+         flood-color="rgb(0,0,0)"
+         result="flood"
+         id="feFlood922" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite924" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="6.58683"
+         result="blur"
+         id="feGaussianBlur926" />
+      <feOffset
+         dx="15.2695"
+         dy="10.1796"
+         result="offset"
+         id="feOffset928" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite930" />
+    </filter>
+    <filter
+       style="color-interpolation-filters:sRGB"
+       id="filter98"
+       x="-0.045215169"
+       y="-0.058601581"
+       width="1.113077"
+       height="1.1379126">
+      <feFlood
+         flood-opacity="0.498039"
+         flood-color="rgb(0,0,0)"
+         result="flood"
+         id="feFlood88" />
+      <feComposite
+         in="flood"
+         in2="SourceGraphic"
+         operator="in"
+         result="composite1"
+         id="feComposite90" />
+      <feGaussianBlur
+         in="composite1"
+         stdDeviation="3"
+         result="blur"
+         id="feGaussianBlur92" />
+      <feOffset
+         dx="13.1737"
+         dy="10.479"
+         result="offset"
+         id="feOffset94" />
+      <feComposite
+         in="SourceGraphic"
+         in2="offset"
+         operator="over"
+         result="composite2"
+         id="feComposite96" />
+    </filter>
+  </defs>
+  <metadata
+     id="metadata3039">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Vanilla Conquer</dc:title>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/4.0/" />
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>OmniBlade</dc:title>
+          </cc:Agent>
+        </dc:creator>
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/4.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     id="g643"
+     transform="translate(14,20)">
+    <path
+       d="M 386.4102,639.99998 40.00002,39.999994 l 692.82032,-1.9e-5 z"
+       style="fill:#375d9e;fill-opacity:0.964706;stroke:#ffc923;stroke-width:30.584;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter4621)"
+       id="path3052"
+       transform="matrix(0.8888889,0,0,0.8888889,0.524275,-5.5555624)" />
+    <path
+       d="M 344.00001,441.35816 195.95436,197.7818 h 296.09128 z"
+       id="path4523"
+       style="fill:#375d9e;fill-opacity:0.964706;stroke:#ffc923;stroke-width:32.0643;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       d="m 344.00001,320 -86.50712,-122.38424 173.01423,-1e-5 z"
+       style="fill:#375d9e;fill-opacity:0.964706;stroke:#ffc923;stroke-width:30;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4525" />
+    <path
+       d="m 159.89922,160 a 184.2899,104.60308 0 0 1 92.14495,-90.588926 184.2899,104.60308 0 0 1 184.2899,2e-6 A 184.2899,104.60308 0 0 1 528.47902,160 h -184.2899 z"
+       style="fill:#ffc923;fill-opacity:1;stroke:#ffc923;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4527" />
+  </g>
+  <g
+     id="g383"
+     transform="matrix(0.90309181,0,0,0.90309181,79.752459,72.942)">
+    <path
+       transform="matrix(1.0790514,0,0,1.0790514,-37.250957,-85.944664)"
+       d="M 558.50781,480 344.72461,835.25554 424.51562,986 H 869.99414 L 942.8418,835.25554 736.35156,480 Z"
+       style="fill:#cc0000;fill-opacity:1;stroke:#000000;stroke-width:44.9048;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter98)"
+       id="path5896" />
+    <path
+       d="M 657.42424,912.56504 532.66728,668.00001 782.18118,668 Z"
+       id="path4523-6"
+       style="fill:#cc0000;fill-opacity:1;stroke:#000000;stroke-width:29.4942;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       d="m 657.42424,790.71429 -72.8989,-122.881 145.79779,-1e-5 z"
+       style="fill:#cc0000;fill-opacity:1;stroke:#000000;stroke-width:27.5953;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4525-4" />
+    <path
+       d="m 502.12454,630.06488 a 155.29971,105.02766 0 0 1 77.64986,-90.95662 155.29971,105.02766 0 0 1 155.29972,0 155.29971,105.02766 0 0 1 77.64985,90.95662 H 657.42426 Z"
+       style="fill:#000000;fill-opacity:1;stroke:#ffc923;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="path4527-4" />
+  </g>
+  <path
+     d="m 748.85798,658.7264 -95.52917,-27.51059 40.1394,148.80365 -109.38102,-108.72967 -11.32927,86.64933 -52.22038,-56.76707 -49.39839,72.29397 -18.28366,-102.42863 -79.47997,64.58296 22.0777,-103.48633 -127.99057,84.41016 80.5974,-147.76853 -100.16757,-0.90321 106.38375,-82.20703 -117.15597,-25.03991 87.71764,-37.96437 -44.31798,-63.26978 85.60333,-8.51793 -70.63036,-131.25766 119.19261,80.02417 -14.09275,-128.99313 69.66728,99.1487 46.90484,-78.67978 34.85071,92.11101 63.43073,-84.22037 2.61919,107.76659 88.51599,-41.65315 -13.63951,81.12813 110.571,-27.25927 -88.00909,101.67475 87.35839,33.55841 -90.41259,44.97871 81.91915,62.48629 -95.58982,5.34087 z"
+     id="path2988"
+     style="fill:#ff0000;fill-opacity:1;fill-rule:nonzero;stroke:#230046;stroke-width:0;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:0.977169" />
+  <path
+     d="m 717.98909,631.50564 -82.56701,-23.77771 34.69295,128.61276 -94.53932,-93.97635 -9.66371,82.90753 -46.34005,-46.89628 -44.84965,64.18187 -12.57173,-100.41127 -68.69551,55.81986 16.14693,-87.8506 -113.20495,73.54694 75.17756,-129.90228 -86.57606,-0.78064 89.6134,-69.40452 -100.12262,-26.99498 77.01408,-29.10841 -52.07289,-57.09569 87.75632,-4.95131 -66.43172,-116.84212 106.82786,74.97125 -13.63796,-112.70572 59.99196,82.05503 38.41192,-67.25624 35.50693,81.30997 59.03769,-75.154 0.67261,96.8829 84.84687,-41.43278 -11.29186,76.32345 91.646,-25.71012 -83.60638,87.87874 75.50492,29.00495 -78.1447,38.87566 70.80372,54.00762 -82.61944,4.61619 z"
+     id="path2988-7"
+     style="fill:#ffa500;fill-opacity:1;fill-rule:nonzero;stroke:#230046;stroke-width:0;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dashoffset:0;stroke-opacity:0.977169" />
+  <path
+     d="m 694.97317,614.10282 -72.33095,-20.82993 30.39198,112.66829 -82.81903,-82.32583 -8.7478,76.46908 -40.313,-44.92225 -39.28952,56.22504 -11.01319,-87.96297 -66.00433,49.0683 17.75529,-78.52444 -96.27677,54.71628 65.17879,-102.68876 -75.84296,-4.33138 78.06076,-58.89814 -86.13912,-28.83505 66.33842,-18.56762 -45.61727,-50.01742 76.87693,-4.33747 -58.196,-102.35685 92.47656,65.67685 -15.26151,-104.56223 51.12737,72.18536 39.49894,-53.39228 31.10504,71.22974 51.71864,-65.83696 0.5892,84.87207 77.20777,-38.39071 -8.56294,70.0031 76.07575,-23.56996 -73.24146,76.98415 66.14436,25.40912 -68.45687,34.05614 62.02596,47.31216 -72.37686,4.0439 z"
+     id="path2988-7-6"
+     style="fill:#ffff00;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1.77756" />
+</svg>

--- a/tiberiandawn/startup.cpp
+++ b/tiberiandawn/startup.cpp
@@ -35,6 +35,7 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #include "function.h"
+#include "common/crashpad.h"
 #include "common/ini.h"
 #include "common/paths.h"
 #include "common/utfargs.h"
@@ -228,6 +229,7 @@ int main(int argc, char** argv)
     Paths.Init("vanillatd", "CONQUER.INI", "CONQUER.MIX", args.ArgV[0]);
     vc_chdir(Paths.Data_Path());
     CDFileClass::Refresh_Search_Drives();
+    Init_Crash_Handler("CONQUER.INI");
 
     if (Parse_Command_Line(args.ArgC, args.ArgV)) {
 


### PR DESCRIPTION
Implements CrashPad as an optional crash handler.

vccrashhandler.exe needs to be copied to the executable directory along with the game binary.
Currently this is just for saving crashdumps locally, but provides scope for adding an upload URL for crash log services such as sentry.io or backtrace.io.