### PR TITLE
[TD] Fix memory leak in MixFileHandler

### DIFF
--- a/tiberiandawn/conquer.cpp
+++ b/tiberiandawn/conquer.cpp
@@ -1878,6 +1878,7 @@ long MixFileHandler(VQAHandle* vqa, long action, void* buffer, long nbytes)
                 error = 1;
             }
         } else {
+            delete file;
             error = 1;
         }
         break;


### PR DESCRIPTION
If a VQA file is not found, the file object is not released. This PR fixes this memoryleak.