### PR TITLE
[TD] Fix radarcrash due to inactive overlappers

### DIFF
--- a/tiberiandawn/iomap.cpp
+++ b/tiberiandawn/iomap.cpp
@@ -178,16 +178,12 @@ void CellClass::Code_Pointers(void)
         OccupierPtr = (ObjectClass*)OccupierPtr->As_Target();
     }
 
-    if (Overlapper[0]) {
-        Overlapper[0] = (ObjectClass*)Overlapper[0]->As_Target();
-    }
-
-    if (Overlapper[1]) {
-        Overlapper[1] = (ObjectClass*)Overlapper[1]->As_Target();
-    }
-
-    if (Overlapper[2]) {
-        Overlapper[2] = (ObjectClass*)Overlapper[2]->As_Target();
+    for (int index = 0; index < ARRAY_SIZE(Overlapper); index++) {
+        if (Overlapper[index] != NULL && Overlapper[index]->IsActive) {
+            Overlapper[index] = (ObjectClass*)Overlapper[index]->As_Target();
+        } else {
+            Overlapper[index] = NULL;
+        }
     }
 
     /*

--- a/tiberiandawn/radar.cpp
+++ b/tiberiandawn/radar.cpp
@@ -515,7 +515,7 @@ void RadarClass::Render_Terrain(CELL cell, int x, int y, int size)
     */
     for (lp = 0; lp < 3; lp++) {
         obj = Map[cell].Overlapper[lp];
-        if (obj && obj->What_Am_I() == RTTI_TERRAIN)
+        if (obj && obj->IsActive && obj->What_Am_I() == RTTI_TERRAIN)
             list[listidx++] = (TerrainClass*)obj;
     }
 


### PR DESCRIPTION
When radar is enabled, the game can crash when trying to render the
minimap because obj->What_Am_I is not present in the object. This
is because the overlapper array may contain inactive objects that
were released. This commit fixes it by checking if the object
is active.

Closes #648 