### PR TITLE
Added Gerwin2k's suggestion for fixing task paths on XP

### DIFF
--- a/common/paths_win.cpp
+++ b/common/paths_win.cpp
@@ -111,10 +111,9 @@ const char* PathsClass::Data_Path()
 const char* PathsClass::User_Path()
 {
     if (UserPath.empty()) {
-        LPWSTR path = nullptr;
+        wchar_t path[MAX_PATH];
         HRESULT hr;
-        hr = SHGetKnownFolderPath(FOLDERID_RoamingAppData, KF_FLAG_CREATE, nullptr, &path);
-        FreeCoTaskMemory scope(path);
+        hr = SHGetFolderPathW(nullptr, CSIDL_APPDATA | CSIDL_FLAG_CREATE, nullptr, 0, path);
 
         if (!SUCCEEDED(hr)) {
             DBG_WARN("Failed to retrieve FOLDERID_RoamingAppData for PathsClass::User_Path()");


### PR DESCRIPTION
This is a fix by Gerwin2k. The original implementation is incompatible with Windows XP.

Check the issue for more details: https://github.com/TheAssemblyArmada/Vanilla-Conquer/issues/619