### PR TITLE
Implements base type get and put in Pipe/Straw.

### DIFF
--- a/common/fixed.h
+++ b/common/fixed.h
@@ -66,6 +66,8 @@
 class fixed
 {
     static constexpr unsigned int PRECISION = 1 << 16;
+    friend class Pipe;
+    friend class Straw;
 
 public:
     // The default constructor must not touch the data members in any way.

--- a/common/pipe.h
+++ b/common/pipe.h
@@ -35,24 +35,10 @@
 #ifndef PIPE_H
 #define PIPE_H
 
+#include "endianness.h"
+#include "fixed.h"
 #include <stddef.h>
-
-/*
-**	The "bool" integral type was defined by the C++ committee in
-**	November of '94. Until the compiler supports this, use the following
-**	definition.
-*/
-#ifndef __BORLANDC__
-#ifndef TRUE_FALSE_DEFINED
-#define TRUE_FALSE_DEFINED
-enum
-{
-    false = 0,
-    true = 1
-};
-typedef int bool;
-#endif
-#endif
+#include <stdint.h>
 
 /*
 **	A "push through" pipe interface abstract class used for such purposes as compression
@@ -82,6 +68,64 @@ public:
         Put_To(&pipe);
     }
     virtual int Put(void const* source, int slen);
+
+    /*
+    **	Write fixed width data to the stream.
+    */
+    void Put(int8_t val)
+    {
+        uint8_t data = val;
+        Put(&data, sizeof(data));
+    }
+
+    void Put(uint8_t val)
+    {
+        uint8_t data = val;
+        Put(&data, sizeof(data));
+    }
+
+    void Put(int16_t val)
+    {
+        uint16_t data = htole16(val);
+        Put(&data, sizeof(data));
+    }
+
+    void Put(uint16_t val)
+    {
+        uint16_t data = htole16(val);
+        Put(&data, sizeof(data));
+    }
+
+    void Put(int32_t val)
+    {
+        uint32_t data = htole32(val);
+        Put(&data, sizeof(data));
+    }
+
+    void Put(uint32_t val)
+    {
+        uint32_t data = htole32(val);
+        Put(&data, sizeof(data));
+    }
+
+    void Put(int64_t val)
+    {
+        uint64_t data = htole64(val);
+        Put(&data, sizeof(data));
+    }
+
+    void Put(uint64_t val)
+    {
+        uint64_t data = htole64(val);
+        Put(&data, sizeof(data));
+    }
+
+    void Put(const fixed& val)
+    {
+        uint32_t data = htole32(val.Data.Raw);
+        static_assert(sizeof(data) == sizeof(val.Data.Raw), "Fixed point data does not match written data size.");
+        Put(&data, sizeof(data));
+    }
 
     /*
     **	Pointer to the next pipe segment in the chain.

--- a/common/straw.h
+++ b/common/straw.h
@@ -35,24 +35,10 @@
 #ifndef STRAW_H
 #define STRAW_H
 
+#include "endianness.h"
+#include "fixed.h"
 #include <stdlib.h>
-
-/*
-**	The "bool" integral type was defined by the C++ committee in
-**	November of '94. Until the compiler supports this, use the following
-**	definition.
-*/
-#ifndef __BORLANDC__
-#ifndef TRUE_FALSE_DEFINED
-#define TRUE_FALSE_DEFINED
-enum
-{
-    false = 0,
-    true = 1
-};
-typedef int bool;
-#endif
-#endif
+#include <stdint.h>
 
 /*
 **	This is a demand driven data carrier. It will retrieve the byte request by passing
@@ -77,6 +63,79 @@ public:
         Get_From(&pipe);
     }
     virtual int Get(void* buffer, int slen);
+
+    bool Get(int8_t& val)
+    {
+        uint8_t data;
+        bool success = Get(&data, sizeof(data)) == sizeof(data);
+        val = data;
+        return success;
+    }
+
+    bool Get(uint8_t& val)
+    {
+        uint8_t data;
+        bool success = Get(&data, sizeof(data)) == sizeof(data);
+        val = data;
+        return success;
+    }
+
+    bool Get(int16_t& val)
+    {
+        uint16_t data;
+        bool success = Get(&data, sizeof(data)) == sizeof(data);
+        val = le16toh(data);
+        return success;
+    }
+
+    bool Get(uint16_t& val)
+    {
+        uint16_t data;
+        bool success = Get(&data, sizeof(data)) == sizeof(data);
+        val = le16toh(data);
+        return success;
+    }
+
+    bool Get(int32_t& val)
+    {
+        uint32_t data;
+        bool success = Get(&data, sizeof(data)) == sizeof(data);
+        val = le32toh(data);
+        return success;
+    }
+
+    bool Get(uint32_t& val)
+    {
+        uint32_t data;
+        bool success = Get(&data, sizeof(data)) == sizeof(data);
+        val = le32toh(data);
+        return success;
+    }
+
+    bool Get(int64_t& val)
+    {
+        uint64_t data;
+        bool success = Get(&data, sizeof(data)) == sizeof(data);
+        val = le64toh(data);
+        return success;
+    }
+
+    bool Get(uint64_t& val)
+    {
+        uint64_t data;
+        bool success = Get(&data, sizeof(data)) == sizeof(data);
+        val = le64toh(data);
+        return success;
+    }
+
+    bool Get(fixed& val)
+    {
+        uint32_t data;
+        bool success = Get(&data, sizeof(data)) == sizeof(data);
+        static_assert(sizeof(data) == sizeof(val.Data.Raw), "Fixed point data does not match written data size.");
+        val.Data.Raw = le32toh(data);
+        return success;
+    }
 
     /*
     **	Pointer to the next pipe segment in the chain.


### PR DESCRIPTION
Implements wrappers around the virtual Get/Put functions that read/write
base data types in an endian consistent way.

Intended to work with #633 to form base for developing cross platform consistent save games.