### PR TITLE
[RA] Fixes briefing drawing speed.

### DIFF
--- a/common/framelimit.cpp
+++ b/common/framelimit.cpp
@@ -15,7 +15,7 @@ extern WWMouseClass* WWMouse;
 void Video_Render_Frame();
 #endif
 
-void Frame_Limiter(bool force_render)
+void Frame_Limiter(bool force_render, bool no_block)
 {
     static auto frame_start = std::chrono::steady_clock::now();
 #ifdef SDL2_BUILD
@@ -25,7 +25,11 @@ void Frame_Limiter(bool force_render)
     auto render_remaining = std::chrono::duration_cast<std::chrono::milliseconds>(frame_start - render_start).count();
 
     if (force_render == false && render_remaining > render_avg) {
-        ms_sleep(unsigned(render_remaining));
+        if (!no_block) {
+            ms_sleep(unsigned(render_remaining));
+        } else {
+            ms_sleep(1); // Unconditionally yield for minimum time.
+        }
         return;
     }
 
@@ -38,7 +42,7 @@ void Frame_Limiter(bool force_render)
     render_avg = (render_avg + render_time) / 2;
 #endif
 
-    if (Settings.Video.FrameLimit > 0) {
+    if (Settings.Video.FrameLimit > 0 && !no_block) {
 #ifdef SDL2_BUILD
         auto frame_end = render_end;
 #else

--- a/common/framelimit.h
+++ b/common/framelimit.h
@@ -1,6 +1,6 @@
 #ifndef FRAMELIMIT_H
 #define FRAMELIMIT_H
 
-void Frame_Limiter(bool force_render = true);
+void Frame_Limiter(bool force_render = true, bool no_block = false);
 
 #endif /* FRAMELIMIT_H */

--- a/redalert/scenario.cpp
+++ b/redalert/scenario.cpp
@@ -1635,7 +1635,7 @@ int BGMessageBox(char const* msg, int btn1, int btn2)
                 Call_Back();
             } while (!Keyboard->Check() && cd);
         }
-        Frame_Limiter();
+        Frame_Limiter(false, true);
     } while (buffer[++bufindex]);
 
     Show_Mouse();


### PR DESCRIPTION
Text was being drawn limited by the frame limiter which slowed the draw
down too much vs the original. Replaced with unconditional thread yield
and frame draw.

Fixes #698
Fixes #531
Partly solves #642