### PR TITLE
[TD] Fixes Ion Cannon destruction of Temple detection.

### DIFF
--- a/tiberiandawn/building.cpp
+++ b/tiberiandawn/building.cpp
@@ -1564,22 +1564,24 @@ ResultType BuildingClass::Take_Damage(int& damage, int distance, WarheadType war
             **	remembering of this fact. The finale uses this information to
             **	play the correct movie.
             */
-            if (*this == STRUCT_TEMPLE && warhead == WARHEAD_PB) {
-                TempleIoned = true;
+            if (GameToPlay == GAME_NORMAL && *this == STRUCT_TEMPLE) {
+                if (warhead == WARHEAD_PB) {
+                    TempleIoned = true;
 #ifdef REMASTER_BUILD
-                /*
-                ** Maybe trigger an achivement if the structure is owned by an AI house in campaign mode. ST -
-                *11/14/2019 1:53PM
-                */
-                if (GameToPlay == GAME_NORMAL && !House->IsHuman && source && source->House && source->House->IsHuman) {
-                    TechnoTypeClass const* object_type = Techno_Type_Class();
-                    if (object_type) {
-                        On_Achievement_Event(source->House, "ION_DESTROYS_TEMPLE", object_type->IniName);
+                    /*
+                    ** Maybe trigger an achivement if the structure is owned by an AI house in campaign mode. ST -
+                    ** 11/14/2019 1:53PM
+                    */
+                    if (!House->IsHuman && source && source->House && source->House->IsHuman) {
+                        TechnoTypeClass const* object_type = Techno_Type_Class();
+                        if (object_type) {
+                            On_Achievement_Event(source->House, "ION_DESTROYS_TEMPLE", object_type->IniName);
+                        }
                     }
-                }
 #endif
-            } else {
-                TempleIoned = false;
+                } else {
+                    TempleIoned = false;
+                }
             }
 
             if (House) {

--- a/tiberiandawn/saveload.cpp
+++ b/tiberiandawn/saveload.cpp
@@ -637,6 +637,7 @@ bool Save_Misc_Values(FileClass& file)
 
     // This is new...
     file.Write(ActionMovie, sizeof(ActionMovie));
+    file.Write(&TempleIoned, sizeof(TempleIoned));
 
     return (true);
 }
@@ -745,6 +746,10 @@ bool Load_Misc_Values(FileClass& file)
 
     if (file.Seek(0, SEEK_CUR) < file.Size()) {
         file.Read(ActionMovie, sizeof(ActionMovie));
+    }
+
+    if (file.Seek(0, SEEK_CUR) < file.Size()) {
+        file.Read(&TempleIoned, sizeof(TempleIoned));
     }
 
     return (true);

--- a/tiberiandawn/scenario.cpp
+++ b/tiberiandawn/scenario.cpp
@@ -316,6 +316,7 @@ void Clear_Scenario(void)
     CrateCount = 0;
     CrateTimer = 0;
     CrateMaker = false;
+    TempleIoned = false;
 
     /*
     ** Call everyone's Init routine, except the Map's; for the Map, only call


### PR DESCRIPTION
Destroying another building after destroying the temple with the ion
cannon will no longer result in the normal GDI ending playing
rather than the Ion Cannon ending.

Fix changes logic to only change TempleIoned bool when the object
destroyed is the temple.