### PR TITLE
Creates Remaster ready mod folders as build output.

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -36,12 +36,16 @@ jobs:
         i686-w64-mingw32-strip --strip-all ./build/RedAlert.dll
         i686-w64-mingw32-objcopy --add-gnu-debuglink=./build/TiberianDawn.dbg ./build/TiberianDawn.dll
         i686-w64-mingw32-objcopy --add-gnu-debuglink=./build/RedAlert.dbg ./build/RedAlert.dll
+        cp -f ./build/TiberianDawn.dll ./build/Vanilla_TD/Data/
+        cp -f ./build/RedAlert.dll ./build/Vanilla_RA/Data/
 
     - name: Create archives
       run: |
         mkdir artifact
         7z a artifact/vanilla-conquer-remasterdll-gcc-${{ steps.gitinfo.outputs.sha_short }}.zip ./build/TiberianDawn.dll ./build/RedAlert.dll
         7z a artifact/vanilla-conquer-remasterdll-gcc-${{ steps.gitinfo.outputs.sha_short }}-debug.zip ./build/TiberianDawn.dbg ./build/RedAlert.dbg
+        7z a artifact/vanilla-ra-remaster-mod-gcc-${{ steps.gitinfo.outputs.sha_short }}.zip ./build/Vanilla_RA
+        7z a artifact/vanilla-td-remaster-mod-gcc-${{ steps.gitinfo.outputs.sha_short }}.zip ./build/Vanilla_TD
 
     - name: Upload artifact
       uses: actions/upload-artifact@v2

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -43,7 +43,9 @@ jobs:
         mkdir artifact
         7z a artifact/vanilla-conquer-remasterdll-msvc-${{ steps.gitinfo.outputs.sha_short }}.zip ./build/RedAlert.dll ./build/TiberianDawn.dll
         7z a artifact/vanilla-conquer-remasterdll-msvc-${{ steps.gitinfo.outputs.sha_short }}-debug.zip ./build/RedAlert.pdb ./build/TiberianDawn.pdb
-  
+        7z a artifact/vanilla-ra-remaster-mod-msvc-${{ steps.gitinfo.outputs.sha_short }}.zip ./build/Vanilla_RA
+        7z a artifact/vanilla-td-remaster-mod-msvc-${{ steps.gitinfo.outputs.sha_short }}.zip ./build/Vanilla_TD
+        
     - name: Upload artifact
       uses: actions/upload-artifact@v2
       with:

--- a/README.md
+++ b/README.md
@@ -87,56 +87,31 @@ If you encounter a bug that may be data related like invisible things or crashin
 
 ### Remastered
 
-The build process will produce `TiberianDawn.dll` and `RedAlert.dll` in your build directory if you enable them with `-DBUILD_REMASTERTD=ON` and `-DBUILD_REMASTERRA=ON`.
+The build process will produce _Vanilla_TD_ and _Vanilla_RA_ directories in your build directory if you enable them with `-DBUILD_REMASTERTD=ON` and `-DBUILD_REMASTERRA=ON`.
 These work as mods for the Remastered Collection.
 
-To manually create a local Remastered mod after launching both games once, head to _My Documents/CnCRemastered/CnCRemastered/Mods_.
+To manually install a local Remastered mod, launch both games once then head to _My Documents/CnCRemastered/CnCRemastered/Mods_.
 You should see _Tiberian\_Dawn_ and _Red\_Alert_ directories.
-
-Create a mod directory within either game, we'll call it _Vanilla_. Create a directory inside it called _Data_.
 
 #### Tiberian Dawn
 
-Copy _TiberianDawn.dll_ to the _Data_ directory. Next create a JSON file (a text file) `ccmod.json` in the mod directory and add the following content:
-
-```json
-{
-    "name": "Vanilla",
-    "description": "",
-    "author": "",
-    "load_order": 1,
-    "version_high": 1,
-    "version_low": 0,
-    "game_type": "TD"
-}
-```
+Copy the _Vanilla_TD_ directory to the _Tiberian\_Dawn_ directory.
 
 The directory structure should look like this:
 
-    My Documents/CnCRemastered/CnCRemastered/Mods/Tiberian_Dawn/Vanilla/Data/TiberianDawn.dll
-    My Documents/CnCRemastered/CnCRemastered/Mods/Tiberian_Dawn/Vanilla/ccmod.json
+    My Documents/CnCRemastered/CnCRemastered/Mods/Tiberian_Dawn/Vanilla_TD/Data/TiberianDawn.dll
+    My Documents/CnCRemastered/CnCRemastered/Mods/Tiberian_Dawn/Vanilla_TD/ccmod.json
+    My Documents/CnCRemastered/CnCRemastered/Mods/Tiberian_Dawn/Vanilla_TD/GameConstants_Mod.xml
 
 You should now see the new mod in the mods list of Tiberian Dawn Remastered.
 
 #### Red Alert
 
-Copy _RedAlert.dll_ to the _Data_ directory. Next create a JSON file (a text file) `ccmod.json` in the mod directory and add the following content:
-
-```json
-{
-    "name": "Vanilla",
-    "description": "",
-    "author": "",
-    "load_order": 1,
-    "version_high": 1,
-    "version_low": 0,
-    "game_type": "RA"
-}
-```
+Copy the _Vanilla_RA_ directory to the _Red\_Alert_ directory.
 
 The directory structure should look like this:
 
-    My Documents/CnCRemastered/CnCRemastered/Mods/Red_Alert/Vanilla/Data/RedAlert.dll
-    My Documents/CnCRemastered/CnCRemastered/Mods/Red_Alert/Vanilla/ccmod.json
+    My Documents/CnCRemastered/CnCRemastered/Mods/Red_Alert/Vanilla_RA/Data/RedAlert.dll
+    My Documents/CnCRemastered/CnCRemastered/Mods/Red_Alert/Vanilla_RA/ccmod.json
 
-You should now see the new mod in the mods list of Tiberian Dawn Remastered.
+You should now see the new mod in the mods list of Red Alert Remastered.

--- a/redalert/CMakeLists.txt
+++ b/redalert/CMakeLists.txt
@@ -221,6 +221,12 @@ if(BUILD_REMASTERRA)
     target_include_directories(RedAlert PUBLIC ${CMAKE_SOURCE_DIR} .)
     target_link_libraries(RedAlert commonr ${REMASTER_LIBS} ${STATIC_LIBS})
     set_target_properties(RedAlert PROPERTIES PREFIX "")
+
+    add_custom_command(TARGET RedAlert POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/resources/remaster_mods/Vanilla_RA ${CMAKE_BINARY_DIR}/Vanilla_RA
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/Vanilla_RA/Data
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:RedAlert> ${CMAKE_BINARY_DIR}/Vanilla_RA/Data/
+    )
 endif()
 
 if(BUILD_VANILLARA)

--- a/resources/remaster_mods/Vanilla_RA/ccmod.json
+++ b/resources/remaster_mods/Vanilla_RA/ccmod.json
@@ -1,0 +1,9 @@
+{
+    "name": "Vanilla RA",
+    "description": "Default changes from Vanilla Conquer.",
+    "author": "The Assembly Armada",
+    "load_order": 1,
+    "version_high": 1,
+    "version_low": 0,
+    "game_type": "RA"
+}

--- a/resources/remaster_mods/Vanilla_TD/GameConstants_Mod.xml
+++ b/resources/remaster_mods/Vanilla_TD/GameConstants_Mod.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<GameConstants>
+    <GameConstantsClass>
+        <CNCTDSupportMegamaps network="client" overwrite="true"> true </CNCTDSupportMegamaps>
+    </GameConstantsClass>
+</GameConstants>

--- a/resources/remaster_mods/Vanilla_TD/ccmod.json
+++ b/resources/remaster_mods/Vanilla_TD/ccmod.json
@@ -1,0 +1,9 @@
+{
+    "name": "Vanilla TD",
+    "description": "Default changes from Vanilla Conquer.",
+    "author": "The Assembly Armada",
+    "load_order": 1,
+    "version_high": 1,
+    "version_low": 0,
+    "game_type": "TD"
+}

--- a/tiberiandawn/CMakeLists.txt
+++ b/tiberiandawn/CMakeLists.txt
@@ -185,6 +185,12 @@ if(BUILD_REMASTERTD)
     target_include_directories(TiberianDawn PUBLIC ${CMAKE_SOURCE_DIR} .)
     target_link_libraries(TiberianDawn commonr ${REMASTER_LIBS} ${STATIC_LIBS})
     set_target_properties(TiberianDawn PROPERTIES PREFIX "")
+
+    add_custom_command(TARGET TiberianDawn POST_BUILD
+        COMMAND ${CMAKE_COMMAND} -E copy_directory ${CMAKE_SOURCE_DIR}/resources/remaster_mods/Vanilla_TD ${CMAKE_BINARY_DIR}/Vanilla_TD
+        COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/Vanilla_TD/Data
+        COMMAND ${CMAKE_COMMAND} -E copy_if_different $<TARGET_FILE:TiberianDawn> ${CMAKE_BINARY_DIR}/Vanilla_TD/Data/
+    )
 endif()
 
 if(BUILD_VANILLATD)


### PR DESCRIPTION
Remaster builds now generate folders for each game with the correct
structure and content to act as ready to go game mods.

README.md is updated to reflect the changes and simplifies the instructions.