### PR TITLE
[TD] Fix map editor crashing due to uninitialized sidebar buttons

### DIFF
--- a/tiberiandawn/sidebar.cpp
+++ b/tiberiandawn/sidebar.cpp
@@ -916,11 +916,11 @@ void SidebarClass::AI(KeyNumType& input, int x, int y)
         }
     }
 
-    if ((!IsRepairMode) && Repair->IsOn) {
+    if ((!IsRepairMode) && Repair && Repair->IsOn) {
         Repair->Turn_Off();
     }
 
-    if ((!IsSellMode) && Upgrade->IsOn) {
+    if ((!IsSellMode) && Upgrade && Upgrade->IsOn) {
         Upgrade->Turn_Off();
     }
 


### PR DESCRIPTION
One of the changes introduced by 320x200 mode was replacing the statically allocated ShapeButtons on sidebar with ToggleClass pointers. Because of this, the mapeditor crashed trying to check if it was active. We fixed this by checking if the button was initialized.