### PR TITLE
Gamepad support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -79,12 +79,6 @@ set(REMASTER_LIBS "")
 find_package(ClangFormat)
 include(ClangFormat)
 
-if(BUILD_TESTS)
-    # Tests need to respect some options so need to occur after the options are set.
-    enable_testing()
-    add_subdirectory(tests)
-endif()
-
 if(NOT BUILD_VANILLATD AND MAP_EDITORTD)
     message(WARNING "Internal scenario editor requires a Tiberian Dawn executable to be built, but it was not enabled.")
     set(BUILD_VANILLATD TRUE)
@@ -117,6 +111,12 @@ if(OPENAL)
     find_package(OpenAL REQUIRED)
     list(APPEND VANILLA_LIBS OpenAL::OpenAL)
     set(DSOUND OFF)
+endif()
+
+if(BUILD_TESTS)
+    # Tests need to respect some options so need to occur after the options are set.
+    enable_testing()
+    add_subdirectory(tests)
 endif()
 
 add_subdirectory(common)

--- a/common/settings.cpp
+++ b/common/settings.cpp
@@ -66,7 +66,7 @@ void SettingsClass::Load(INIClass& ini)
     /*
     ** Boxing and raw input require software cursor.
     */
-    if (Video.Boxing || Mouse.RawInput) {
+    if (Video.Boxing || Mouse.RawInput || Mouse.ControllerEnabled) {
         Video.HardwareCursor = false;
     }
 }

--- a/common/settings.cpp
+++ b/common/settings.cpp
@@ -11,6 +11,7 @@ SettingsClass::SettingsClass()
     */
     Mouse.RawInput = true;
     Mouse.Sensitivity = 100;
+    Mouse.ControllerEnabled = false;
     Mouse.ControllerPointerSpeed = 10;
 
     /*
@@ -38,6 +39,7 @@ void SettingsClass::Load(INIClass& ini)
     */
     Mouse.RawInput = ini.Get_Bool("Mouse", "RawInput", Mouse.RawInput);
     Mouse.Sensitivity = ini.Get_Int("Mouse", "Sensitivity", Mouse.Sensitivity);
+    Mouse.ControllerEnabled = ini.Get_Bool("Mouse", "ControllerEnabled", Mouse.ControllerEnabled);
     Mouse.ControllerPointerSpeed = ini.Get_Int("Mouse", "ControllerPointerSpeed", Mouse.ControllerPointerSpeed);
 
     /*
@@ -76,6 +78,7 @@ void SettingsClass::Save(INIClass& ini)
     */
     ini.Put_Bool("Mouse", "RawInput", Mouse.RawInput);
     ini.Put_Int("Mouse", "Sensitivity", Mouse.Sensitivity);
+    ini.Put_Bool("Mouse", "ControllerEnabled", Mouse.ControllerEnabled);
     ini.Put_Int("Mouse", "ControllerPointerSpeed", Mouse.ControllerPointerSpeed);
 
     /*

--- a/common/settings.cpp
+++ b/common/settings.cpp
@@ -11,6 +11,7 @@ SettingsClass::SettingsClass()
     */
     Mouse.RawInput = true;
     Mouse.Sensitivity = 100;
+    Mouse.ControllerPointerSpeed = 10;
 
     /*
     ** Video settings
@@ -37,6 +38,7 @@ void SettingsClass::Load(INIClass& ini)
     */
     Mouse.RawInput = ini.Get_Bool("Mouse", "RawInput", Mouse.RawInput);
     Mouse.Sensitivity = ini.Get_Int("Mouse", "Sensitivity", Mouse.Sensitivity);
+    Mouse.ControllerPointerSpeed = ini.Get_Int("Mouse", "ControllerPointerSpeed", Mouse.ControllerPointerSpeed);
 
     /*
     ** Video settings
@@ -74,6 +76,7 @@ void SettingsClass::Save(INIClass& ini)
     */
     ini.Put_Bool("Mouse", "RawInput", Mouse.RawInput);
     ini.Put_Int("Mouse", "Sensitivity", Mouse.Sensitivity);
+    ini.Put_Int("Mouse", "ControllerPointerSpeed", Mouse.ControllerPointerSpeed);
 
     /*
     ** Video settings

--- a/common/settings.h
+++ b/common/settings.h
@@ -16,6 +16,7 @@ public:
     {
         bool RawInput;
         int Sensitivity;
+        int ControllerPointerSpeed;
     } Mouse;
 
     struct

--- a/common/settings.h
+++ b/common/settings.h
@@ -16,6 +16,7 @@ public:
     {
         bool RawInput;
         int Sensitivity;
+        bool ControllerEnabled;
         int ControllerPointerSpeed;
     } Mouse;
 

--- a/common/video.h
+++ b/common/video.h
@@ -63,14 +63,12 @@ extern SurfaceMonitorClass& AllSurfaces; // List of all surfaces
 bool Set_Video_Mode(int w, int h, int bits_per_pixel);
 void Get_Video_Scale(float& x, float& y);
 void Set_Video_Cursor_Clip(bool clipped);
-void Move_Video_Mouse(int xrel, int yrel);
+void Move_Video_Mouse(float xrel, float yrel);
 void Get_Video_Mouse(int& x, int& y);
 void Toggle_Video_Fullscreen();
 void Reset_Video_Mode();
 unsigned Get_Free_Video_Memory();
 void Wait_Blit();
-void Get_Game_Resolution(int& w, int& h);
-void Set_Video_Mouse(int x, int y);
 
 /*
 ** Set desired cursor image in game palette.

--- a/common/video.h
+++ b/common/video.h
@@ -69,6 +69,8 @@ void Toggle_Video_Fullscreen();
 void Reset_Video_Mode();
 unsigned Get_Free_Video_Memory();
 void Wait_Blit();
+void Get_Game_Resolution(int& w, int& h);
+void Set_Video_Mouse(int x, int y);
 
 /*
 ** Set desired cursor image in game palette.

--- a/common/video_sdl2.cpp
+++ b/common/video_sdl2.cpp
@@ -337,7 +337,7 @@ bool Set_Video_Mode(int w, int h, int bits_per_pixel)
     /*
     ** Init gamepad.
     */
-    if(Settings.Mouse.ControllerEnabled) {
+    if (Settings.Mouse.ControllerEnabled) {
         SDL_Init(SDL_INIT_GAMECONTROLLER);
         Keyboard->Open_Controller();
     }
@@ -379,7 +379,8 @@ void Set_Video_Cursor_Clip(bool clipped)
 
         if (Settings.Video.Windowed) {
             SDL_SetWindowGrab(window, hwcursor.Clip ? SDL_TRUE : SDL_FALSE);
-            relative = SDL_SetRelativeMouseMode(Settings.Mouse.ControllerEnabled || (Settings.Mouse.RawInput && hwcursor.Clip) ? SDL_TRUE : SDL_FALSE);
+            relative = SDL_SetRelativeMouseMode(
+                Settings.Mouse.ControllerEnabled || (Settings.Mouse.RawInput && hwcursor.Clip) ? SDL_TRUE : SDL_FALSE);
 
             /*
             ** When grabbing with raw input, move in-game cursor where the real cursor was and vice versa.

--- a/common/video_sdl2.cpp
+++ b/common/video_sdl2.cpp
@@ -406,9 +406,9 @@ void Set_Video_Cursor_Clip(bool clipped)
     }
 }
 
-void Move_Video_Mouse(int xrel, int yrel)
+void Move_Video_Mouse(float xrel, float yrel)
 {
-    if (hwcursor.Clip || !Settings.Video.Windowed) {
+    if (Keyboard->Is_Gamepad_Active() || hwcursor.Clip || !Settings.Video.Windowed) {
         hwcursor.X += xrel * (Settings.Mouse.Sensitivity / 100.0f);
         hwcursor.Y += yrel * (Settings.Mouse.Sensitivity / 100.0f);
     }
@@ -438,18 +438,6 @@ void Get_Video_Mouse(int& x, int& y)
         x /= scale_x;
         y /= scale_y;
     }
-}
-
-void Get_Game_Resolution(int& w, int& h)
-{
-    w = hwcursor.GameW;
-    h = hwcursor.GameH;
-}
-
-void Set_Video_Mouse(int x, int y)
-{
-    hwcursor.X = x;
-    hwcursor.Y = y;
 }
 
 /***********************************************************************************************

--- a/common/video_sdl2.cpp
+++ b/common/video_sdl2.cpp
@@ -379,7 +379,7 @@ void Set_Video_Cursor_Clip(bool clipped)
 
         if (Settings.Video.Windowed) {
             SDL_SetWindowGrab(window, hwcursor.Clip ? SDL_TRUE : SDL_FALSE);
-            relative = SDL_SetRelativeMouseMode(Settings.Mouse.RawInput && hwcursor.Clip ? SDL_TRUE : SDL_FALSE);
+            relative = SDL_SetRelativeMouseMode(Settings.Mouse.ControllerEnabled || (Settings.Mouse.RawInput && hwcursor.Clip) ? SDL_TRUE : SDL_FALSE);
 
             /*
             ** When grabbing with raw input, move in-game cursor where the real cursor was and vice versa.

--- a/common/video_sdl2.cpp
+++ b/common/video_sdl2.cpp
@@ -337,8 +337,10 @@ bool Set_Video_Mode(int w, int h, int bits_per_pixel)
     /*
     ** Init gamepad.
     */
-    SDL_Init(SDL_INIT_GAMECONTROLLER);
-    Keyboard->Open_Controller();
+    if(Settings.Mouse.ControllerEnabled) {
+        SDL_Init(SDL_INIT_GAMECONTROLLER);
+        Keyboard->Open_Controller();
+    }
 
     return true;
 }

--- a/common/video_sdl2.cpp
+++ b/common/video_sdl2.cpp
@@ -47,6 +47,7 @@
 
 #include <SDL.h>
 
+extern WWKeyboardClass* Keyboard;
 static SDL_Window* window;
 static SDL_Renderer* renderer;
 static SDL_Palette* palette;
@@ -333,6 +334,12 @@ bool Set_Video_Mode(int w, int h, int bits_per_pixel)
     hwcursor.Y = h / 2;
     Update_HWCursor_Settings();
 
+    /*
+    ** Init gamepad.
+    */
+    SDL_Init(SDL_INIT_GAMECONTROLLER);
+    Keyboard->Open_Controller();
+
     return true;
 }
 
@@ -419,7 +426,7 @@ void Move_Video_Mouse(int xrel, int yrel)
 
 void Get_Video_Mouse(int& x, int& y)
 {
-    if (Settings.Mouse.RawInput && (hwcursor.Clip || !Settings.Video.Windowed)) {
+    if (Keyboard->Is_Gamepad_Active() || (Settings.Mouse.RawInput && (hwcursor.Clip || !Settings.Video.Windowed))) {
         x = hwcursor.X;
         y = hwcursor.Y;
     } else {
@@ -429,6 +436,18 @@ void Get_Video_Mouse(int& x, int& y)
         x /= scale_x;
         y /= scale_y;
     }
+}
+
+void Get_Game_Resolution(int& w, int& h)
+{
+    w = hwcursor.GameW;
+    h = hwcursor.GameH;
+}
+
+void Set_Video_Mouse(int x, int y)
+{
+    hwcursor.X = x;
+    hwcursor.Y = y;
 }
 
 /***********************************************************************************************
@@ -468,6 +487,8 @@ void Reset_Video_Mode(void)
 
     SDL_DestroyWindow(window);
     window = nullptr;
+
+    Keyboard->Close_Controller();
 }
 
 static void Update_HWCursor()

--- a/common/wwkeyboard.cpp
+++ b/common/wwkeyboard.cpp
@@ -671,10 +671,10 @@ void WWKeyboardClass::Process_Controller_Axis_Motion()
         const int16_t xSign = (ControllerLeftXAxis > 0) - (ControllerLeftXAxis < 0);
         const int16_t ySign = (ControllerLeftYAxis > 0) - (ControllerLeftYAxis < 0);
 
-        float movX = pow(std::abs(ControllerLeftXAxis), CONTROLLER_AXIS_SPEEDUP) * xSign * deltaTime
-                               * Settings.Mouse.ControllerPointerSpeed / CONTROLLER_SPEED_MOD * ControllerSpeedBoost;
-        float movY = pow(std::abs(ControllerLeftYAxis), CONTROLLER_AXIS_SPEEDUP) * ySign * deltaTime
-                               * Settings.Mouse.ControllerPointerSpeed / CONTROLLER_SPEED_MOD * ControllerSpeedBoost;
+        float movX = std::pow(std::abs(ControllerLeftXAxis), CONTROLLER_AXIS_SPEEDUP) * xSign * deltaTime
+                     * Settings.Mouse.ControllerPointerSpeed / CONTROLLER_SPEED_MOD * ControllerSpeedBoost;
+        float movY = std::pow(std::abs(ControllerLeftYAxis), CONTROLLER_AXIS_SPEEDUP) * ySign * deltaTime
+                     * Settings.Mouse.ControllerPointerSpeed / CONTROLLER_SPEED_MOD * ControllerSpeedBoost;
 
         Move_Video_Mouse(movX, movY);
     }

--- a/common/wwkeyboard.cpp
+++ b/common/wwkeyboard.cpp
@@ -665,7 +665,7 @@ void WWKeyboardClass::Close_Controller()
 void WWKeyboardClass::Process_Controller_Axis_Motion()
 {
     const uint32_t currentTime = SDL_GetTicks();
-    const double deltaTime = currentTime - LastControllerTime;
+    const float deltaTime = currentTime - LastControllerTime;
     LastControllerTime = currentTime;
 
     if (ControllerLeftXAxis != 0 || ControllerLeftYAxis != 0) {

--- a/common/wwkeyboard.cpp
+++ b/common/wwkeyboard.cpp
@@ -555,6 +555,13 @@ void WWKeyboardClass::Fill_Buffer_From_System(void)
             break;
         case SDL_MOUSEMOTION:
             Move_Video_Mouse(event.motion.xrel, event.motion.yrel);
+            if (Is_Gamepad_Active()) {
+                int mousePosX;
+                int mousePosY;
+                Get_Video_Mouse(mousePosX, mousePosY);
+                EmulatedPointerPosX = mousePosX;
+                EmulatedPointerPosY = mousePosY;
+            }
             break;
         case SDL_MOUSEBUTTONDOWN:
         case SDL_MOUSEBUTTONUP: {
@@ -598,7 +605,31 @@ void WWKeyboardClass::Fill_Buffer_From_System(void)
                 break;
             }
             break;
+        case SDL_CONTROLLERDEVICEREMOVED:
+            if (GameController != nullptr) {
+                const SDL_GameController* removedController = SDL_GameControllerFromInstanceID(event.jdevice.which);
+                if (removedController == GameController) {
+                    SDL_GameControllerClose(GameController);
+                    GameController = nullptr;
+                }
+            }
+            break;
+        case SDL_CONTROLLERDEVICEADDED:
+            if (GameController == nullptr) {
+                GameController = SDL_GameControllerOpen(event.jdevice.which);
+            }
+            break;
+        case SDL_CONTROLLERAXISMOTION:
+            Handle_Controller_Axis_Event(event.caxis);
+            break;
+        case SDL_CONTROLLERBUTTONDOWN:
+        case SDL_CONTROLLERBUTTONUP:
+            Handle_Controller_Button_Event(event.cbutton);
+            break;
         }
+    }
+    if (Is_Gamepad_Active()) {
+        Process_Controller_Axis_Motion();
     }
 #elif defined(_WIN32)
     if (!Is_Buffer_Full()) {
@@ -613,6 +644,208 @@ void WWKeyboardClass::Fill_Buffer_From_System(void)
     }
 #endif
 }
+
+#ifdef SDL2_BUILD
+bool WWKeyboardClass::Is_Gamepad_Active()
+{
+    return GameController != nullptr;
+}
+
+void WWKeyboardClass::Open_Controller()
+{
+    for (int i = 0; i < SDL_NumJoysticks(); ++i) {
+        if (SDL_IsGameController(i)) {
+            GameController = SDL_GameControllerOpen(i);
+        }
+    }
+
+    int mousePosX;
+    int mousePosY;
+    Get_Video_Mouse(mousePosX, mousePosY);
+    EmulatedPointerPosX = mousePosX;
+    EmulatedPointerPosY = mousePosY;
+}
+
+void WWKeyboardClass::Close_Controller()
+{
+    if (SDL_GameControllerGetAttached(GameController)) {
+        SDL_GameControllerClose(GameController);
+        GameController = nullptr;
+    }
+}
+
+void WWKeyboardClass::Process_Controller_Axis_Motion()
+{
+    const uint32_t currentTime = SDL_GetTicks();
+    const double deltaTime = currentTime - LastControllerTime;
+    LastControllerTime = currentTime;
+
+    if (ControllerLeftXAxis != 0 || ControllerLeftYAxis != 0) {
+        const int16_t xSign = (ControllerLeftXAxis > 0) - (ControllerLeftXAxis < 0);
+        const int16_t ySign = (ControllerLeftYAxis > 0) - (ControllerLeftYAxis < 0);
+
+        EmulatedPointerPosX += pow(std::abs(ControllerLeftXAxis), CONTROLLER_AXIS_SPEEDUP) * xSign * deltaTime
+                               * Settings.Mouse.ControllerPointerSpeed / CONTROLLER_SPEED_MOD * ControllerSpeedBoost;
+        EmulatedPointerPosY += pow(std::abs(ControllerLeftYAxis), CONTROLLER_AXIS_SPEEDUP) * ySign * deltaTime
+                               * Settings.Mouse.ControllerPointerSpeed / CONTROLLER_SPEED_MOD * ControllerSpeedBoost;
+
+        int width;
+        int height;
+        Get_Game_Resolution(width, height);
+
+        if (EmulatedPointerPosX < 0)
+            EmulatedPointerPosX = 0;
+        else if (EmulatedPointerPosX >= width)
+            EmulatedPointerPosX = width - 1;
+
+        if (EmulatedPointerPosY < 0)
+            EmulatedPointerPosY = 0;
+        else if (EmulatedPointerPosY >= height)
+            EmulatedPointerPosY = height - 1;
+
+        Set_Video_Mouse(EmulatedPointerPosX, EmulatedPointerPosY);
+    }
+}
+
+void WWKeyboardClass::Handle_Controller_Axis_Event(const SDL_ControllerAxisEvent& motion)
+{
+    AnalogScrollActive = false;
+    ScrollDirType directionX = SDIR_NONE;
+    ScrollDirType directionY = SDIR_NONE;
+
+    if (motion.axis == SDL_CONTROLLER_AXIS_LEFTX) {
+        if (std::abs(motion.value) > CONTROLLER_L_DEADZONE)
+            ControllerLeftXAxis = motion.value;
+        else
+            ControllerLeftXAxis = 0;
+    } else if (motion.axis == SDL_CONTROLLER_AXIS_LEFTY) {
+        if (std::abs(motion.value) > CONTROLLER_L_DEADZONE)
+            ControllerLeftYAxis = motion.value;
+        else
+            ControllerLeftYAxis = 0;
+    } else if (motion.axis == SDL_CONTROLLER_AXIS_RIGHTX) {
+        if (std::abs(motion.value) > CONTROLLER_R_DEADZONE)
+            ControllerRightXAxis = motion.value;
+        else
+            ControllerRightXAxis = 0;
+    } else if (motion.axis == SDL_CONTROLLER_AXIS_RIGHTY) {
+        if (std::abs(motion.value) > CONTROLLER_R_DEADZONE)
+            ControllerRightYAxis = motion.value;
+        else
+            ControllerRightYAxis = 0;
+    } else if (motion.axis == SDL_CONTROLLER_AXIS_TRIGGERRIGHT) {
+        if (std::abs(motion.value) > CONTROLLER_TRIGGER_R_DEADZONE)
+            ControllerSpeedBoost = 1 + (static_cast<float>(motion.value) / 32767) * CONTROLLER_TRIGGER_SPEEDUP;
+        else
+            ControllerSpeedBoost = 1;
+    }
+
+    if (ControllerRightXAxis != 0) {
+        AnalogScrollActive = true;
+        directionX = ControllerRightXAxis > 0 ? SDIR_E : SDIR_W;
+    }
+    if (ControllerRightYAxis != 0) {
+        AnalogScrollActive = true;
+        directionY = ControllerRightYAxis > 0 ? SDIR_S : SDIR_N;
+    }
+
+    if (directionX == SDIR_E && directionY == SDIR_N)
+        ScrollDirection = SDIR_NE;
+    else if (directionX == SDIR_E && directionY == SDIR_S)
+        ScrollDirection = SDIR_SE;
+    else if (directionX == SDIR_W && directionY == SDIR_N)
+        ScrollDirection = SDIR_NW;
+    else if (directionX == SDIR_W && directionY == SDIR_S)
+        ScrollDirection = SDIR_SW;
+    else if (directionX == SDIR_E)
+        ScrollDirection = SDIR_E;
+    else if (directionX == SDIR_W)
+        ScrollDirection = SDIR_W;
+    else if (directionY == SDIR_S)
+        ScrollDirection = SDIR_S;
+    else if (directionY == SDIR_N)
+        ScrollDirection = SDIR_N;
+}
+
+void WWKeyboardClass::Handle_Controller_Button_Event(const SDL_ControllerButtonEvent& button)
+{
+    bool keyboardPress = false;
+    bool mousePress = false;
+    unsigned short key;
+    SDL_Scancode scancode;
+
+    switch (button.button) {
+    case SDL_CONTROLLER_BUTTON_A:
+        mousePress = true;
+        key = VK_LBUTTON;
+        break;
+    case SDL_CONTROLLER_BUTTON_B:
+        mousePress = true;
+        key = VK_RBUTTON;
+        break;
+    case SDL_CONTROLLER_BUTTON_X:
+        keyboardPress = true;
+        scancode = SDL_SCANCODE_G;
+        break;
+    case SDL_CONTROLLER_BUTTON_Y:
+        keyboardPress = true;
+        scancode = SDL_SCANCODE_F;
+        break;
+    case SDL_CONTROLLER_BUTTON_BACK:
+        keyboardPress = true;
+        scancode = SDL_SCANCODE_ESCAPE;
+        break;
+    case SDL_CONTROLLER_BUTTON_START:
+        keyboardPress = true;
+        scancode = SDL_SCANCODE_RETURN;
+        break;
+    case SDL_CONTROLLER_BUTTON_LEFTSHOULDER:
+        keyboardPress = true;
+        scancode = SDL_SCANCODE_LCTRL;
+        break;
+    case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER:
+        keyboardPress = true;
+        scancode = SDL_SCANCODE_LALT;
+        break;
+    case SDL_CONTROLLER_BUTTON_DPAD_UP:
+        keyboardPress = true;
+        scancode = SDL_SCANCODE_1;
+        break;
+    case SDL_CONTROLLER_BUTTON_DPAD_RIGHT:
+        keyboardPress = true;
+        scancode = SDL_SCANCODE_2;
+        break;
+    case SDL_CONTROLLER_BUTTON_DPAD_DOWN:
+        keyboardPress = true;
+        scancode = SDL_SCANCODE_3;
+        break;
+    case SDL_CONTROLLER_BUTTON_DPAD_LEFT:
+        keyboardPress = true;
+        scancode = SDL_SCANCODE_4;
+        break;
+    default:
+        break;
+    }
+
+    if (keyboardPress) {
+        Put_Key_Message(scancode, button.state == SDL_RELEASED);
+    } else if (mousePress) {
+        int x, y;
+        Get_Video_Mouse(x, y);
+        Put_Mouse_Message(key, x, y, button.state == SDL_RELEASED);
+    }
+}
+
+bool WWKeyboardClass::Is_Analog_Scroll_Active()
+{
+    return AnalogScrollActive;
+}
+
+unsigned char WWKeyboardClass::Get_Scroll_Direction()
+{
+    return ScrollDirection;
+}
+#endif
 
 /***********************************************************************************************
  * WWKeyboardClass::Clear -- Clears the keyboard buffer.                                       *

--- a/common/wwkeyboard.cpp
+++ b/common/wwkeyboard.cpp
@@ -723,22 +723,23 @@ void WWKeyboardClass::Handle_Controller_Axis_Event(const SDL_ControllerAxisEvent
         directionY = ControllerRightYAxis > 0 ? SDIR_S : SDIR_N;
     }
 
-    if (directionX == SDIR_E && directionY == SDIR_N)
+    if (directionX == SDIR_E && directionY == SDIR_N) {
         ScrollDirection = SDIR_NE;
-    else if (directionX == SDIR_E && directionY == SDIR_S)
+    } else if (directionX == SDIR_E && directionY == SDIR_S) {
         ScrollDirection = SDIR_SE;
-    else if (directionX == SDIR_W && directionY == SDIR_N)
+    } else if (directionX == SDIR_W && directionY == SDIR_N) {
         ScrollDirection = SDIR_NW;
-    else if (directionX == SDIR_W && directionY == SDIR_S)
+    } else if (directionX == SDIR_W && directionY == SDIR_S) {
         ScrollDirection = SDIR_SW;
-    else if (directionX == SDIR_E)
+    } else if (directionX == SDIR_E) {
         ScrollDirection = SDIR_E;
-    else if (directionX == SDIR_W)
+    } else if (directionX == SDIR_W) {
         ScrollDirection = SDIR_W;
-    else if (directionY == SDIR_S)
+    } else if (directionY == SDIR_S) {
         ScrollDirection = SDIR_S;
-    else if (directionY == SDIR_N)
+    } else if (directionY == SDIR_N) {
         ScrollDirection = SDIR_N;
+    }
 }
 
 void WWKeyboardClass::Handle_Controller_Button_Event(const SDL_ControllerButtonEvent& button)

--- a/common/wwkeyboard.cpp
+++ b/common/wwkeyboard.cpp
@@ -554,14 +554,7 @@ void WWKeyboardClass::Fill_Buffer_From_System(void)
             }
             break;
         case SDL_MOUSEMOTION:
-            Move_Video_Mouse(event.motion.xrel, event.motion.yrel);
-            if (Is_Gamepad_Active()) {
-                int mousePosX;
-                int mousePosY;
-                Get_Video_Mouse(mousePosX, mousePosY);
-                EmulatedPointerPosX = mousePosX;
-                EmulatedPointerPosY = mousePosY;
-            }
+            Move_Video_Mouse(static_cast<float>(event.motion.xrel), static_cast<float>(event.motion.yrel));
             break;
         case SDL_MOUSEBUTTONDOWN:
         case SDL_MOUSEBUTTONUP: {
@@ -656,15 +649,8 @@ void WWKeyboardClass::Open_Controller()
     for (int i = 0; i < SDL_NumJoysticks(); ++i) {
         if (SDL_IsGameController(i)) {
             GameController = SDL_GameControllerOpen(i);
-            //Settings.Mouse.RawInput = false;
         }
     }
-
-    int mousePosX;
-    int mousePosY;
-    Get_Video_Mouse(mousePosX, mousePosY);
-    EmulatedPointerPosX = mousePosX;
-    EmulatedPointerPosY = mousePosY;
 }
 
 void WWKeyboardClass::Close_Controller()
@@ -685,26 +671,12 @@ void WWKeyboardClass::Process_Controller_Axis_Motion()
         const int16_t xSign = (ControllerLeftXAxis > 0) - (ControllerLeftXAxis < 0);
         const int16_t ySign = (ControllerLeftYAxis > 0) - (ControllerLeftYAxis < 0);
 
-        EmulatedPointerPosX += pow(std::abs(ControllerLeftXAxis), CONTROLLER_AXIS_SPEEDUP) * xSign * deltaTime
+        float movX = pow(std::abs(ControllerLeftXAxis), CONTROLLER_AXIS_SPEEDUP) * xSign * deltaTime
                                * Settings.Mouse.ControllerPointerSpeed / CONTROLLER_SPEED_MOD * ControllerSpeedBoost;
-        EmulatedPointerPosY += pow(std::abs(ControllerLeftYAxis), CONTROLLER_AXIS_SPEEDUP) * ySign * deltaTime
+        float movY = pow(std::abs(ControllerLeftYAxis), CONTROLLER_AXIS_SPEEDUP) * ySign * deltaTime
                                * Settings.Mouse.ControllerPointerSpeed / CONTROLLER_SPEED_MOD * ControllerSpeedBoost;
 
-        int width;
-        int height;
-        Get_Game_Resolution(width, height);
-
-        if (EmulatedPointerPosX < 0)
-            EmulatedPointerPosX = 0;
-        else if (EmulatedPointerPosX >= width)
-            EmulatedPointerPosX = width - 1;
-
-        if (EmulatedPointerPosY < 0)
-            EmulatedPointerPosY = 0;
-        else if (EmulatedPointerPosY >= height)
-            EmulatedPointerPosY = height - 1;
-
-        Set_Video_Mouse(EmulatedPointerPosX, EmulatedPointerPosY);
+        Move_Video_Mouse(movX, movY);
     }
 }
 

--- a/common/wwkeyboard.cpp
+++ b/common/wwkeyboard.cpp
@@ -55,6 +55,7 @@
 #include "video.h"
 #include "miscasm.h"
 #include <string.h>
+#include <cmath>
 #ifdef SDL2_BUILD
 #include <SDL.h>
 #include "sdl_keymap.h"

--- a/common/wwkeyboard.cpp
+++ b/common/wwkeyboard.cpp
@@ -580,7 +580,7 @@ void WWKeyboardClass::Fill_Buffer_From_System(void)
                 break;
             }
 
-            if (Settings.Mouse.RawInput) {
+            if (Settings.Mouse.RawInput || Is_Gamepad_Active()) {
                 Get_Video_Mouse(x, y);
             } else {
                 float scale_x = 1.0f, scale_y = 1.0f;
@@ -656,6 +656,7 @@ void WWKeyboardClass::Open_Controller()
     for (int i = 0; i < SDL_NumJoysticks(); ++i) {
         if (SDL_IsGameController(i)) {
             GameController = SDL_GameControllerOpen(i);
+            //Settings.Mouse.RawInput = false;
         }
     }
 

--- a/common/wwkeyboard.h
+++ b/common/wwkeyboard.h
@@ -811,7 +811,7 @@ private:
 
     enum
     {
-        CONTROLLER_L_DEADZONE = 3000,
+        CONTROLLER_L_DEADZONE = 4000,
         CONTROLLER_R_DEADZONE = 6000,
         CONTROLLER_TRIGGER_R_DEADZONE = 3000
     };

--- a/common/wwkeyboard.h
+++ b/common/wwkeyboard.h
@@ -799,7 +799,6 @@ private:
 #ifdef SDL2_BUILD
     void Handle_Controller_Axis_Event(const SDL_ControllerAxisEvent& motion);
     void Handle_Controller_Button_Event(const SDL_ControllerButtonEvent& button);
-    void Handle_Touch_Event(const SDL_TouchFingerEvent& event);
     void Process_Controller_Axis_Motion();
 
     // used to convert user-friendly pointer speed values into more useable ones
@@ -822,8 +821,6 @@ private:
     int16_t ControllerRightXAxis = 0;
     int16_t ControllerRightYAxis = 0;
     uint32_t LastControllerTime = 0;
-    float EmulatedPointerPosX = 0;
-    float EmulatedPointerPosY = 0;
     float ControllerSpeedBoost = 1;
     bool AnalogScrollActive = false;
     ScrollDirType ScrollDirection = SDIR_NONE;

--- a/common/wwkeyboard.h
+++ b/common/wwkeyboard.h
@@ -39,6 +39,7 @@
 #include <stdint.h>
 
 #ifdef SDL2_BUILD
+#define SDL_MAIN_HANDLED
 #include <SDL.h>
 #endif
 
@@ -802,9 +803,9 @@ private:
     void Process_Controller_Axis_Motion();
 
     // used to convert user-friendly pointer speed values into more useable ones
-    const double CONTROLLER_SPEED_MOD = 2000000.0;
+    const float CONTROLLER_SPEED_MOD = 2000000.0f;
     // bigger value correndsponds to faster pointer movement speed with bigger stick axis values
-    const double CONTROLLER_AXIS_SPEEDUP = 1.03;
+    const float CONTROLLER_AXIS_SPEEDUP = 1.03f;
     // speedup value while the trigger is pressed
     const int CONTROLLER_TRIGGER_SPEEDUP = 2;
 

--- a/common/wwkeyboard.h
+++ b/common/wwkeyboard.h
@@ -803,11 +803,11 @@ private:
     void Process_Controller_Axis_Motion();
 
     // used to convert user-friendly pointer speed values into more useable ones
-    const float CONTROLLER_SPEED_MOD = 2000000.0f;
+    static constexpr float CONTROLLER_SPEED_MOD = 2000000.0f;
     // bigger value correndsponds to faster pointer movement speed with bigger stick axis values
-    const float CONTROLLER_AXIS_SPEEDUP = 1.03f;
+    static constexpr float CONTROLLER_AXIS_SPEEDUP = 1.03f;
     // speedup value while the trigger is pressed
-    const int CONTROLLER_TRIGGER_SPEEDUP = 2;
+    static constexpr int CONTROLLER_TRIGGER_SPEEDUP = 2;
 
     enum
     {

--- a/redalert/scroll.cpp
+++ b/redalert/scroll.cpp
@@ -98,6 +98,14 @@ void ScrollClass::AI(KeyNumType& input, int x, int y)
 		*/
         bool noscroll = false;
 
+#ifdef SDL2_BUILD
+        if (Keyboard->Is_Analog_Scroll_Active()) {
+            unsigned char scrollDirection = Keyboard->Get_Scroll_Direction();
+            int scrollDistance = (7 - Options.ScrollRate) * 20;
+            Scroll_Map((DirType)scrollDirection, scrollDistance, true);
+        }
+#endif
+
         if (!noscroll) {
             bool at_screen_edge = (y == 0 || x == 0 || x >= SeenBuff.Get_Width() - 1 || y >= SeenBuff.Get_Height() - 1);
 

--- a/tests/drawbuff.cpp
+++ b/tests/drawbuff.cpp
@@ -11,6 +11,19 @@ bool GameInFocus;
 int ScreenWidth;
 int WindowList[9][9];
 extern "C" char* _ShapeBuffer = 0;
+void* Keyboard;
+
+void Process_Network()
+{
+}
+
+void Focus_Restore()
+{
+}
+
+void Focus_Loss()
+{
+}
 
 int Open_File(char const*, int)
 {

--- a/tests/drawbuff.cpp
+++ b/tests/drawbuff.cpp
@@ -1,5 +1,6 @@
 #include "common/drawline.h"
 #include "common/gbuffer.h"
+#include "common/wwkeyboard.h"
 
 #include <stdint.h>
 #include <string.h>
@@ -11,7 +12,7 @@ bool GameInFocus;
 int ScreenWidth;
 int WindowList[9][9];
 extern "C" char* _ShapeBuffer = 0;
-void* Keyboard;
+WWKeyboardClass* Keyboard;
 
 void Process_Network()
 {

--- a/tests/drawline.cpp
+++ b/tests/drawline.cpp
@@ -1,5 +1,6 @@
 #include "common/drawline.h"
 #include "common/gbuffer.h"
+#include "common/wwkeyboard.h"
 
 #include <stdint.h>
 #include <string.h>
@@ -11,7 +12,7 @@ bool GameInFocus;
 int ScreenWidth;
 int WindowList[9][9];
 char* _ShapeBuffer = 0;
-void* Keyboard;
+WWKeyboardClass* Keyboard;
 
 void Process_Network()
 {

--- a/tests/drawline.cpp
+++ b/tests/drawline.cpp
@@ -11,6 +11,19 @@ bool GameInFocus;
 int ScreenWidth;
 int WindowList[9][9];
 char* _ShapeBuffer = 0;
+void* Keyboard;
+
+void Process_Network()
+{
+}
+
+void Focus_Restore()
+{
+}
+
+void Focus_Loss()
+{
+}
 
 int Open_File(char const*, int)
 {

--- a/tests/fatpixel.cpp
+++ b/tests/fatpixel.cpp
@@ -1,5 +1,6 @@
 #include "common/drawmisc.h"
 #include "common/gbuffer.h"
+#include "common/wwkeyboard.h"
 
 #include <stdint.h>
 #include <string.h>
@@ -10,7 +11,7 @@ bool GameInFocus;
 int ScreenWidth;
 int WindowList[9][9];
 char* _ShapeBuffer = 0;
-void* Keyboard;
+WWKeyboardClass* Keyboard;
 
 void Process_Network()
 {

--- a/tests/fatpixel.cpp
+++ b/tests/fatpixel.cpp
@@ -10,6 +10,19 @@ bool GameInFocus;
 int ScreenWidth;
 int WindowList[9][9];
 char* _ShapeBuffer = 0;
+void* Keyboard;
+
+void Process_Network()
+{
+}
+
+void Focus_Restore()
+{
+}
+
+void Focus_Loss()
+{
+}
 
 int Open_File(char const*, int)
 {

--- a/tests/putpixel.cpp
+++ b/tests/putpixel.cpp
@@ -1,5 +1,6 @@
 #include "common/drawbuff.h"
 #include "common/gbuffer.h"
+#include "common/wwkeyboard.h"
 
 #include <stdint.h>
 #include <string.h>
@@ -10,7 +11,7 @@ bool GameInFocus;
 int ScreenWidth;
 int WindowList[9][9];
 char* _ShapeBuffer = 0;
-void* Keyboard;
+WWKeyboardClass* Keyboard;
 
 void Process_Network()
 {

--- a/tests/putpixel.cpp
+++ b/tests/putpixel.cpp
@@ -10,6 +10,19 @@ bool GameInFocus;
 int ScreenWidth;
 int WindowList[9][9];
 char* _ShapeBuffer = 0;
+void* Keyboard;
+
+void Process_Network()
+{
+}
+
+void Focus_Restore()
+{
+}
+
+void Focus_Loss()
+{
+}
 
 int Open_File(char const*, int)
 {

--- a/tests/tobuff.cpp
+++ b/tests/tobuff.cpp
@@ -1,5 +1,6 @@
 #include "common/drawmisc.h"
 #include "common/gbuffer.h"
+#include "common/wwkeyboard.h"
 
 #include <stdint.h>
 #include <string.h>
@@ -10,7 +11,7 @@ bool GameInFocus;
 int ScreenWidth;
 int WindowList[9][9];
 char* _ShapeBuffer = 0;
-void* Keyboard;
+WWKeyboardClass* Keyboard;
 
 void Process_Network()
 {

--- a/tests/tobuff.cpp
+++ b/tests/tobuff.cpp
@@ -10,6 +10,19 @@ bool GameInFocus;
 int ScreenWidth;
 int WindowList[9][9];
 char* _ShapeBuffer = 0;
+void* Keyboard;
+
+void Process_Network()
+{
+}
+
+void Focus_Restore()
+{
+}
+
+void Focus_Loss()
+{
+}
 
 int Open_File(char const*, int)
 {

--- a/tiberiandawn/scroll.cpp
+++ b/tiberiandawn/scroll.cpp
@@ -102,6 +102,14 @@ void ScrollClass::AI(KeyNumType& input, int x, int y)
             noscroll = true;
         }
 
+#ifdef SDL2_BUILD
+        if (Keyboard->Is_Analog_Scroll_Active()) {
+            unsigned char scrollDirection = Keyboard->Get_Scroll_Direction();
+            int scrollDistance = (7 - Options.ScrollRate) * 20;
+            Scroll_Map((DirType)scrollDirection, scrollDistance, true);
+        }
+#endif
+
         if (!noscroll) {
 
             /*


### PR DESCRIPTION
Gamepad support from PS Vita port. Tested on Linux with Xbox Series X (or whatever that name is) controller.
I used bindings from Vita port:
Left analog stick - Cursor movement
Right analog stick - Map scrolling
Right trigger - Cursor speedup
A - Left mouse button
B - Right mouse button
X - G (Guard Area)
Y - F (Formation. RA only)
D-Pad Up/Right/Down/Left - 1/2/3/4 button
R1 - Alt (force move)
L1 - Ctrl (force attack)
SELECT - Esc (opens menu, skips videos)
START - Enter (to submit score after the mission)
