### PR TITLE
Fix Tiberian Dawn crashing under Command and Conquer: Remastered Collection.

### DIFF
--- a/tiberiandawn/techno.cpp
+++ b/tiberiandawn/techno.cpp
@@ -2449,7 +2449,7 @@ BulletClass* TechnoClass::Fire_At(TARGET target, int which)
         //reveal that unit and a little area around it.
         if (GameToPlay == GAME_NORMAL) {
             if ((!IsOwnedByPlayer && !IsDiscoveredByPlayer)
-                || (!Map[Center_Coord()].IsMapped && (What_Am_I() != RTTI_AIRCRAFT || !IsOwnedByPlayer))) {
+                || (!Map[Coord_Cell(Center_Coord())].IsMapped && (What_Am_I() != RTTI_AIRCRAFT || !IsOwnedByPlayer))) {
                 Map.Sight_From(PlayerPtr, Coord_Cell(Center_Coord()), 1, false);
             }
         }


### PR DESCRIPTION
Tiberian Dawn was crashing at the start of GDI Mission 1. This commit restores a missing conversion from Coordinates to Cells in the unit firing code.