### PR TITLE
Add 320x200 support for VanillaTD

### DIFF
--- a/common/interpal.cpp
+++ b/common/interpal.cpp
@@ -46,6 +46,7 @@
 void Show_Mouse();
 void Hide_Mouse();
 
+extern int Get_Resolution_Factor(void);
 extern GraphicViewPortClass SeenBuff;
 
 bool InterpolationPaletteChanged = false;
@@ -293,23 +294,34 @@ void Interpolate_2X_Scale(GraphicBufferClass* source,
     bool source_locked = false;
     bool dest_locked = false;
 
-    /*
-    **If a palette table exists on disk then read it in otherwise create it
-    */
-    if (InterpolationPaletteChanged) {
-        if (palette_file_name) {
-            Read_Interpolation_Palette(palette_file_name);
-        }
-        if (InterpolationPaletteChanged) {
-            Create_Palette_Interpolation_Table();
-        }
-    }
+    int scale_factor = Get_Resolution_Factor();
 
-    /*
-    ** Write the palette table to disk so we dont have to create it again next time
-    */
-    if (palette_file_name) {
-        Write_Interpolation_Palette(palette_file_name);
+    /* If there is no scaling factor, there is no need for any kind of interpolation. */
+    if (scale_factor == 0)
+        mode = -1;
+
+    /* There is no need to create an interpolation palette if we are not interpolating.  */
+    if (mode == -1) {
+
+        /*
+        **If a palette table exists on disk then read it in otherwise create it
+        */
+
+        if (InterpolationPaletteChanged) {
+            if (palette_file_name) {
+                Read_Interpolation_Palette(palette_file_name);
+            }
+            if (InterpolationPaletteChanged) {
+                Create_Palette_Interpolation_Table();
+            }
+        }
+
+        /*
+        ** Write the palette table to disk so we dont have to create it again next time
+        */
+        if (palette_file_name) {
+            Write_Interpolation_Palette(palette_file_name);
+        }
     }
     if (dest == &SeenBuff)
         Hide_Mouse();
@@ -349,13 +361,17 @@ void Interpolate_2X_Scale(GraphicBufferClass* source,
     // Get width of source and dest buffers.
     //
     src_width = source->Get_Width();
-    dest_width = 2 * (dest->Get_Width() + dest->Get_XAdd() + dest->Get_Pitch());
+    dest_width = (scale_factor + 1) * (dest->Get_Width() + dest->Get_XAdd() + dest->Get_Pitch());
     last_dest_ptr = dest_ptr;
 
     /*
     ** Call the appropriate assembly language copy routine
     */
     switch (mode) {
+    case -1:
+        memcpy(dest_ptr, src_ptr, src_width * source->Get_Height());
+        break;
+
     case 0:
         Asm_Interpolate(src_ptr, dest_ptr, source->Get_Height(), src_width, dest_width);
         break;

--- a/common/settings.cpp
+++ b/common/settings.cpp
@@ -24,6 +24,7 @@ SettingsClass::SettingsClass()
     Video.FrameLimit = 120;
     Video.InterpolationMode = 2;
     Video.HardwareCursor = false;
+    Video.DOSMode = false;
     Video.Scaler = "nearest";
     Video.Driver = "default";
     Video.PixelFormat = "default";
@@ -48,6 +49,7 @@ void SettingsClass::Load(INIClass& ini)
     Video.Height = ini.Get_Int("Video", "Height", Video.Height);
     Video.FrameLimit = ini.Get_Int("Video", "FrameLimit", Video.FrameLimit);
     Video.HardwareCursor = ini.Get_Bool("Video", "HardwareCursor", Video.HardwareCursor);
+    Video.DOSMode = ini.Get_Bool("Video", "DOSMode", Video.DOSMode);
     Video.Scaler = ini.Get_String("Video", "Scaler", Video.Scaler);
     Video.Driver = ini.Get_String("Video", "Driver", Video.Driver);
     Video.PixelFormat = ini.Get_String("Video", "PixelFormat", Video.PixelFormat);
@@ -84,6 +86,7 @@ void SettingsClass::Save(INIClass& ini)
     ini.Put_Int("Video", "Height", Video.Height);
     ini.Put_Int("Video", "FrameLimit", Video.FrameLimit);
     ini.Put_Bool("Video", "HardwareCursor", Video.HardwareCursor);
+    ini.Put_Bool("Video", "DOSMode", Video.DOSMode);
     ini.Put_String("Video", "Scaler", Video.Scaler);
     ini.Put_String("Video", "Driver", Video.Driver);
     ini.Put_String("Video", "PixelFormat", Video.PixelFormat);

--- a/common/settings.h
+++ b/common/settings.h
@@ -29,6 +29,7 @@ public:
         int FrameLimit;
         int InterpolationMode;
         bool HardwareCursor;
+        bool DOSMode;
         std::string Scaler;
         std::string Driver;
         std::string PixelFormat;

--- a/redalert/conquer.cpp
+++ b/redalert/conquer.cpp
@@ -100,6 +100,12 @@ TcpipManagerClass Winsock;
 MPG_RESPONSE far __stdcall MpegCallback(MPG_CMD cmd, LPVOID data, LPVOID user);
 #endif
 
+/* Dummy function for Interpolate_2X_Scale in `common` database. */
+int Get_Resolution_Factor(void)
+{
+    return 1;
+}
+
 #define SHAPE_TRANS 0x40
 
 void* Get_Shape_Header_Data(void* ptr);

--- a/tiberiandawn/conquer.cpp
+++ b/tiberiandawn/conquer.cpp
@@ -3785,7 +3785,7 @@ static void Do_Record_Playback(void)
  * HISTORY:                                                                *
  *   01/25/1996     : Created.                                             *
  *=========================================================================*/
-void const* Hires_Retrieve(char* name)
+void const* Hires_Retrieve(const char* name)
 {
     char filename[30];
 

--- a/tiberiandawn/credits.cpp
+++ b/tiberiandawn/credits.cpp
@@ -103,8 +103,13 @@ void CreditClass::Graphic_Logic(bool forced)
         **	Display the new current value.
         */
         // LogicPage->Fill_Rect(xx-(20 << factor), 1 << factor, xx+(20 << factor), 6 << factor, LTGREY);
+
+        TextPrintType flags =
+            factor ? TPF_GREEN12_GRAD | TPF_CENTER | TPF_USE_GRAD_PAL : TPF_6PT_GRAD | TPF_CENTER | TPF_NOSHADOW;
+        unsigned fore = factor ? 11 : WHITE;
+
         TabClass::Draw_Credits_Tab();
-        Fancy_Text_Print("%ld", xx, 0, 11, TBLACK, TPF_GREEN12_GRAD | TPF_CENTER | TPF_USE_GRAD_PAL, Current);
+        Fancy_Text_Print("%ld", xx, 0, fore, TBLACK, flags, Current);
 
         IsToRedraw = false;
         IsAudible = false;

--- a/tiberiandawn/defines.h
+++ b/tiberiandawn/defines.h
@@ -34,6 +34,12 @@
 #ifndef DEFINES_H
 #define DEFINES_H
 
+/* Windows version of strncasecmp*/
+#ifdef _MSC_VER /* MinGW provides strncasecmp. */
+#define strncasecmp _strnicmp
+#define strcasecmp  _stricmp
+#endif
+
 //#define PETROGLYPH_EXAMPLE_MOD
 
 /**********************************************************************

--- a/tiberiandawn/expand.cpp
+++ b/tiberiandawn/expand.cpp
@@ -191,7 +191,7 @@ bool Expansion_Dialog(void)
             /*
             **	Load the background picture.
             */
-            Load_Title_Screen("HTITLE.PCX", &HidPage, Palette);
+            Load_Title_Screen(TitlePicture, &HidPage, Palette);
             Blit_Hid_Page_To_Seen_Buff();
 
             Dialog_Box(option_x, option_y, option_width, option_height);
@@ -374,7 +374,7 @@ bool Bonus_Dialog(void)
             /*
             **	Load the background picture.
             */
-            Load_Title_Screen("HTITLE.PCX", &HidPage, Palette);
+            Load_Title_Screen(TitlePicture, &HidPage, Palette);
             Blit_Hid_Page_To_Seen_Buff();
 
             Dialog_Box(option_x, option_y, option_width, option_height);

--- a/tiberiandawn/function.h
+++ b/tiberiandawn/function.h
@@ -1067,3 +1067,6 @@ void GlyphX_Debug_Print(const char* debug_text);
 ** Achievement event. ST - 11/11/2019 11:39AM
 */
 void On_Achievement_Event(const HouseClass* player_ptr, const char* achievement_type, const char* achievement_reason);
+
+/* Holds the title filename. On 320x200, set to TITLE.CPS, else HTITLE.PCX. */
+extern char* TitlePicture;

--- a/tiberiandawn/function.h
+++ b/tiberiandawn/function.h
@@ -376,7 +376,7 @@ void Dump_Heap_Pointers(void);
 unsigned long Disk_Space_Available(void);
 
 void Validate_Error(char* name);
-void const* Hires_Retrieve(char* name);
+void const* Hires_Retrieve(const char* name);
 int Get_Resolution_Factor(void);
 
 void Shake_The_Screen(int shakes, HousesType house = HOUSE_NONE);

--- a/tiberiandawn/globals.cpp
+++ b/tiberiandawn/globals.cpp
@@ -952,3 +952,6 @@ bool ConnectionLost;
 TheaterType LastTheater = THEATER_NONE;
 
 bool RunningAsDLL = false;
+
+/* Holds the title filename. On 320x200, set to TITLE.CPS, else HTITLE.PCX. */
+char* TitlePicture = NULL;

--- a/tiberiandawn/goptions.cpp
+++ b/tiberiandawn/goptions.cpp
@@ -60,6 +60,7 @@ void GameOptionsClass::Adjust_Variables_For_Resolution(void)
     Border1Len = 72 * factor;
     Border2Len = 16 * factor;
     ButtonResumeY = (OptionHeight - (15 * factor));
+    TitlePicture = (char*)(factor == 1 ? "TITLE.CPS" : "HTITLE.PCX");
 }
 /***********************************************************************************************
  * OptionsClass::Process -- Handles all the options graphic interface.                         *

--- a/tiberiandawn/gscreen.cpp
+++ b/tiberiandawn/gscreen.cpp
@@ -477,32 +477,26 @@ extern bool CanVblankSync;
  *=============================================================================================*/
 void GScreenClass::Blit_Display(void)
 {
-    if (SeenBuff.Get_Width() != 320) {
 #if (0)
-        if (HidPage.Get_IsDirectDraw() && (Options.GameSpeed > 1 || Options.ScrollRate == 6 && CanVblankSync)) {
-            WWMouse->Draw_Mouse(&HidPage);
-            SeenBuff.Get_Graphic_Buffer()->Get_DD_Surface()->Flip(NULL, DDFLIP_WAIT);
-            SeenBuff.Blit(HidPage, 0, 0, 0, 0, SeenBuff.Get_Width(), SeenBuff.Get_Height(), false);
-#ifdef CHEAT_KEYS
-            Add_Current_Screen();
-#endif
-            // HidPage.Blit ( SeenBuff , 0 , 0 , 0 , 0 , HidPage.Get_Width() , HidPage.Get_Height() , (BOOL) FALSE );
-            WWMouse->Erase_Mouse(&HidPage, false);
-        } else {
-#else //(0)
+    if (HidPage.Get_IsDirectDraw() && (Options.GameSpeed > 1 || Options.ScrollRate == 6 && CanVblankSync)) {
         WWMouse->Draw_Mouse(&HidPage);
-        HidPage.Blit(SeenBuff, 0, 0, 0, 0, HidPage.Get_Width(), HidPage.Get_Height(), false);
+        SeenBuff.Get_Graphic_Buffer()->Get_DD_Surface()->Flip(NULL, DDFLIP_WAIT);
+        SeenBuff.Blit(HidPage, 0, 0, 0, 0, SeenBuff.Get_Width(), SeenBuff.Get_Height(), false);
 #ifdef CHEAT_KEYS
         Add_Current_Screen();
 #endif
+        // HidPage.Blit ( SeenBuff , 0 , 0 , 0 , 0 , HidPage.Get_Width() , HidPage.Get_Height() , (BOOL) FALSE );
         WWMouse->Erase_Mouse(&HidPage, false);
+    } else {
+#else //(0)
+    WWMouse->Draw_Mouse(&HidPage);
+    HidPage.Blit(SeenBuff, 0, 0, 0, 0, HidPage.Get_Width(), HidPage.Get_Height(), false);
+#ifdef CHEAT_KEYS
+    Add_Current_Screen();
+#endif
+    WWMouse->Erase_Mouse(&HidPage, false);
 #endif //(0)
 #if (0)
-        }
-#endif //(0)
-
-    } else {
-        // ST - 1/2/2019 5:26PM
-        // ModeX_Blit (&HiddenPage);
     }
+#endif //(0)
 }

--- a/tiberiandawn/init.cpp
+++ b/tiberiandawn/init.cpp
@@ -488,7 +488,7 @@ bool Init_Game(int, char*[])
     memset(CurrentPalette, 0x01, 768);
 
     if (!Special.IsFromInstall) {
-        Load_Title_Screen("HTITLE.PCX", &HidPage, Palette);
+        Load_Title_Screen(TitlePicture, &HidPage, Palette);
         Blit_Hid_Page_To_Seen_Buff();
     }
 
@@ -814,7 +814,7 @@ bool Select_Game(bool fade)
                 **	Display the title page; fade it in if this is the first time
                 **	through the loop, and the 'fade' flag is true
                 */
-                Load_Title_Screen("HTITLE.PCX", &HidPage, Palette);
+                Load_Title_Screen(TitlePicture, &HidPage, Palette);
                 memcpy(GamePalette, Palette, 768);
                 Blit_Hid_Page_To_Seen_Buff();
 

--- a/tiberiandawn/loaddlg.cpp
+++ b/tiberiandawn/loaddlg.cpp
@@ -313,7 +313,7 @@ int LoadOptionsClass::Process(void)
                 Map.Render();
             } else {
                 HiddenPage.Clear();
-                Load_Title_Screen("HTITLE.PCX", &HidPage, Palette);
+                Load_Title_Screen(TitlePicture, &HidPage, Palette);
                 Blit_Hid_Page_To_Seen_Buff();
             }
 

--- a/tiberiandawn/menus.cpp
+++ b/tiberiandawn/menus.cpp
@@ -816,7 +816,7 @@ int Main_Menu(unsigned long timeout)
             /*
             **	Load the background picture.
             */
-            Load_Title_Screen("HTITLE.PCX", &HidPage, Palette);
+            Load_Title_Screen(TitlePicture, &HidPage, Palette);
             Blit_Hid_Page_To_Seen_Buff();
 
             /*

--- a/tiberiandawn/menus.cpp
+++ b/tiberiandawn/menus.cpp
@@ -454,67 +454,50 @@ int Do_Menu(char const** strings, bool blue)
  *=========================================================================*/
 int Main_Menu(unsigned long timeout)
 {
-    enum
-    {
-        D_DIALOG_W = 152 * 2,
-        D_DIALOG_H = 136 * 2,
-        D_DIALOG_X = 85 * 2,
-        D_DIALOG_Y = 0,
-        D_DIALOG_CX = D_DIALOG_X + (D_DIALOG_W / 2),
+    int scale_factor = Get_Resolution_Factor() + 1;
 
-        D_START_W = 125 * 2,
-        D_START_H = 9 * 2,
-        D_START_X = 98 * 2,
-        D_START_Y = 35 * 2,
+    int D_DIALOG_W = 152 * scale_factor, D_DIALOG_H = 136 * scale_factor, D_DIALOG_X = 85 * scale_factor,
+        D_DIALOG_Y = 0, D_DIALOG_CX = D_DIALOG_X + (D_DIALOG_W / scale_factor),
+
+        D_START_W = 125 * scale_factor, D_START_H = 9 * scale_factor, D_START_X = 98 * scale_factor,
+        D_START_Y = 35 * scale_factor,
 
 #ifdef BONUS_MISSIONS
-        D_BONUS_W = 125 * 2,
-        D_BONUS_H = 9 * 2,
-        D_BONUS_X = 98 * 2,
-        D_BONUS_Y = 0,
+        D_BONUS_W = 125 * scale_factor, D_BONUS_H = 9 * scale_factor, D_BONUS_X = 98 * scale_factor, D_BONUS_Y = 0,
 #endif // BONUS_MISSIONS
 
-        D_INTERNET_W = 125 * 2,
-        D_INTERNET_H = 9 * 2,
-        D_INTERNET_X = 98 * 2,
-        D_INTERNET_Y = 36 * 2,
+        D_INTERNET_W = 125 * scale_factor, D_INTERNET_H = 9 * scale_factor, D_INTERNET_X = 98 * scale_factor,
+        D_INTERNET_Y = 36 * scale_factor,
 
-        D_LOAD_W = 125 * 2,
-        D_LOAD_H = 9 * 2,
-        D_LOAD_X = 98 * 2,
-        D_LOAD_Y = 53 * 2,
+        D_LOAD_W = 125 * scale_factor, D_LOAD_H = 9 * scale_factor, D_LOAD_X = 98 * scale_factor,
+        D_LOAD_Y = 53 * scale_factor,
 
-        D_MULTI_W = 125 * 2,
-        D_MULTI_H = 9 * 2,
-        D_MULTI_X = 98 * 2,
-        D_MULTI_Y = 71 * 2,
+        D_MULTI_W = 125 * scale_factor, D_MULTI_H = 9 * scale_factor, D_MULTI_X = 98 * scale_factor,
+        D_MULTI_Y = 71 * scale_factor,
 
-        D_INTRO_W = 125 * 2,
-        D_INTRO_H = 9 * 2,
-        D_INTRO_X = 98 * 2,
-        D_INTRO_Y = 89 * 2,
+        D_INTRO_W = 125 * scale_factor, D_INTRO_H = 9 * scale_factor, D_INTRO_X = 98 * scale_factor,
+        D_INTRO_Y = 89 * scale_factor,
 #if (GERMAN | FRENCH)
-        D_EXIT_W = 83 * 2,
+        D_EXIT_W = 83 * scale_factor,
 #else
-        D_EXIT_W = 63 * 2,
+        D_EXIT_W = 63 * scale_factor,
 #endif
-        D_EXIT_H = 9 * 2,
+        D_EXIT_H = 9 * scale_factor,
 #if (GERMAN | FRENCH)
-        D_EXIT_X = 118 * 2,
+        D_EXIT_X = 118 * scale_factor,
 #else
-        D_EXIT_X = 128 * 2,
+        D_EXIT_X = 128 * scale_factor,
 #endif
-        D_EXIT_Y = 111 * 2,
-
-    };
+        D_EXIT_Y = 111 * scale_factor;
 
 #ifdef NEWMENU
-    int starty = 25 * 2;
+    int starty = 25 * scale_factor;
 #endif
 
     // Make sure any changes to buttons here are also reflected in the enum and handling in Select_Game in init.cpp.
     enum
     {
+
 #ifdef NEWMENU
         BUTTON_EXPAND = 100 * 2,
         BUTTON_START,
@@ -551,9 +534,9 @@ int Main_Menu(unsigned long timeout)
 
 #ifdef NEWMENU
 #ifdef BONUS_MISSIONS
-    int ystep = 13 * 2;
+    int ystep = 13 * scale_factor;
 #else
-    int ystep = 15 * 2;
+    int ystep = 15 * scale_factor;
 #endif // BONUS_MISSIONS
 
     if (expansions)

--- a/tiberiandawn/mplayer.cpp
+++ b/tiberiandawn/mplayer.cpp
@@ -264,7 +264,7 @@ GameType Select_MPlayer_Game(void)
                 /*
                 ..................... Refresh the backdrop ......................
                 */
-                Load_Title_Screen("HTITLE.PCX", &HidPage, Palette);
+                Load_Title_Screen(TitlePicture, &HidPage, Palette);
                 Blit_Hid_Page_To_Seen_Buff();
                 /*
                 ..................... Draw the background .......................
@@ -384,7 +384,7 @@ GameType Select_MPlayer_Game(void)
                 Call_Back();
                 Show_Internet_Connection_Progress(); // changed to do nothing
                 Hide_Mouse();
-                Load_Title_Screen("HTITLE.PCX", &HidPage, Palette);
+                Load_Title_Screen(TitlePicture, &HidPage, Palette);
                 Blit_Hid_Page_To_Seen_Buff();
                 Show_Mouse();
                 Call_Back();

--- a/tiberiandawn/netdlg.cpp
+++ b/tiberiandawn/netdlg.cpp
@@ -1006,7 +1006,7 @@ static int Net_Join_Dialog(void)
     */
     Send_Join_Queries(game_index, 1, 0);
 
-    Load_Title_Screen("HTITLE.PCX", &HidPage, Palette);
+    Load_Title_Screen(TitlePicture, &HidPage, Palette);
     Blit_Hid_Page_To_Seen_Buff();
     Set_Palette(Palette);
 
@@ -1046,7 +1046,7 @@ static int Net_Join_Dialog(void)
             .................. Redraw backgound & dialog box ...................
             */
             if (display >= REDRAW_BACKGROUND) {
-                Load_Title_Screen("HTITLE.PCX", &HidPage, Palette);
+                Load_Title_Screen(TitlePicture, &HidPage, Palette);
                 Blit_Hid_Page_To_Seen_Buff();
                 Set_Palette(Palette);
 
@@ -1977,7 +1977,7 @@ static int Net_Join_Dialog(void)
     Restore screen
     ------------------------------------------------------------------------*/
     Hide_Mouse();
-    Load_Title_Screen("HTITLE.PCX", &HidPage, Palette);
+    Load_Title_Screen(TitlePicture, &HidPage, Palette);
     Blit_Hid_Page_To_Seen_Buff();
     Show_Mouse();
 
@@ -3113,7 +3113,7 @@ static int Net_New_Dialog(void)
     }
     playerlist.Add_Item(item, MPlayerTColors[MPlayerColorIdx]);
 
-    Load_Title_Screen("HTITLE.PCX", &HidPage, Palette);
+    Load_Title_Screen(TitlePicture, &HidPage, Palette);
     Blit_Hid_Page_To_Seen_Buff();
     Set_Palette(Palette);
     while (Get_Mouse_State() > 0)
@@ -3168,7 +3168,7 @@ static int Net_New_Dialog(void)
                 /*
                 ** Reload and draw the title page
                 */
-                Load_Title_Screen("HTITLE.PCX", &HidPage, Palette);
+                Load_Title_Screen(TitlePicture, &HidPage, Palette);
                 Blit_Hid_Page_To_Seen_Buff();
                 Set_Palette(Palette);
 
@@ -3858,7 +3858,7 @@ static int Net_New_Dialog(void)
     Restore screen
     ------------------------------------------------------------------------*/
     Hide_Mouse();
-    Load_Title_Screen("HTITLE.PCX", &HidPage, Palette);
+    Load_Title_Screen(TitlePicture, &HidPage, Palette);
     Blit_Hid_Page_To_Seen_Buff();
     Show_Mouse();
 
@@ -4437,7 +4437,7 @@ static int Net_Fake_New_Dialog(void)
     Wait_For_Focus();
 
     CCDebugString("C&C95 - About to uncompress title page.\n");
-    Load_Title_Screen("HTITLE.PCX", &HidPage, Palette);
+    Load_Title_Screen(TitlePicture, &HidPage, Palette);
     Blit_Hid_Page_To_Seen_Buff();
     CCDebugString("C&C95 - About to set the palette.\n");
     Set_Palette(Palette);
@@ -4492,7 +4492,7 @@ static int Net_Fake_New_Dialog(void)
             */
             if (display >= REDRAW_BACKGROUND) {
 
-                Load_Title_Screen("HTITLE.PCX", &HidPage, Palette);
+                Load_Title_Screen(TitlePicture, &HidPage, Palette);
                 Blit_Hid_Page_To_Seen_Buff();
                 Set_Palette(Palette);
 
@@ -4814,7 +4814,7 @@ static int Net_Fake_New_Dialog(void)
     Restore screen
     ------------------------------------------------------------------------*/
     Hide_Mouse();
-    Load_Title_Screen("HTITLE.PCX", &HidPage, Palette);
+    Load_Title_Screen(TitlePicture, &HidPage, Palette);
     Blit_Hid_Page_To_Seen_Buff();
     Show_Mouse();
 
@@ -5010,7 +5010,7 @@ static int Net_Fake_Join_Dialog(void)
     Wait_For_Focus();
 
     CCDebugString("C&C95 - About to uncompress title page.\n");
-    Load_Title_Screen("HTITLE.PCX", &HidPage, Palette);
+    Load_Title_Screen(TitlePicture, &HidPage, Palette);
     Blit_Hid_Page_To_Seen_Buff();
     CCDebugString("C&C95 - About to set the palette.\n");
     Set_Palette(Palette);
@@ -5056,7 +5056,7 @@ static int Net_Fake_Join_Dialog(void)
             .................. Redraw backgound & dialog box ...................
             */
             if (display >= REDRAW_BACKGROUND) {
-                Load_Title_Screen("HTITLE.PCX", &HidPage, Palette);
+                Load_Title_Screen(TitlePicture, &HidPage, Palette);
                 Blit_Hid_Page_To_Seen_Buff();
                 Set_Palette(Palette);
 
@@ -5514,7 +5514,7 @@ static int Net_Fake_Join_Dialog(void)
     Restore screen
     ------------------------------------------------------------------------*/
     Hide_Mouse();
-    Load_Title_Screen("HTITLE.PCX", &HidPage, Palette);
+    Load_Title_Screen(TitlePicture, &HidPage, Palette);
     Blit_Hid_Page_To_Seen_Buff();
     Show_Mouse();
 

--- a/tiberiandawn/nulldlg.cpp
+++ b/tiberiandawn/nulldlg.cpp
@@ -423,7 +423,7 @@ int Com_Scenario_Dialog(void)
     srand((unsigned)time(NULL));
     Seed = rand();
 
-    Load_Title_Screen("HTITLE.PCX", &HidPage, Palette);
+    Load_Title_Screen(TitlePicture, &HidPage, Palette);
     Blit_Hid_Page_To_Seen_Buff();
     Set_Palette(Palette);
 
@@ -943,7 +943,7 @@ int Com_Scenario_Dialog(void)
     Restore screen
     ------------------------------------------------------------------------*/
     Hide_Mouse();
-    Load_Title_Screen("HTITLE.PCX", &HidPage, Palette);
+    Load_Title_Screen(TitlePicture, &HidPage, Palette);
     Blit_Hid_Page_To_Seen_Buff();
     Show_Mouse();
 

--- a/tiberiandawn/power.cpp
+++ b/tiberiandawn/power.cpp
@@ -165,6 +165,7 @@ void PowerClass::Draw_It(bool complete)
 {
     static int _modtable[] = {0, -1, 0, 1, 0, -1, -2, -1, 0, 1, 2, 1, 0};
     int power_color;
+    int factor = Get_Resolution_Factor();
 
     if (complete || IsToRedraw) {
         //		PowX = TacPixelX + TacWidth*ICON_PIXEL_W;	// X position of upper left corner of power bar.
@@ -198,8 +199,31 @@ void PowerClass::Draw_It(bool complete)
                 /*
                 ** Draw the unfilled section
                 */
-                CC_Draw_Shape(PowerBarShape, 0, PowX, PowY, WINDOW_CUSTOM, SHAPE_WIN_REL);
-                CC_Draw_Shape(PowerBarShape, 1, PowX, PowY + 100, WINDOW_CUSTOM, SHAPE_WIN_REL);
+                if (factor) {
+
+                    CC_Draw_Shape(PowerBarShape, 0, PowX, PowY, WINDOW_CUSTOM, SHAPE_WIN_REL);
+                    CC_Draw_Shape(PowerBarShape, 1, PowX, PowY + 100, WINDOW_CUSTOM, SHAPE_WIN_REL);
+                } else {
+                    /* Draw MS-DOS power gauge. */
+                    int top_y = PowY + 1;
+                    int x0 = PowX;
+                    int x1 = x0 + 7;
+                    int y0 = PowY + 1;
+                    int y1 = bottom;
+
+                    LogicPage->Fill_Rect(x0, y0, x1, y1, LTGREY);               //Inside power bar
+                    LogicPage->Draw_Line(x0, y0, x0, y1, WHITE);                //Left line
+                    LogicPage->Draw_Line(x0 + 1, y0, x0 + 1, y1, GREY);         //Left shadow line
+                    LogicPage->Draw_Line(x0, y0, x1 - 1, y0, WHITE);            //Upper line
+                    LogicPage->Draw_Line(x0 + 1, y0 + 1, x1 - 1, y0 + 1, GREY); //Upper shadow line
+                    LogicPage->Draw_Line(x1 - 1, y0, x1 - 1, y1, WHITE);        //Right line
+                    LogicPage->Draw_Line(x1, y0, x1, y1, GREY);                 //Right shadow line
+                    LogicPage->Draw_Line(x0, y1, x1 - 1, y1, WHITE);            //bottom line
+
+                    for (int y = y0 + 4; y < y1 - 1; y += 5) {
+                        LogicPage->Draw_Line(x0 + 2, y, x0 + 4, y, GREY); //Draw power meter
+                    }
+                }
 
                 /*
                 ** Set up the clip region for the filled section
@@ -211,37 +235,41 @@ void PowerClass::Draw_It(bool complete)
                 ** What color is the filled section?
                 */
                 if (power_height) {
-                    power_color = 0; // green
+                    power_color = (factor) ? 0 : GREEN; // green
 
                     if (PlayerPtr->Drain > PlayerPtr->Power) {
-                        power_color = 2;
+                        power_color = (factor) ? 2 : YELLOW;
                     }
                     if (PlayerPtr->Drain > (PlayerPtr->Power * 2)) {
-                        power_color = 4;
+                        power_color = (factor) ? 4 : RED;
                     }
 
                     /*
                     ** Draw the filled section
                     */
-                    CC_Draw_Shape(PowerBarShape,
-                                  2 + power_color,
-                                  PowX,
-                                  PowY - WindowList[WINDOW_CUSTOM][WINDOWY],
-                                  WINDOW_CUSTOM,
-                                  SHAPE_WIN_REL);
+                    if (Get_Resolution_Factor()) {
+                        CC_Draw_Shape(PowerBarShape,
+                                      2 + power_color,
+                                      PowX,
+                                      PowY - WindowList[WINDOW_CUSTOM][WINDOWY],
+                                      WINDOW_CUSTOM,
+                                      SHAPE_WIN_REL);
 
-                    CC_Draw_Shape(PowerBarShape,
-                                  3 + power_color,
-                                  PowX,
-                                  PowY - WindowList[WINDOW_CUSTOM][WINDOWY] + 100,
-                                  WINDOW_CUSTOM,
-                                  SHAPE_WIN_REL);
+                        CC_Draw_Shape(PowerBarShape,
+                                      3 + power_color,
+                                      PowX,
+                                      PowY - WindowList[WINDOW_CUSTOM][WINDOWY] + 100,
+                                      WINDOW_CUSTOM,
+                                      SHAPE_WIN_REL);
+                    } else {
+                        LogicPage->Fill_Rect(PowX + 2, bottom - power_height + 1, PowX + 5, bottom - 1, power_color);
+                    }
                 }
 
                 /*
                 **	Draw the power drain threshold marker.
                 */
-                CC_Draw_Shape(PowerShape, 0, PowX, bottom - drain_height + 1, WINDOW_MAIN, SHAPE_NORMAL);
+                CC_Draw_Shape(PowerShape, 0, PowX, bottom - drain_height, WINDOW_MAIN, SHAPE_NORMAL);
             }
             LogicPage->Unlock();
         }

--- a/tiberiandawn/radar.cpp
+++ b/tiberiandawn/radar.cpp
@@ -273,7 +273,7 @@ bool RadarClass::Radar_Activate(int control)
 
     case 2:
         if (GameToPlay == GAME_NORMAL) {
-            Map.Zoom.Disable();
+            Map.Zoom->Disable();
         }
         IsRadarActive = false;
         IsRadarActivating = false;
@@ -282,7 +282,7 @@ bool RadarClass::Radar_Activate(int control)
 
     case 3:
         if (GameToPlay == GAME_NORMAL) {
-            Map.Zoom.Enable();
+            Map.Zoom->Enable();
         }
         IsRadarActive = true;
         IsRadarActivating = false;
@@ -994,6 +994,10 @@ bool RadarClass::Map_Cell(CELL cell, HouseClass* house, bool and_for_allies)
 
 void RadarClass::Cursor_Cell(CELL cell, int value)
 {
+    /* Radar seem to crash on some clicks because it get cell = -1 */
+    if (cell < 0)
+        return;
+
     int temp = (*this)[cell].IsRadarCursor;
 
     /*

--- a/tiberiandawn/sidebar.cpp
+++ b/tiberiandawn/sidebar.cpp
@@ -107,10 +107,11 @@ typedef enum ButtonNumberType
 /*
 ** Sidebar buttons
 */
+
 SidebarClass::SBGadgetClass SidebarClass::Background;
-ShapeButtonClass SidebarClass::Repair;
-ShapeButtonClass SidebarClass::Upgrade;
-ShapeButtonClass SidebarClass::Zoom;
+ToggleClass* SidebarClass::Repair = NULL;
+ToggleClass* SidebarClass::Upgrade = NULL;
+ToggleClass* SidebarClass::Zoom = NULL;
 ShapeButtonClass SidebarClass::StripClass::UpButton[COLUMNS];
 ShapeButtonClass SidebarClass::StripClass::DownButton[COLUMNS];
 SidebarClass::StripClass::SelectClass SidebarClass::StripClass::SelectButton[COLUMNS][MAX_VISIBLE];
@@ -264,9 +265,41 @@ void SidebarClass::Init_Clear(void)
  *=============================================================================================*/
 void SidebarClass::Init_IO(void)
 {
+#if (FRENCH)
+    const char* repair_shp = "REPAIRF.SHP";
+    const char* sell_shp = "SELLF.SHP";
+    const char* map_shp = "MAPF.SHP";
+#else
+#if (GERMAN)
+    const char* repair_shp = "REPAIRG.SHP";
+    const char* sell_shp = "SELLG.SHP";
+    const char* map_shp = "MAPG.SHP";
+#else
+    const char* repair_shp = "REPAIR.SHP";
+    const char* sell_shp = "SELL.SHP";
+    const char* map_shp = "MAP.SHP";
+#endif
+#endif
+
     void* oldfont;
     int oldx;
     PowerClass::Init_IO();
+
+    if (Get_Resolution_Factor()) {
+        if (!Repair)
+            Repair = new ShapeButtonClass();
+        if (!Upgrade)
+            Upgrade = new ShapeButtonClass();
+        if (!Zoom)
+            Zoom = new ShapeButtonClass();
+    } else {
+        if (!Repair)
+            Repair = new TextButtonClass();
+        if (!Upgrade)
+            Upgrade = new TextButtonClass();
+        if (!Zoom)
+            Zoom = new TextButtonClass();
+    }
 
     /*
     ** Add the sidebar's buttons only if we're not in editor mode.
@@ -285,9 +318,9 @@ void SidebarClass::Init_IO(void)
         int maxwidth = String_Pixel_Width(Text_String(TXT_REPAIR_BUTTON)) + 8;
         maxwidth = MAX((unsigned)maxwidth, String_Pixel_Width(Text_String(TXT_BUTTON_SELL)) + 8);
         maxwidth = MAX((unsigned)maxwidth, String_Pixel_Width(Text_String(TXT_MAP)) + 8);
-        Repair.Width = maxwidth;
-        Upgrade.Width = maxwidth;
-        Zoom.Width = maxwidth;
+        Repair->Width = maxwidth;
+        Upgrade->Width = maxwidth;
+        Zoom->Width = maxwidth;
         //		Repair.Width = String_Pixel_Width(Text_String(TXT_REPAIR_BUTTON)) + 8;
         //		Upgrade.Width = String_Pixel_Width(Text_String(TXT_BUTTON_SELL)) + 8;
         //		Zoom.Width = String_Pixel_Width(Text_String(TXT_MAP)) + 8;
@@ -295,61 +328,76 @@ void SidebarClass::Init_IO(void)
         ** find the spacing between buttons by getting remaining width
         ** and dividing it between the buttons.
         */
-        int buttonspacing = (SideBarWidth - (Repair.Width + Upgrade.Width + Zoom.Width)) / 4;
+        int buttonspacing = (SideBarWidth - (Repair->Width + Upgrade->Width + Zoom->Width)) / 4;
 
-        Repair.IsSticky = true;
-        Repair.ID = BUTTON_REPAIR;
-        Repair.X = 484;
-        Repair.Y = 160;
-        Repair.IsPressed = false;
-        Repair.IsToggleType = true;
-        Repair.ReflectButtonState = true;
-#if (FRENCH)
-        Repair.Set_Shape(Hires_Retrieve("REPAIRF.SHP"));
-#else
-#if (GERMAN)
-        Repair.Set_Shape(Hires_Retrieve("REPAIRG.SHP"));
-#else
-        Repair.Set_Shape(Hires_Retrieve("REPAIR.SHP"));
-#endif
-#endif
+        if (Get_Resolution_Factor()) {
+            ShapeButtonClass* SBCRepair = (ShapeButtonClass*)Repair;
+            ShapeButtonClass* SBCUpgrade = (ShapeButtonClass*)Upgrade;
+            ShapeButtonClass* SBCZoom = (ShapeButtonClass*)Zoom;
 
-        Upgrade.IsSticky = true;
-        Upgrade.ID = BUTTON_UPGRADE;
-        Upgrade.X = 480 + 57;
-        Upgrade.Y = 160;
-        Upgrade.IsPressed = false;
-        Upgrade.IsToggleType = true;
-        Upgrade.ReflectButtonState = true;
-#if (FRENCH)
-        Upgrade.Set_Shape(Hires_Retrieve("SELLF.SHP"));
-#else
-#if (GERMAN)
-        Upgrade.Set_Shape(Hires_Retrieve("SELLG.SHP"));
-#else
-        Upgrade.Set_Shape(Hires_Retrieve("SELL.SHP"));
-#endif
-#endif
+            Repair->X = 484;
+            Repair->Y = 160;
+            SBCRepair->ReflectButtonState = true;
+            SBCRepair->Set_Shape(Hires_Retrieve(repair_shp));
 
-        Zoom.IsSticky = true;
-        Zoom.ID = BUTTON_ZOOM;
-        Zoom.X = 480 + 110;
-        Zoom.Y = 160;
-        Zoom.IsPressed = false;
-#if (FRENCH)
-        Zoom.Set_Shape(Hires_Retrieve("MAPF.SHP"));
-#else
-#if (GERMAN)
-        Zoom.Set_Shape(Hires_Retrieve("MAPG.SHP"));
-#else
-        Zoom.Set_Shape(Hires_Retrieve("MAP.SHP"));
-#endif
-#endif
+            Upgrade->X = 480 + 57;
+            Upgrade->Y = 160;
+            SBCUpgrade->ReflectButtonState = true;
+            SBCUpgrade->Set_Shape(Hires_Retrieve(sell_shp));
+
+            Zoom->X = 480 + 110;
+            Zoom->Y = 160;
+            SBCZoom->Set_Shape(Hires_Retrieve(map_shp));
+        } else {
+            TextButtonClass* TBCRepair = (TextButtonClass*)Repair;
+            TextButtonClass* TBCUpgrade = (TextButtonClass*)Upgrade;
+            TextButtonClass* TBCZoom = (TextButtonClass*)Zoom;
+
+            TBCRepair->Set_Text("Repair");
+            TBCRepair->Set_Style(TPF_6POINT | TPF_NOSHADOW | TPF_CENTER);
+
+            TBCUpgrade->Set_Text("Sell");
+            TBCUpgrade->Set_Style(TPF_6POINT | TPF_NOSHADOW | TPF_CENTER);
+
+            TBCZoom->Set_Text("Map");
+            TBCZoom->Set_Style(TPF_6POINT | TPF_NOSHADOW | TPF_CENTER);
+
+            /* Hardcode button positions for now. */
+
+            Repair->X = 482 / 2;
+            Repair->Y = 160 / 2;
+            Repair->Width = String_Pixel_Width("Repair") + 2;
+            Repair->Height = String_Pixel_Width("R") + 3;
+
+            Upgrade->X = (484 + 65) / 2 + 2;
+            Upgrade->Y = 160 / 2;
+            Upgrade->Width = String_Pixel_Width("Sell") + 3;
+            Upgrade->Height = String_Pixel_Width("S") + 3;
+
+            Zoom->X = (480 + 110) / 2 + 5;
+            Zoom->Y = 160 / 2;
+            Zoom->Width = String_Pixel_Width("Map") + 1;
+            Zoom->Height = String_Pixel_Width("S") + 3;
+        }
+
+        Repair->IsSticky = true;
+        Repair->ID = BUTTON_REPAIR;
+        Repair->IsPressed = false;
+        Repair->IsToggleType = true;
+
+        Upgrade->IsSticky = true;
+        Upgrade->ID = BUTTON_UPGRADE;
+        Upgrade->IsPressed = false;
+        Upgrade->IsToggleType = true;
+
+        Zoom->IsSticky = true;
+        Zoom->ID = BUTTON_ZOOM;
+        Zoom->IsPressed = false;
 
         if (IsRadarActive || GameToPlay != GAME_NORMAL) {
-            Zoom.Enable();
+            Zoom->Enable();
         } else {
-            Zoom.Disable();
+            Zoom->Disable();
         }
 
         Set_Font(oldfont);
@@ -708,23 +756,24 @@ void SidebarClass::Draw_It(bool complete)
             CC_Draw_Shape(SidebarShape1, 0, SideX, 158, WINDOW_MAIN, SHAPE_WIN_REL);
             CC_Draw_Shape(SidebarShape2, 0, SideX, 158 + 118, WINDOW_MAIN, SHAPE_WIN_REL);
 
-#if (0)
-            if (complete) {
-                LogicPage->Fill_Rect(
-                    SideX + Map.PowWidth, SideY, SideX + SideWidth - 1, SideY + SideHeight - 1, LTGREY);
+            if (Get_Resolution_Factor() == 0) {
+                if (complete) {
+                    LogicPage->Fill_Rect(
+                        SideX + Map.PowWidth, SideY, SideX + SideWidth - 1, SideY + SideHeight - 1, LTGREY);
+                }
+                LogicPage->Fill_Rect(SideX, SideY, SideX + SideWidth - 1, SideY + TopHeight - 1, LTGREY);
+                Draw_Box(SideX + Map.PowWidth,
+                         SideY + TopHeight,
+                         SideWidth - Map.PowWidth,
+                         SideHeight - TopHeight,
+                         BOXSTYLE_RAISED,
+                         false);
             }
-            LogicPage->Fill_Rect(SideX, SideY, SideX + SideWidth - 1, SideY + TopHeight - 1, LTGREY);
-            Draw_Box(SideX + Map.PowWidth,
-                     SideY + TopHeight,
-                     SideWidth - Map.PowWidth,
-                     SideHeight - TopHeight,
-                     BOXSTYLE_RAISED,
-                     false);
-#endif //(0)                                                                                                           \
-       // Repair.Draw_Me(true);                                                                                        \
-       // Upgrade.Draw_Me(true);                                                                                       \
-       // Zoom.Draw_Me(true);                                                                                          \
-    //	} else {                                                                                                        \
+
+            //  Repair.Draw_Me(true);
+            //  Upgrade.Draw_Me(true);
+            //  Zoom.Draw_Me(true);
+            //	} else {                                                                                                        \
     //		if (IsToRedraw || complete) {                                                                                  \
     //			LogicPage->Fill_Rect(TacPixelX + Lepton_To_Pixel(TacLeptonWidth), SIDE_Y, 319, SIDE_Y+TOP_HEIGHT,             \
     //BLACK);                                                                                                          \
@@ -739,9 +788,9 @@ void SidebarClass::Draw_It(bool complete)
     if (IsSidebarActive) {
         Column[0].Draw_It(complete);
         Column[1].Draw_It(complete);
-        Repair.Draw_Me(true);
-        Upgrade.Draw_Me(true);
-        Zoom.Draw_Me(true);
+        Repair->Draw_Me(true);
+        Upgrade->Draw_Me(true);
+        Zoom->Draw_Me(true);
     }
 
     IsToRedraw = false;
@@ -864,12 +913,12 @@ void SidebarClass::AI(KeyNumType& input, int x, int y)
         }
     }
 
-    if ((!IsRepairMode) && Repair.IsOn) {
-        Repair.Turn_Off();
+    if ((!IsRepairMode) && Repair->IsOn) {
+        Repair->Turn_Off();
     }
 
-    if ((!IsSellMode) && Upgrade.IsOn) {
-        Upgrade.Turn_Off();
+    if ((!IsSellMode) && Upgrade->IsOn) {
+        Upgrade->Turn_Off();
     }
 
     PowerClass::AI(input, x, y);
@@ -984,12 +1033,12 @@ bool SidebarClass::Activate(int control)
             Set_View_Dimensions(0, Map.Get_Tab_Height(), SeenBuff.Get_Width() - sidewidth);
             IsToRedraw = true;
             Help_Text(TXT_NONE);
-            Repair.Zap();
-            Add_A_Button(Repair);
-            Upgrade.Zap();
-            Add_A_Button(Upgrade);
-            Zoom.Zap();
-            Add_A_Button(Zoom);
+            Repair->Zap();
+            Add_A_Button(*Repair);
+            Upgrade->Zap();
+            Add_A_Button(*Upgrade);
+            Zoom->Zap();
+            Add_A_Button(*Zoom);
             Column[0].Activate();
             Column[1].Activate();
             Background.Zap();
@@ -1001,9 +1050,9 @@ bool SidebarClass::Activate(int control)
         } else {
             Help_Text(TXT_NONE);
             Set_View_Dimensions(0, Map.Get_Tab_Height());
-            Remove_A_Button(Repair);
-            Remove_A_Button(Upgrade);
-            Remove_A_Button(Zoom);
+            Remove_A_Button(*Repair);
+            Remove_A_Button(*Upgrade);
+            Remove_A_Button(*Zoom);
             Remove_A_Button(Background);
             Column[0].Deactivate();
             Column[1].Deactivate();
@@ -2575,5 +2624,21 @@ void SidebarClass::Zoom_Mode_Control(void)
         if (GameToPlay != GAME_NORMAL) {
             Player_Names(Is_Player_Names() == 0);
         }
+    }
+}
+
+SidebarClass::~SidebarClass()
+{
+    if (Repair) {
+        delete Repair;
+        Repair = NULL;
+    }
+    if (Upgrade) {
+        delete Upgrade;
+        Upgrade = NULL;
+    }
+    if (Zoom) {
+        delete Zoom;
+        Zoom = NULL;
     }
 }

--- a/tiberiandawn/sidebar.cpp
+++ b/tiberiandawn/sidebar.cpp
@@ -752,22 +752,25 @@ void SidebarClass::Draw_It(bool complete)
             */
             // CC_Draw_Shape(SidebarShape1, (int)complete, SideX, 158, WINDOW_MAIN, SHAPE_WIN_REL);
             // CC_Draw_Shape(SidebarShape2, (int)complete, SideX, 158+118, WINDOW_MAIN, SHAPE_WIN_REL);
-            LogicPage->Draw_Line(SideX, 157, SeenBuff.Get_Width() - 1, 157, 0);
-            CC_Draw_Shape(SidebarShape1, 0, SideX, 158, WINDOW_MAIN, SHAPE_WIN_REL);
-            CC_Draw_Shape(SidebarShape2, 0, SideX, 158 + 118, WINDOW_MAIN, SHAPE_WIN_REL);
 
             if (Get_Resolution_Factor() == 0) {
                 if (complete) {
                     LogicPage->Fill_Rect(
                         SideX + Map.PowWidth, SideY, SideX + SideWidth - 1, SideY + SideHeight - 1, LTGREY);
                 }
-                LogicPage->Fill_Rect(SideX, SideY, SideX + SideWidth - 1, SideY + TopHeight - 1, LTGREY);
+                // Draw rectangle covering "Repair", "Sell", and "Map Buttons"
+                LogicPage->Fill_Rect(SideX, SideY - 1, SideX + SideWidth, SideY + TopHeight, LTGREY);
+
                 Draw_Box(SideX + Map.PowWidth,
                          SideY + TopHeight,
                          SideWidth - Map.PowWidth,
                          SideHeight - TopHeight,
                          BOXSTYLE_RAISED,
                          false);
+            } else {
+                LogicPage->Draw_Line(SideX, 157, SeenBuff.Get_Width() - 1, 157, 0);
+                CC_Draw_Shape(SidebarShape1, 0, SideX, 158, WINDOW_MAIN, SHAPE_WIN_REL);
+                CC_Draw_Shape(SidebarShape2, 0, SideX, 158 + 118, WINDOW_MAIN, SHAPE_WIN_REL);
             }
 
             //  Repair.Draw_Me(true);

--- a/tiberiandawn/sidebar.h
+++ b/tiberiandawn/sidebar.h
@@ -115,9 +115,7 @@ public:
         : PowerClass(x)
     {
     }
-    virtual ~SidebarClass()
-    {
-    }
+    virtual ~SidebarClass();
 
     /*
     ** Initialization
@@ -396,9 +394,9 @@ public:
     **	This is the button that is used to collapse and expand the sidebar.
     ** These buttons must be available to derived classes, for Save/Load.
     */
-    static ShapeButtonClass Repair;
-    static ShapeButtonClass Upgrade;
-    static ShapeButtonClass Zoom;
+    static ToggleClass* Repair;
+    static ToggleClass* Upgrade;
+    static ToggleClass* Zoom;
     static SBGadgetClass Background;
 
     bool Scroll(bool up, int column);

--- a/tiberiandawn/startup.cpp
+++ b/tiberiandawn/startup.cpp
@@ -292,6 +292,14 @@ int main(int argc, char** argv)
 
         CCDebugString("C&C95 - Creating main window.\n");
 
+#ifndef REMASTER_BUILD
+        /* If DOSMode is enabled, adjust resolution accordingly. */
+        if (Settings.Video.DOSMode) {
+            ScreenWidth = 320;
+            ScreenHeight = 200;
+        }
+#endif
+
 #if defined(_WIN32) && !defined(SDL2_BUILD)
         Create_Main_Window(ProgramInstance, ScreenWidth, ScreenHeight);
 #endif
@@ -304,8 +312,9 @@ int main(int argc, char** argv)
 
         bool video_success = false;
         CCDebugString("C&C95 - Setting video mode.\n");
+
         /*
-        ** Set 640x400 video mode.
+        ** Set video mode.
         */
 #ifdef REMASTER_BUILD
         video_success = true;

--- a/tiberiandawn/tab.cpp
+++ b/tiberiandawn/tab.cpp
@@ -102,6 +102,10 @@ void TabClass::Draw_It(bool complete)
         if (Tab_Height != 0) {
 
             if (LogicPage->Lock()) {
+                unsigned factor = Get_Resolution_Factor();
+                unsigned fore = factor ? 11 : WHITE;
+                TextPrintType flags = factor ? TPF_GREEN12_GRAD | TPF_CENTER | TPF_USE_GRAD_PAL
+                                             : TPF_6PT_GRAD | TPF_CENTER | TPF_NOSHADOW;
 
                 LogicPage->Fill_Rect(0, 0, rightx, Tab_Height - 2, BLACK);
                 CC_Draw_Shape(TabShape, 0, 0, 0, WINDOW_MAIN, SHAPE_NORMAL);
@@ -109,18 +113,8 @@ void TabClass::Draw_It(bool complete)
                 Draw_Credits_Tab();
                 LogicPage->Draw_Line(0, Tab_Height - 1, rightx, Tab_Height - 1, BLACK);
 
-                Fancy_Text_Print(TXT_TAB_BUTTON_CONTROLS,
-                                 Eva_Width / 2,
-                                 0,
-                                 11,
-                                 TBLACK,
-                                 TPF_GREEN12_GRAD | TPF_CENTER | TPF_USE_GRAD_PAL);
-                Fancy_Text_Print(TXT_TAB_SIDEBAR,
-                                 width - (Eva_Width / 2),
-                                 0,
-                                 11,
-                                 TBLACK,
-                                 TPF_GREEN12_GRAD | TPF_CENTER | TPF_USE_GRAD_PAL);
+                Fancy_Text_Print(TXT_TAB_BUTTON_CONTROLS, Eva_Width / 2, 0, fore, TBLACK, flags);
+                Fancy_Text_Print(TXT_TAB_SIDEBAR, width - (Eva_Width / 2), 0, fore, TBLACK, flags);
             }
             LogicPage->Unlock();
         }
@@ -133,7 +127,8 @@ void TabClass::Draw_It(bool complete)
 
 void TabClass::Draw_Credits_Tab(void)
 {
-    CC_Draw_Shape(TabShape, 0, 320, 0, WINDOW_MAIN, SHAPE_NORMAL);
+    unsigned x = Get_Resolution_Factor() ? 320 : 160;
+    CC_Draw_Shape(TabShape, 0, x, 0, WINDOW_MAIN, SHAPE_NORMAL);
 }
 
 /***********************************************************************************************
@@ -156,9 +151,16 @@ void TabClass::Hilite_Tab(int tab)
     int xpos = 0;
     int text = TXT_TAB_BUTTON_CONTROLS;
     tab = tab;
+    unsigned factor = Get_Resolution_Factor();
+
+    TextPrintType flags =
+        factor ? TPF_GREEN12_GRAD | TPF_CENTER | TPF_USE_GRAD_PAL : TPF_6PT_GRAD | TPF_CENTER | TPF_NOSHADOW;
+
+    unsigned x = factor ? 80 : 40;
+    unsigned fore = factor ? 11 : WHITE;
 
     CC_Draw_Shape(TabShape, 1, xpos, 0, WINDOW_MAIN, SHAPE_NORMAL);
-    Fancy_Text_Print(TXT_TAB_BUTTON_CONTROLS, 80, 0, 11, TBLACK, TPF_GREEN12 | TPF_CENTER | TPF_USE_GRAD_PAL);
+    Fancy_Text_Print(TXT_TAB_BUTTON_CONTROLS, x, 0, fore, TBLACK, flags);
 }
 
 /***********************************************************************************************

--- a/tiberiandawn/winstub.cpp
+++ b/tiberiandawn/winstub.cpp
@@ -530,10 +530,22 @@ void Memory_Error_Handler(void)
 #include "filepcx.h"
 void Load_Title_Screen(char* name, GraphicViewPortClass* video_page, unsigned char* palette)
 {
-
     GraphicBufferClass* load_buffer;
+    const char* ext = strrchr(name, '.');
 
-    load_buffer = Read_PCX_File(name, (char*)palette, NULL, 0);
+    if (!strcasecmp(ext, ".PCX"))
+        load_buffer = Read_PCX_File(name, (char*)palette, NULL, 0); // Load 640x400 title
+    else if (!strcasecmp(ext, ".CPS")) {
+        /* CPS files are hardcoded to 320x200. */
+        const int width = 320;
+        const int height = 200;
+
+        load_buffer = new GraphicBufferClass(width, height, NULL, width * (height + 4));
+        Load_Uncompress(name, *load_buffer, *load_buffer, palette);
+    } else {
+        /* Invalid title screen. */
+        DBG_ERROR("Title screen file %s do not have PCX or CPS extension", name);
+    }
 
     if (load_buffer) {
         load_buffer->Blit(*video_page);


### PR DESCRIPTION
This PR adds support to 320x200 resolution to vanillatd, the same used on MS-DOS version.

![Screenshot from 2021-06-30 13-13-15](https://user-images.githubusercontent.com/7212952/124041470-44c9ae80-d9dd-11eb-89bf-d17c64cf4889.png)


For this to work properly, DOS version of LOCAL.MIX, GENERAL.MIX and CONQUER.MIX is necessary to load the DOS version assets. The High resolution version still works if none of those files are provided.