### PR TITLE
320x200: Fix clickmap being incorrectly stretched

### DIFF
--- a/tiberiandawn/ending.cpp
+++ b/tiberiandawn/ending.cpp
@@ -119,6 +119,7 @@ void Nod_Ending(void)
 #endif // NOT_FOR_WIN95
     int oldfontxspacing = FontXSpacing;
     void const* oldfont;
+    int factor = Get_Resolution_Factor() + 1;
 
     Score.Presentation();
 
@@ -185,13 +186,13 @@ void Nod_Ending(void)
                 if ((key & 0x10FF) == KN_LMOUSE && !(key & KN_RLSE_BIT)) {
                     int mousex = Keyboard->MouseQX;
                     int mousey = Keyboard->MouseQY;
-                    if (mousey >= 22 * 2 && mousey <= 177 * 2) {
+                    if (mousey >= 22 * factor && mousey <= 177 * factor) {
                         done++;
-                        if (mousex < 160 * 2 && mousey < 100 * 2)
+                        if (mousex < 160 * factor && mousey < 100 * factor)
                             selection = 2;
-                        if (mousex < 160 * 2 && mousey >= 100 * 2)
+                        if (mousex < 160 * factor && mousey >= 100 * factor)
                             selection = 3;
-                        if (mousex >= 160 * 2 && mousey >= 100 * 2)
+                        if (mousex >= 160 * factor && mousey >= 100 * factor)
                             selection = 4;
                     }
                 }

--- a/tiberiandawn/intro.cpp
+++ b/tiberiandawn/intro.cpp
@@ -106,6 +106,7 @@ void Choose_Side(void)
     int oldfontxspacing = FontXSpacing;
     int setpalette = 0;
     int gdi_start_palette;
+    int scale_factor = Get_Resolution_Factor() + 1;
 
     TextPrintBuffer = new GraphicBufferClass(SeenBuff.Get_Width(), SeenBuff.Get_Height(), (void*)NULL);
     TextPrintBuffer->Clear();
@@ -214,8 +215,8 @@ void Choose_Side(void)
             frame = 0;
         if (Keyboard->Check() && endframe == 255) {
             if ((Keyboard->Get() & 0x10FF) == KN_LMOUSE) {
-                if ((Keyboard->MouseQY > 48 * 2) && (Keyboard->MouseQY < 150 * 2)) {
-                    if ((Keyboard->MouseQX > 18 * 2) && (Keyboard->MouseQX < 148 * 2)) {
+                if ((Keyboard->MouseQY > 48 * scale_factor) && (Keyboard->MouseQY < 150 * scale_factor)) {
+                    if ((Keyboard->MouseQX > 18 * scale_factor) && (Keyboard->MouseQX < 148 * scale_factor)) {
                         // Chose GDI
                         Whom = HOUSE_GOOD;
                         ScenPlayer = SCEN_PLAYER_GDI;
@@ -223,7 +224,7 @@ void Choose_Side(void)
                         speechhandle = Play_Sample(speechg);
                         speechplaying = true;
                         speech = speechg;
-                    } else if ((Keyboard->MouseQX > 160 * 2) && (Keyboard->MouseQX < 300 * 2)) {
+                    } else if ((Keyboard->MouseQX > 160 * scale_factor) && (Keyboard->MouseQX < 300 * scale_factor)) {
                         // Chose Nod
                         selection = 1;
                         endframe = 14;
@@ -244,7 +245,7 @@ void Choose_Side(void)
 
     // erase the "choose side" text
     PseudoSeenBuff->Fill_Rect(0, 180, 319, 199, 0);
-    SeenBuff.Fill_Rect(0, 180 * 2, 319 * 2, 199 * 2, 0);
+    SeenBuff.Fill_Rect(0, 180 * scale_factor, 319 * scale_factor, 199 * scale_factor, 0);
     Interpolate_2X_Scale(PseudoSeenBuff, &SeenBuff, "SIDES.PAL", Settings.Video.InterpolationMode);
     Keyboard->Clear();
     SysMemPage.Clear();

--- a/tiberiandawn/mapsel.cpp
+++ b/tiberiandawn/mapsel.cpp
@@ -421,6 +421,7 @@ void Map_Selection(void)
     int scenario, lastscenario;
     int house = PlayerPtr->Class->House;
     int attackxcoord = 0;
+    int factor = Get_Resolution_Factor() + 1;
 
     static int const _countryx[] = {195,
                                     217,
@@ -1017,7 +1018,7 @@ void Map_Selection(void)
         if (Keyboard->Check()) {
             if ((Keyboard->Get() & 0x10FF) == KN_LMOUSE) {
                 for (selection = 0; selection < CountryArray[scenario].Choices[ScenDir]; selection++) {
-                    color = click_map.Get_Pixel(Get_Mouse_X() / 2, Get_Mouse_Y() / 2);
+                    color = click_map.Get_Pixel(Get_Mouse_X() / factor, Get_Mouse_Y() / factor);
 
                     /*
                     ** Special hack for Egypt the second time through


### PR DESCRIPTION
On 320x200, we could not select the Nod campaign nor advance past GDI Mission 2 because the mouse click coordinate were being incorrectly multiplied by a factor of 2.

This commit fixes that and should allow 320x200 to be playable from start to finish.