### PR TITLE
Increase globals that can be set by map scripting from 30 to 1204

### DIFF
--- a/redalert/scenario.h
+++ b/redalert/scenario.h
@@ -204,7 +204,7 @@ public:
     **	Global flags that are used in the trigger system and are persistent
     **	over the course of the game.
     */
-    bool GlobalFlags[30];
+    bool GlobalFlags[1024];
 
     /*
     **	This records the bookmark view locations the player has recorded.


### PR DESCRIPTION
Increase globals that can be set by map scripting from 30 to 1204. These are used for triggering events.