### PR TITLE
Change to data dir during startup

### DIFF
--- a/redalert/startup.cpp
+++ b/redalert/startup.cpp
@@ -183,7 +183,7 @@ int main(int argc, char* argv[])
     **	Remember the current working directory and drive.
     */
     Paths.Init("vanillara", CONFIG_FILE_NAME, "REDALERT.MIX", args.ArgV[0]);
-    vc_chdir(Paths.Program_Path());
+    vc_chdir(Paths.Data_Path());
     CDFileClass::Refresh_Search_Drives();
 
     if (Parse_Command_Line(args.ArgC, args.ArgV)) {

--- a/tiberiandawn/startup.cpp
+++ b/tiberiandawn/startup.cpp
@@ -151,7 +151,7 @@ int main(int argc, char** argv)
     **	Remember the current working directory and drive.
     */
     Paths.Init("vanillatd", "CONQUER.INI", "CONQUER.MIX", args.ArgV[0]);
-    vc_chdir(Paths.Program_Path());
+    vc_chdir(Paths.Data_Path());
     CDFileClass::Refresh_Search_Drives();
 
     if (Parse_Command_Line(args.ArgC, args.ArgV)) {


### PR DESCRIPTION
Current way of using Program_Path breaks symlinking the binaries
in legacy/development mode.

Data_Path is likely better in all possible scenarios as the
default working directory.