### PR TITLE
Fix for issue-605. BufferPtr within the Buffer class now stored as a char*

### DIFF
--- a/common/buff.cpp
+++ b/common/buff.cpp
@@ -61,7 +61,7 @@
  *   07/29/1996 JLB : Created.                                                                 *
  *=============================================================================================*/
 Buffer::Buffer(void* buffer, long size)
-    : BufferPtr(buffer)
+    : BufferPtr((char*)buffer)
     , Size(size)
     , IsAllocated(false)
 {
@@ -77,7 +77,7 @@ Buffer::Buffer(char* buffer, long size)
 
 // Alternate constructor for void const * pointer.
 Buffer::Buffer(void const* buffer, long size)
-    : BufferPtr((void*)buffer)
+    : BufferPtr((char*)buffer)
     , Size(size)
     , IsAllocated(false)
 {

--- a/common/buff.h
+++ b/common/buff.h
@@ -95,7 +95,7 @@ protected:
     /*
     **	Pointer to the buffer memory.
     */
-    void* BufferPtr;
+    char* BufferPtr;
 
     /*
     **	The size of the buffer memory.


### PR DESCRIPTION
This avoids undefined behavior. I have done this in a constrained way to avoid having to make more widepread changes to xpipe.h, xstraw.h and beyond - as I'm led to believe the Buffer class is under wider review / adjustments.