### PR TITLE
Fix MGG shroud not updating in radar if your own MGG is moving

### DIFF
--- a/redalert/unit.cpp
+++ b/redalert/unit.cpp
@@ -1804,7 +1804,7 @@ void UnitClass::Per_Cell_Process(PCPType why)
         ** If this is a mobile gap generator, restore the shroud where appropriate
         ** and re-shroud around us.
         */
-        if (Class->IsGapper && !House->IsPlayerControl) {
+        if (Class->IsGapper) {
             Shroud_Regen();
         }
 


### PR DESCRIPTION
Fix MGG shroud not updating in radar if your own MGG is moving.

A check prevented the reshroud function from getting called in the cell processing code. The same logic for non-moving Mobile Gap Generators at he end of UnitClass::AI() does not have this specific check and hence when standing still the MGG updates just fine. This bug applies to 3.03 and remaster.