### PR TITLE
Add option to specify aspect ratio when boxing

### DIFF
--- a/common/settings.cpp
+++ b/common/settings.cpp
@@ -24,6 +24,7 @@ SettingsClass::SettingsClass()
     Video.Width = 0;
     Video.Height = 0;
     Video.Boxing = true;
+    Video.CorrectAspectRatio = true;
     Video.FrameLimit = 120;
     Video.InterpolationMode = 2;
     Video.HardwareCursor = false;
@@ -55,6 +56,7 @@ void SettingsClass::Load(INIClass& ini)
     Video.WindowHeight = ini.Get_Int("Video", "WindowHeight", Video.WindowHeight);
     Video.Windowed = ini.Get_Bool("Video", "Windowed", Video.Windowed);
     Video.Boxing = ini.Get_Bool("Video", "Boxing", Video.Boxing);
+    Video.CorrectAspectRatio = ini.Get_Bool("Video", "CorrectAspectRatio", Video.CorrectAspectRatio);
     Video.Width = ini.Get_Int("Video", "Width", Video.Width);
     Video.Height = ini.Get_Int("Video", "Height", Video.Height);
     Video.FrameLimit = ini.Get_Int("Video", "FrameLimit", Video.FrameLimit);
@@ -95,6 +97,7 @@ void SettingsClass::Save(INIClass& ini)
     ini.Put_Int("Video", "WindowHeight", Video.WindowHeight);
     ini.Put_Bool("Video", "Windowed", Video.Windowed);
     ini.Put_Bool("Video", "Boxing", Video.Boxing);
+    ini.Put_Bool("Video", "CorrectAspectRatio", Video.CorrectAspectRatio);
     ini.Put_Int("Video", "Width", Video.Width);
     ini.Put_Int("Video", "Height", Video.Height);
     ini.Put_Int("Video", "FrameLimit", Video.FrameLimit);

--- a/common/settings.cpp
+++ b/common/settings.cpp
@@ -24,7 +24,7 @@ SettingsClass::SettingsClass()
     Video.Width = 0;
     Video.Height = 0;
     Video.Boxing = true;
-    Video.CorrectAspectRatio = true;
+    Video.BoxingAspectRatio = "4:3";
     Video.FrameLimit = 120;
     Video.InterpolationMode = 2;
     Video.HardwareCursor = false;
@@ -56,7 +56,7 @@ void SettingsClass::Load(INIClass& ini)
     Video.WindowHeight = ini.Get_Int("Video", "WindowHeight", Video.WindowHeight);
     Video.Windowed = ini.Get_Bool("Video", "Windowed", Video.Windowed);
     Video.Boxing = ini.Get_Bool("Video", "Boxing", Video.Boxing);
-    Video.CorrectAspectRatio = ini.Get_Bool("Video", "CorrectAspectRatio", Video.CorrectAspectRatio);
+    Video.BoxingAspectRatio = ini.Get_String("Video", "BoxingAspectRatio", Video.BoxingAspectRatio);
     Video.Width = ini.Get_Int("Video", "Width", Video.Width);
     Video.Height = ini.Get_Int("Video", "Height", Video.Height);
     Video.FrameLimit = ini.Get_Int("Video", "FrameLimit", Video.FrameLimit);
@@ -97,7 +97,7 @@ void SettingsClass::Save(INIClass& ini)
     ini.Put_Int("Video", "WindowHeight", Video.WindowHeight);
     ini.Put_Bool("Video", "Windowed", Video.Windowed);
     ini.Put_Bool("Video", "Boxing", Video.Boxing);
-    ini.Put_Bool("Video", "CorrectAspectRatio", Video.CorrectAspectRatio);
+    ini.Put_String("Video", "BoxingAspectRatio", Video.BoxingAspectRatio);
     ini.Put_Int("Video", "Width", Video.Width);
     ini.Put_Int("Video", "Height", Video.Height);
     ini.Put_Int("Video", "FrameLimit", Video.FrameLimit);

--- a/common/settings.h
+++ b/common/settings.h
@@ -26,7 +26,7 @@ public:
         int WindowHeight;
         bool Windowed;
         bool Boxing;
-        bool CorrectAspectRatio;
+        std::string BoxingAspectRatio;
         int Width;
         int Height;
         int FrameLimit;

--- a/common/settings.h
+++ b/common/settings.h
@@ -26,6 +26,7 @@ public:
         int WindowHeight;
         bool Windowed;
         bool Boxing;
+        bool CorrectAspectRatio;
         int Width;
         int Height;
         int FrameLimit;

--- a/common/video_sdl2.cpp
+++ b/common/video_sdl2.cpp
@@ -134,9 +134,21 @@ static void Update_HWCursor_Settings()
     */
     float ar = (float)hwcursor.GameW / hwcursor.GameH;
     if (Settings.Video.Boxing) {
-        if (Settings.Video.CorrectAspectRatio) {
-            ar = 4.0 / 3.0;
+        try {
+            size_t colonPos = Settings.Video.BoxingAspectRatio.find(":");
+
+            if (colonPos == std::string::npos) {
+                throw "No colon";
+            }
+
+            size_t arLen = Settings.Video.BoxingAspectRatio.length();
+            std::string arW = Settings.Video.BoxingAspectRatio.substr(0, colonPos);
+            std::string arH = Settings.Video.BoxingAspectRatio.substr(colonPos + 1, arLen - colonPos);
+            ar = std::stof(arW) / std::stof(arH);
+        } catch (...) {
+            DBG_ERROR("Aspect ratio '%s' is invalid", Settings.Video.BoxingAspectRatio.c_str());
         }
+
         render_dst.w = win_w;
         render_dst.h = render_dst.w / ar;
         if (render_dst.h > win_h) {

--- a/common/video_sdl2.cpp
+++ b/common/video_sdl2.cpp
@@ -134,20 +134,23 @@ static void Update_HWCursor_Settings()
     */
     float ar = (float)hwcursor.GameW / hwcursor.GameH;
     if (Settings.Video.Boxing) {
-        try {
-            size_t colonPos = Settings.Video.BoxingAspectRatio.find(":");
+        size_t colonPos = Settings.Video.BoxingAspectRatio.find(":");
+        std::string arW;
+        std::string arH;
 
-            if (colonPos == std::string::npos) {
-                throw "No colon";
-            }
-
+        /*
+        ** If we don't have a valid string for aspect ratio, default back to 4:3.
+        */
+        if (colonPos == std::string::npos) {
+            arW = "4";
+            arH = "3";
+        } else {
             size_t arLen = Settings.Video.BoxingAspectRatio.length();
-            std::string arW = Settings.Video.BoxingAspectRatio.substr(0, colonPos);
-            std::string arH = Settings.Video.BoxingAspectRatio.substr(colonPos + 1, arLen - colonPos);
-            ar = std::stof(arW) / std::stof(arH);
-        } catch (...) {
-            DBG_ERROR("Aspect ratio '%s' is invalid", Settings.Video.BoxingAspectRatio.c_str());
+            arW = Settings.Video.BoxingAspectRatio.substr(0, colonPos);
+            arH = Settings.Video.BoxingAspectRatio.substr(colonPos + 1, arLen - colonPos);
         }
+
+        ar = std::stof(arW) / std::stof(arH);
 
         render_dst.w = win_w;
         render_dst.h = render_dst.w / ar;

--- a/common/video_sdl2.cpp
+++ b/common/video_sdl2.cpp
@@ -134,6 +134,9 @@ static void Update_HWCursor_Settings()
     */
     float ar = (float)hwcursor.GameW / hwcursor.GameH;
     if (Settings.Video.Boxing) {
+        if (Settings.Video.CorrectAspectRatio) {
+            ar = 4.0 / 3.0;
+        }
         render_dst.w = win_w;
         render_dst.h = render_dst.w / ar;
         if (render_dst.h > win_h) {


### PR DESCRIPTION
This adds an ini option to force a 4:3 aspect ratio when letterboxing is enabled. Pretty self-explanatory, but in my opinion this makes it closer to how it looked originally.

It's still subjective, so I don't mind changing the default to false.