### PR TITLE
Add "sharp-linear" scaling option

### DIFF
--- a/common/video_sdl2.cpp
+++ b/common/video_sdl2.cpp
@@ -333,13 +333,10 @@ bool Set_Video_Mode(int w, int h, int bits_per_pixel)
     /*
     ** Set requested scaling algorithm.
     */
-    if (Settings.Video.Scaler == "sharp-linear") {
-        DBG_INFO("  scaler set to 'sharp-linear'");
-    } else {
+    DBG_INFO("  scaler set to '%s'", Settings.Video.Scaler.c_str());
+    if (Settings.Video.Scaler != "sharp-linear") {
         if (!SDL_SetHintWithPriority(SDL_HINT_RENDER_SCALE_QUALITY, Settings.Video.Scaler.c_str(), SDL_HINT_OVERRIDE)) {
-            DBG_WARN("  scaler '%s' is unsupported");
-        } else {
-            DBG_INFO("  scaler set to '%s'", Settings.Video.Scaler.c_str());
+            DBG_WARN("  scaler '%s' is unsupported", Settings.Video.Scaler.c_str());
         }
     }
 

--- a/common/video_sdl2.cpp
+++ b/common/video_sdl2.cpp
@@ -334,7 +334,7 @@ bool Set_Video_Mode(int w, int h, int bits_per_pixel)
     ** Set requested scaling algorithm.
     */
     DBG_INFO("  scaler set to '%s'", Settings.Video.Scaler.c_str());
-    if (Settings.Video.Scaler != "sharp-linear") {
+    if (Settings.Video.Scaler.compare("sharp-linear") == 0) {
         if (!SDL_SetHintWithPriority(SDL_HINT_RENDER_SCALE_QUALITY, Settings.Video.Scaler.c_str(), SDL_HINT_OVERRIDE)) {
             DBG_WARN("  scaler '%s' is unsupported", Settings.Video.Scaler.c_str());
         }
@@ -712,7 +712,7 @@ public:
         if (flags & GBC_VISIBLE) {
             windowSurface = SDL_CreateRGBSurfaceWithFormat(0, w, h, SDL_BITSPERPIXEL(pixel_format), pixel_format);
 
-            if (Settings.Video.Scaler == "sharp-linear") {
+            if (Settings.Video.Scaler.compare("sharp-linear") == 0) {
                 this->RecalculateRenderTarget();
             }
 
@@ -911,7 +911,7 @@ void Toggle_Video_Fullscreen()
         SDL_SetWindowSize(window, Settings.Video.WindowWidth, Settings.Video.WindowHeight);
     }
 
-    if (frontSurface && Settings.Video.Scaler == "sharp-linear") {
+    if (frontSurface && Settings.Video.Scaler.compare("sharp-linear") == 0) {
         frontSurface->RecalculateRenderTarget();
     }
 

--- a/common/video_sdl2.cpp
+++ b/common/video_sdl2.cpp
@@ -333,7 +333,9 @@ bool Set_Video_Mode(int w, int h, int bits_per_pixel)
     /*
     ** Set requested scaling algorithm.
     */
-    if (Settings.Video.Scaler != "sharp-linear") {
+    if (Settings.Video.Scaler == "sharp-linear") {
+        DBG_INFO("  scaler set to 'sharp-linear'");
+    } else {
         if (!SDL_SetHintWithPriority(SDL_HINT_RENDER_SCALE_QUALITY, Settings.Video.Scaler.c_str(), SDL_HINT_OVERRIDE)) {
             DBG_WARN("  scaler '%s' is unsupported");
         } else {

--- a/common/video_sdl2.cpp
+++ b/common/video_sdl2.cpp
@@ -333,10 +333,12 @@ bool Set_Video_Mode(int w, int h, int bits_per_pixel)
     /*
     ** Set requested scaling algorithm.
     */
-    if (!SDL_SetHintWithPriority(SDL_HINT_RENDER_SCALE_QUALITY, Settings.Video.Scaler.c_str(), SDL_HINT_OVERRIDE)) {
-        DBG_WARN("  scaler '%s' is unsupported");
-    } else {
-        DBG_INFO("  scaler set to '%s'", Settings.Video.Scaler.c_str());
+    if (Settings.Video.Scaler != "sharp-linear") {
+        if (!SDL_SetHintWithPriority(SDL_HINT_RENDER_SCALE_QUALITY, Settings.Video.Scaler.c_str(), SDL_HINT_OVERRIDE)) {
+            DBG_WARN("  scaler '%s' is unsupported");
+        } else {
+            DBG_INFO("  scaler set to '%s'", Settings.Video.Scaler.c_str());
+        }
     }
 
     if (palette == nullptr) {
@@ -722,12 +724,37 @@ public:
         : flags(flags)
         , windowSurface(nullptr)
         , texture(nullptr)
+        , prescaledTexture(nullptr)
     {
         surface = SDL_CreateRGBSurface(0, w, h, 8, 0, 0, 0, 0);
         SDL_SetSurfacePalette(surface, palette);
 
         if (flags & GBC_VISIBLE) {
             windowSurface = SDL_CreateRGBSurfaceWithFormat(0, w, h, SDL_BITSPERPIXEL(pixel_format), pixel_format);
+
+            if (Settings.Video.Scaler == "sharp-linear") {
+                SDL_Rect viewport;
+                SDL_RenderGetViewport(renderer, &viewport);
+
+                /*
+                ** Calculate one integer scale larger than viewport resolution
+                */
+                int scaleFactor = 1;
+                if (viewport.w > viewport.h) {
+                    scaleFactor = (viewport.w / w) + 1;
+                } else {
+                    scaleFactor = (viewport.h / h) + 1;
+                }
+
+                SDL_SetHintWithPriority(SDL_HINT_RENDER_SCALE_QUALITY, "best", SDL_HINT_OVERRIDE);
+                prescaledTexture = SDL_CreateTexture(renderer,
+                                                     windowSurface->format->format,
+                                                     SDL_TEXTUREACCESS_TARGET,
+                                                     w * scaleFactor,
+                                                     h * scaleFactor);
+                SDL_SetHintWithPriority(SDL_HINT_RENDER_SCALE_QUALITY, "nearest", SDL_HINT_OVERRIDE);
+            }
+
             texture = SDL_CreateTexture(renderer, windowSurface->format->format, SDL_TEXTUREACCESS_STREAMING, w, h);
             frontSurface = this;
         }
@@ -740,6 +767,10 @@ public:
         }
 
         SDL_FreeSurface(surface);
+
+        if (prescaledTexture) {
+            SDL_DestroyTexture(prescaledTexture);
+        }
 
         if (texture) {
             SDL_DestroyTexture(texture);
@@ -837,8 +868,24 @@ public:
         }
 
         SDL_UpdateTexture(texture, NULL, windowSurface->pixels, windowSurface->pitch);
-        SDL_RenderClear(renderer);
-        SDL_RenderCopy(renderer, texture, NULL, &render_dst);
+
+        if (prescaledTexture) {
+            /*
+            ** Nearest-neighbor integer scale up to a render target before a final linear scale.
+            */
+            SDL_SetRenderTarget(renderer, prescaledTexture);
+            SDL_RenderClear(renderer);
+            SDL_RenderCopy(renderer, texture, NULL, NULL);
+
+            SDL_SetRenderTarget(renderer, NULL);
+            SDL_RenderClear(renderer);
+            SDL_RenderCopy(renderer, prescaledTexture, NULL, &render_dst);
+        } else {
+            SDL_SetRenderTarget(renderer, NULL);
+            SDL_RenderClear(renderer);
+            SDL_RenderCopy(renderer, texture, NULL, &render_dst);
+        }
+
         SDL_RenderPresent(renderer);
     }
 
@@ -846,6 +893,7 @@ private:
     SDL_Surface* surface;
     SDL_Surface* windowSurface;
     SDL_Texture* texture;
+    SDL_Texture* prescaledTexture;
     GBC_Enum flags;
 };
 

--- a/common/video_sdl2.cpp
+++ b/common/video_sdl2.cpp
@@ -334,7 +334,7 @@ bool Set_Video_Mode(int w, int h, int bits_per_pixel)
     ** Set requested scaling algorithm.
     */
     DBG_INFO("  scaler set to '%s'", Settings.Video.Scaler.c_str());
-    if (Settings.Video.Scaler.compare("sharp-linear") == 0) {
+    if (Settings.Video.Scaler.compare("sharp-linear") != 0) {
         if (!SDL_SetHintWithPriority(SDL_HINT_RENDER_SCALE_QUALITY, Settings.Video.Scaler.c_str(), SDL_HINT_OVERRIDE)) {
             DBG_WARN("  scaler '%s' is unsupported", Settings.Video.Scaler.c_str());
         }


### PR DESCRIPTION
This adds a special "sharp-linear" option to the Scaler ini setting which uses a render target texture to do an integer scale up to some resolution higher than the viewport before a final linear scale back down. This produces a sharp image that doesn't exhibit weird thick lines in text or other uneven pixels.

It's a little computationally heavy to be scaling up so high, but on machines with plenty of headroom, the boost in image quality is probably worth it.

### Nearest
![nearest](https://user-images.githubusercontent.com/110798/128583201-f32bd0b9-b747-4257-9472-f4ba8278ada4.png)

### "sharp-linear"
![sharp-linear](https://user-images.githubusercontent.com/110798/128583206-b335c683-0c9b-4edd-8131-bd90c637529b.png)

