### PR TITLE
[VanillaMix] Fix packing directory of files into .mix on Windows

### DIFF
--- a/tools/mixtool/makemix.cpp
+++ b/tools/mixtool/makemix.cpp
@@ -338,7 +338,14 @@ int Create_Mix(const char* outfile,
         struct dirent* dirp;
         struct stat st;
 
-        if ((dp = opendir(search_dir)) != nullptr) {
+#ifdef _WIN32
+        // Windows needs a full path
+        char* full_search_dir = _fullpath(NULL, search_dir, PATH_MAX);
+#else
+        const char* full_search_dir = search_dir;
+#endif
+
+        if (full_search_dir != nullptr && (dp = opendir(full_search_dir)) != nullptr) {
             while ((dirp = readdir(dp)) != nullptr) {
                 std::string fullpath = std::string(search_dir) + PathsClass::SEP;
                 fullpath += dirp->d_name;


### PR DESCRIPTION
See #686 for context.

I discovered that the `opendir()` only works on my Windows 10 machine when it's supplied with a full path. To make packing files consistent with the rest of the CLI args, I've added a call to `_fullpath()` just before in order to ensure the directory is found.