### PR TITLE
Fix remaster crash on map startup

### DIFF
--- a/common/utfargs.h
+++ b/common/utfargs.h
@@ -19,8 +19,10 @@ public:
         : ArgC(argc)
         , ArgV(argv)
     {
+#ifndef REMASTER_BUILD
 #ifdef _WIN32
         ArgV = CommandLineToArgvU(GetCommandLineW(), &ArgC);
+#endif
 #endif
     }
 
@@ -28,6 +30,7 @@ public:
     char** ArgV;
 
 private:
+#ifndef REMASTER_BUILD
 #ifdef _WIN32
     // Taken from https://github.com/thpatch/win32_utf8/blob/master/src/shell32_dll.c
     // Get the command line as UTF-8 as it would be on other platforms.
@@ -71,6 +74,7 @@ private:
 
         return argv_u;
     }
+#endif
 #endif
 };
 

--- a/tiberiandawn/startup.cpp
+++ b/tiberiandawn/startup.cpp
@@ -114,19 +114,94 @@ BOOL WINAPI DllMain(HINSTANCE instance, unsigned int fdwReason, void* lpvReserve
 #endif
 
 #ifdef REMASTER_BUILD
+int main(int, char*[]);
+
 int DLL_Startup(const char* command_line_in)
 {
+    /* Construct argc and argv from command_line_in. Remaster build requires
+    ** that first argument is a full path to DLL, not executable. Furthermore, it
+    ** seems to override the argv to include extra parameters which the DLL
+    ** expects. Getting the argc and argv from executable will result in
+    ** a crash trying to read the font files. */
+
     RunningAsDLL = true;
     HINSTANCE instance = ProgramInstance;
     char command_line[1024];
-    strcpy(command_line, command_line_in);
     int argc = 0;
-    char** argv = nullptr;
-#else // not remaster
+    unsigned command_scan;
+    char command_char;
+    char* argv[20];
+    char path_to_exe[280];
+
+    strcpy(command_line, command_line_in);
+    ProgramInstance = instance;
+
+    /*
+    ** Get the full path to the .DLL
+    */
+    DWORD readed = GetModuleFileNameA(instance, &path_to_exe[0], 280);
+    if (readed >= 280 - 1) {
+        MessageBoxA(NULL, "Path to remaster is too large.", "Command & Conquer", MB_ICONEXCLAMATION | MB_OK);
+        return -1;
+    }
+
+    /*
+    ** First argument is supposed to be a pointer to the .EXE that is running
+    ** - False. Must be a pointer to the DLL - giulianob 07/11/2021
+    **
+    */
+    argc = 1;                  // Set argument count to 1
+    argv[0] = &path_to_exe[0]; // Set 1st command line argument to point to full path
+
+    /*
+    ** Get pointers to command line arguments just like if we were in DOS
+    **
+    ** The command line we get is cr/zero? terminated.
+    **
+    */
+
+    command_scan = 0;
+
+    /* This certainly can be improved, but worse than this is not working :)*/
+
+    do {
+        /*
+        ** Scan for non-space character on command line
+        */
+        do {
+            command_char = *(command_line + command_scan++);
+        } while (command_char == ' ');
+
+        if (command_char != 0 && command_char != 13) {
+            argv[argc++] = command_line + command_scan - 1;
+
+            /*
+            ** Scan for space character on command line
+            */
+            bool in_quotes = false;
+            do {
+                command_char = *(command_line + command_scan++);
+                if (command_char == '"') {
+                    in_quotes = !in_quotes;
+                }
+            } while ((in_quotes || command_char != ' ') && command_char != 0 && command_char != 13);
+
+            *(command_line + command_scan - 1) = 0;
+        }
+
+    } while (command_char != 0 && command_char != 13 && argc < 20);
+
+    if (argc >= 20) {
+        MessageBoxA(NULL, "Too many arguments on command line.", "Command & Conquer", MB_ICONEXCLAMATION | MB_OK);
+        return -1;
+    }
+
+    return main(argc, argv);
+}
+#endif // REMASTER_BUILD
 
 int main(int argc, char** argv)
 {
-#endif
     UtfArgs args(argc, argv);
     CCDebugString("C&C95 - Starting up.\n");
 


### PR DESCRIPTION
Remaster seems to pass a modified argv parameters to DLL. First parameter should be path to DLL, and second parameter should be path to CDROM. Path to EXE and its parameters *must* not be retrieved, use what the game passed to it.

Code seems awful, but that is the original code they provided. Hopefully, it won't need to be touched again for a while because everything that is interesting is from `main` and beyond.