### PR TITLE
Fix typos.

### DIFF
--- a/common/buff.cpp
+++ b/common/buff.cpp
@@ -137,7 +137,7 @@ Buffer::Buffer(Buffer const& buffer)
  * Buffer::operator = -- Assignment operator for the buffer object.                            *
  *                                                                                             *
  *    This will make a duplicate of the buffer object specified. Any buffer pointed to by the  *
- *    left hand buffer will be lost (possibley freed as a result).                             *
+ *    left hand buffer will be lost (possibly freed as a result).                              *
  *                                                                                             *
  * INPUT:   buffer   -- Reference to the right hand buffer object.                             *
  *                                                                                             *

--- a/common/ccfile.cpp
+++ b/common/ccfile.cpp
@@ -119,7 +119,7 @@ void CCFileClass::Error(int error, int canretry, char const* filename)
         }
     }
 
-    // If its not a required CD releated error, pass to next class handling in the chain.
+    // If it's not a required CD related error, pass to next class handling in the chain.
     CDFileClass::Error(error, canretry, filename);
 }
 
@@ -285,7 +285,7 @@ long CCFileClass::Seek(long pos, int dir)
 long CCFileClass::Size(void)
 {
     /*
-    **	If the file is resident, the the size is already known. Just return the size in this
+    **	If the file is resident, then the size is already known. Just return the size in this
     **	case.
     */
     if (Is_Resident())
@@ -345,7 +345,7 @@ int CCFileClass::Is_Available(int)
  * CCFileClass::Is_Open -- Determines if the file is open.                                     *
  *                                                                                             *
  *    A mixfile is open if there is a pointer to the mixfile data. In absence of this,         *
- *    the the file is open if the file handle is valid.                                        *
+ *    then the file is open if the file handle is valid.                                       *
  *                                                                                             *
  * INPUT:   none                                                                               *
  *                                                                                             *

--- a/common/cdfile.cpp
+++ b/common/cdfile.cpp
@@ -233,7 +233,7 @@ int CDFileClass::Set_Search_Drives(char* pathlist)
                 }
 
                 /*
-                ** Regardless of anything else, add the relative path so it works if its in the working dir.
+                ** Regardless of anything else, add the relative path so it works if it's in the working dir.
                 */
                 Add_Search_Drive(ptr);
             }

--- a/common/connect.h
+++ b/common/connect.h
@@ -66,7 +66,7 @@
  * NOTES ON ACK/RETRY:																		*
  * This class provides a "non-sequenced" ACK/Retry approach to packet		*
  * transmission.  It sends out as many packets as are in the queue, whose	*
- * resend delta times have expired; and it ACK's any packets its received	*
+ * resend delta times have expired; and it ACK's any packets it's received *
  * who haven't been ACK'd yet.  Thus, order of delivery is NOT guaranteed;	*
  * but, the performance is better than a "sequenced" approach.  Also, the	*
  * Packet ID scheme (see below) ensures that the application will read		*

--- a/common/control.cpp
+++ b/common/control.cpp
@@ -55,7 +55,7 @@
  *                                                                                             *
  *          flags -- The input event flags that this gadget recognizes.                        *
  *                                                                                             *
- *          sticky-- This this a "sticky" gadget? A sticky gadget is one that takes over the   *
+ *          sticky-- Is this a "sticky" gadget? A sticky gadget is one that takes over the     *
  *                   gadget list while the mouse button is held down, if the mouse button was  *
  *                   initially clicked over its region. This is the behavior of "normal"       *
  *                   buttons in Windows.                                                       *

--- a/common/dipthong.cpp
+++ b/common/dipthong.cpp
@@ -45,7 +45,7 @@
 /***************************************************************************
  * Fixup_Text -- Converts dipthonged foreign text into normal text.        *
  *                                                                         *
- *    Takes text that has been processed (or undipped) to hold foriegn     *
+ *    Takes text that has been processed (or undipped) to hold foreign     *
  *    language character pairs (needed for Window_Print) and converts it   *
  *    so that Text_Print will print it properly.  Typically this would be  *
  *    used after text has been undipped but before it will be Text_Printed.*
@@ -124,7 +124,7 @@ int Dip_Text(char const* source, char* dest)
 
             /*
             **	Characters greater than 127 cannot be dipthonged.  They must
-            **	be preceeded with an extended character code.
+            **	be preceded with an extended character code.
             */
             *dest++ = (char)KA_EXTEND;
             first -= 127;

--- a/common/filepcx.cpp
+++ b/common/filepcx.cpp
@@ -44,18 +44,18 @@
  * GBC* Read_PCX_File (char* name, char* palette ,void *Buff, long size ); *
  *                                                                         *
  *                                                                         *
- * INPUT: name is a NULL terminated string of the fromat [xxxx.pcx]        *
- *        palette is optional, if palette != NULL the the color palette of *
+ * INPUT: name is a NULL terminated string of the format [xxxx.pcx]        *
+ *        palette is optional, if palette != NULL then the color palette of*
  *                  the pcx file will be place in the memory block pointed *
  *              by palette.                                                *
- *           Buff is optinal, if Buff == NULL a new memory Buffer          *
+ *           Buff is optional, if Buff == NULL a new memory Buffer         *
  *                   will be allocated, otherwise the file will be placed  *
- *                   at location pointd by Buffer;                         *
+ *                   at the location pointed to by Buffer;                 *
  *          Size is the size in bytes of the memory block pointed by Buff  *
  *              is also optional;                                          *
  *                                                                         *
- * OUTPUT: on succes a pointer to a GraphicBufferClass cointaining the     *
- *         pcx file, NULL othewise.                                        *
+ * OUTPUT: on success a pointer to a GraphicBufferClass containing the     *
+ *         pcx file, NULL otherwise.                                       *
  *                                                                         *
  * WARNINGS:                                                               *
  *         Appears to be a comment-free zone                               *
@@ -182,10 +182,10 @@ static void Write_Pcx_ScanLine(int file_handle, int scansize, unsigned char* ptr
  *                                                                         *
  *                                                                         *
  *                                                                         *
- * INPUT:  name  is a NULL terminated string of the fromat [xxxx.pcx]      *
+ * INPUT:  name  is a NULL terminated string of the format [xxxx.pcx]      *
  *         pic   is a pointer to a GraphicViewPortClass or to a            *
  *         GraphicBufferClass holding the picture.                         *
- *         palette is a pointer the the memry block holding the color      *
+ *         palette is a pointer to the memory block holding the color      *
  *            palette of the picture.                                      *
  *                                                                         *
  * OUTPUT: FALSE  if the function fails zero otherwise                     *

--- a/common/font.cpp
+++ b/common/font.cpp
@@ -224,8 +224,8 @@ void Set_Font_Palette_Range(void const* palette, int start_idx, int end_idx)
  * WARNINGS:   Some system memory is grabbed by this routine.              *
  *                                                                         *
  * HISTORY:                                                                *
- *   4/10/91    BS  : 2.0 compatibily                                      *
- *   6/09/91    JLB : IBM and Amiga compatability.                         *
+ *   4/10/91    BS  : 2.0 compatibility                                    *
+ *   6/09/91    JLB : IBM and Amiga compatibility.                         *
  *   11/27/1991 JLB : Uses file I/O routines for disk access.              *
  *   01/29/1992 DRD : Modified to use new font format.                     *
  *   02/01/1992 DRD : Added font file verification.                        *

--- a/common/gadget.cpp
+++ b/common/gadget.cpp
@@ -66,7 +66,7 @@
 extern WWKeyboardClass* Keyboard;
 
 /*
-**	This records the current gadget the the gadget system is "stuck on". Such a
+**	This records the current gadget that the gadget system is "stuck on". Such a
 **	gadget will be processed to the exclusion of all others until the mouse button
 **	is no longer pressed.
 */
@@ -524,7 +524,7 @@ KeyNumType GadgetClass::Input(void)
     **	For mouse button clicks, the mouse position is actually held in the MouseQ...
     **	globals rather than their normal Mouse... globals. This is because we need to
     **	know the position of the mouse at the exact instant when the click occurred
-    **	rather the the mouse position at the time we get around to this function.
+    **	rather than the mouse position at the time we get around to this function.
     */
     if (((key & 0xFF) == KN_LMOUSE) || ((key & 0xFF) == KN_RMOUSE)) {
         mousex = Keyboard->MouseQX;

--- a/common/gbuffer.cpp
+++ b/common/gbuffer.cpp
@@ -66,8 +66,8 @@ void GraphicBufferClass::DD_Init(GBC_Enum flags)
 {
     VideoSurfacePtr = Video::Shared().CreateSurface(Width, Height, flags);
 
-    Allocated = false;   // even if system alloced, dont flag it cuz
-                         //   we dont want it freed.
+    Allocated = false;   // even if system alloced, don't flag it cuz
+                         //   we don't want it freed.
     IsHardware = true;   // flag it as a video surface
     Offset = NOT_LOCKED; // flag it as unavailable for reading or writing
     LockCount = 0;       //  surface is not locked
@@ -82,7 +82,7 @@ void GraphicBufferClass::Attach_DD_Surface(GraphicBufferClass* attach_buffer)
  * GBC::INIT -- Core function responsible for initing a GBC                *
  *                                                                         *
  * INPUT:      int      - the width in pixels of the GraphicBufferClass    *
- *             int      - the heigh in pixels of the GraphicBufferClass    *
+ *             int      - the height in pixels of the GraphicBufferClass   *
  *             void *   - pointer to user supplied buffer (system will     *
  *                        allocate space if buffer is NULL)                *
  *             long     - size of the user provided buffer                 *
@@ -212,7 +212,7 @@ GraphicBufferClass::GraphicBufferClass(int w, int h, void* buffer)
 }
 
 /*====================================================================================*
- * GBC::GRAPHICBUFFERCLASS -- contructor for GraphicsBufferClass with special flags   *
+ * GBC::GRAPHICBUFFERCLASS -- constructor for GraphicsBufferClass with special flags   *
  *                                                                                    *
  * INPUT:        int w          - width of buffer in pixels (default = 320)           *
  *               int h          - height of buffer in pixels (default = 200)          *
@@ -254,7 +254,7 @@ GraphicBufferClass::~GraphicBufferClass()
 bool GraphicBufferClass::Lock()
 {
     //
-    // If its not a direct draw surface then the lock is always sucessful.
+    // If its not a direct draw surface then the lock is always successful.
     //
     if (!IsHardware) {
         return (Offset != 0);
@@ -268,7 +268,7 @@ bool GraphicBufferClass::Lock()
     }
 
     /*
-    ** If we dont have focus then return failure
+    ** If we don't have focus then return failure
     */
     if (!GameInFocus) {
         return false;
@@ -306,7 +306,7 @@ bool GraphicBufferClass::Lock()
 
     Unblock_Mouse(this);
 
-    return result; // Return false because we couldnt lock or restore the surface
+    return result; // Return false because we couldn't lock or restore the surface
 }
 
 /***************************************************************************

--- a/common/gbuffer.h
+++ b/common/gbuffer.h
@@ -46,10 +46,10 @@
  * minimum amount of code space.  For programs that require MCGA or VESA   *
  * support, all that is necessary to do is link either the MCGA or VESA    *
  * specific libraries in, previous to WWLIB32.  The linker will then       *
- * overide the the necessary stub functions automatically.                 *
+ * override the necessary stub functions automatically.                    *
  *                                                                         *
  * In addition, there are helpful inline function calls for parameter      *
- * ellimination.  This header file gives the defintion for all             *
+ * elimination.  This header file gives the definition for all             *
  * GraphicViewPort and GraphicBuffer classes.                              *
  *                                                                         *
  * Terminology:                                                            *
@@ -124,7 +124,7 @@ class VideoSurface;
 /*=========================================================================*/
 /* GraphicBufferClass - A GraphicBuffer refers to an actual instance of an */
 /*      allocated buffer.  The GraphicBuffer may be drawn to directly      */
-/*      becuase it inherits a ViewPort which represents its physcial size. */
+/*      because it inherits a ViewPort which represents its physical size. */
 /*                                                                         */
 /*          BYTE    *Buffer  -  is the offset to graphic buffer            */
 /*          int     Width    -  is the width of graphic buffer             */

--- a/common/graphicsviewport.cpp
+++ b/common/graphicsviewport.cpp
@@ -199,7 +199,7 @@ void GraphicViewPortClass::Attach(GraphicBufferClass* gbuffer, int x, int y, int
  *              int the new width of the viewport in pixels                *
  *              int the new height of the viewport in pixels               *
  *                                                                         *
- * OUTPUT:      BOOL whether the Graphic View Port could be sucessfully    *
+ * OUTPUT:      BOOL whether the Graphic View Port could be successfully   *
  *                      resized.                                           *
  *                                                                         *
  * WARNINGS:   You may not resize a Graphic View Port which is derived     *

--- a/common/graphicsviewport.h
+++ b/common/graphicsviewport.h
@@ -46,10 +46,10 @@
  * minimum amount of code space.  For programs that require MCGA or VESA   *
  * support, all that is necessary to do is link either the MCGA or VESA    *
  * specific libraries in, previous to WWLIB32.  The linker will then       *
- * overide the the necessary stub functions automatically.                 *
+ * override the necessary stub functions automatically.                    *
  *                                                                         *
  * In addition, there are helpful inline function calls for parameter      *
- * ellimination.  This header file gives the defintion for all             *
+ * elimination.  This header file gives the definition for all             *
  * GraphicViewPort and GraphicBuffer classes.                              *
  *                                                                         *
  * Terminology:                                                            *
@@ -305,7 +305,7 @@ public:
         return;
     }
 
-    // This doesnt seem to exist anywhere?? - Steve T 9/26/95 6:05PM
+    // This doesn't seem to exist anywhere?? - Steve T 9/26/95 6:05PM
     //      VOID Grey_Out_Region(int x, int y, int width, int height, int color);
 
     //

--- a/common/ini.cpp
+++ b/common/ini.cpp
@@ -855,7 +855,7 @@ int INIClass::Get_Int(char const* section, char const* entry, int defvalue) cons
  *                                                                                             *
  *          entry    -- The entry identifier to tag to the integer number specified.           *
  *                                                                                             *
- *          number   -- The number to assign the the specified entry and placed in the         *
+ *          number   -- The number to assign to the specified entry and place in the           *
  *                      specified section.                                                     *
  *                                                                                             *
  * OUTPUT:  bool; Was the number placed into the INI database?                                 *

--- a/common/interpal.cpp
+++ b/common/interpal.cpp
@@ -317,7 +317,7 @@ void Interpolate_2X_Scale(GraphicBufferClass* source,
         }
 
         /*
-        ** Write the palette table to disk so we dont have to create it again next time
+        ** Write the palette table to disk so we don't have to create it again next time
         */
         if (palette_file_name) {
             Write_Interpolation_Palette(palette_file_name);
@@ -328,7 +328,7 @@ void Interpolate_2X_Scale(GraphicBufferClass* source,
 
     Wait_Blit();
     /*
-    ** Lock video surfaces if requred
+    ** Lock video surfaces if required
     */
     if (source->Get_IsDirectDraw()) {
         if (!source->Lock()) {

--- a/common/keyframe.cpp
+++ b/common/keyframe.cpp
@@ -414,7 +414,7 @@ uintptr_t Build_Frame(void const* dataptr, unsigned short framenumber, void* buf
 
     if (UseBigShapeBuffer) {
         /*
-        ** Save the uncompressed shape data so we dont have to uncompress it
+        ** Save the uncompressed shape data so we don't have to uncompress it
         ** again next time its drawn.
         ** We keep a space free before the raw shape data so we can add line
         ** header info before the shape is drawn for the first time

--- a/common/linear.cpp
+++ b/common/linear.cpp
@@ -129,7 +129,7 @@ bool Linear_Scale_To_Linear(void* thisptr,
     int dst_x1 = dst_width + dst_x;
     int dst_y1 = dst_height + dst_y;
 
-    // These ifs are all for clipping purposes incase coords are outside
+    // These ifs are all for clipping purposes in case coords are outside
     // the expected area.
     if (src_x < 0) {
         src_x0 = 0;

--- a/common/link.cpp
+++ b/common/link.cpp
@@ -245,7 +245,7 @@ LinkClass& LinkClass::Tail_Of_List(void)
  *                                                                                             *
  *    Use this routine to add a link object to the list, but to be added right after the       *
  *    given link. This allows inserting a link in the middle of the chain. A quite necessary   *
- *    ability if the chain is order dependant (e.g., the gadget system).                       *
+ *    ability if the chain is order dependent (e.g., the gadget system).                       *
  *                                                                                             *
  * INPUT:   list -- gadget object to add this one to                                           *
  *                                                                                             *

--- a/common/mp.cpp
+++ b/common/mp.cpp
@@ -757,7 +757,7 @@ void XMP_Shift_Left_Bits(digit* number, int bits, int precision)
  *                                                                                             *
  *          precision-- The precision of the MP number specified.                              *
  *                                                                                             *
- * OUTPUT:  Returns with the final value of the carry bit. This is the the bit value of the    *
+ * OUTPUT:  Returns with the final value of the carry bit. This is the bit value of the        *
  *          upper most bit of the MP number prior to the rotate operation.                     *
  *                                                                                             *
  * WARNINGS:   none                                                                            *

--- a/common/newdel.cpp
+++ b/common/newdel.cpp
@@ -29,10 +29,10 @@
  *                                                                         *
  *-------------------------------------------------------------------------*
  * Functions:                                                              *
- *   operator NEW -- Overides the global new function.                     *
- *   operator delete -- Overides the global delete function.               *
- *   operator NEW[] -- Overides the array version of new.                  *
- *   operator delete[] -- Overides the array version of delete[]           *
+ *   operator NEW -- Overrides the global new function.                    *
+ *   operator delete -- Overrides the global delete function.              *
+ *   operator NEW[] -- Overrides the array version of new.                 *
+ *   operator delete[] -- Overrides the array version of delete[]          *
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #include "wwmem.h"
@@ -44,7 +44,7 @@
 /*= = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = = =*/
 
 /***************************************************************************
- * OPERATOR NEW -- Overides the global new function.                       *
+ * OPERATOR NEW -- Overrides the global new function.                      *
  *                                                                         *
  * INPUT:                                                                  *
  *                                                                         *
@@ -61,7 +61,7 @@ void* operator new(size_t size)
 }
 
 /***************************************************************************
- * OPERATOR NEW[] -- Overides the array version of new.                    *
+ * OPERATOR NEW[] -- Overrides the array version of new.                   *
  *                                                                         *
  *                                                                         *
  *                                                                         *
@@ -80,7 +80,7 @@ void* operator new[](size_t size)
 }
 
 /***************************************************************************
- * OPERATOR DELETE -- Overides the global delete function.                 *
+ * OPERATOR DELETE -- Overrides the global delete function.                *
  *                                                                         *
  *                                                                         *
  *                                                                         *
@@ -99,7 +99,7 @@ void operator delete(void* ptr)
 }
 
 /***************************************************************************
- * OPERATOR DELETE[] -- Overides the array version of delete[]           	*
+ * OPERATOR DELETE[] -- Overrides the array version of delete[]            *
  *                                                                         *
  *                                                                         *
  *                                                                         *

--- a/common/pk.cpp
+++ b/common/pk.cpp
@@ -99,7 +99,7 @@ int PKey::Encode_Modulus(void* buffer) const
  *                                                                                             *
  * INPUT:   buffer   -- Pointer to the buffer that will be filled with the encoded exponent.   *
  *                                                                                             *
- * OUTPUT:  Returns with the nuber of bytes stored into the buffer.                            *
+ * OUTPUT:  Returns with the number of bytes stored into the buffer.                           *
  *                                                                                             *
  * WARNINGS:   Be sure the buffer is big enough to hold the encoded exponent. Usually this is  *
  *             about the same size as the Crypt_Block_Size (plus a byte or two).               *
@@ -306,7 +306,7 @@ int PKey::Encrypt(void const* source, int slen, void* dest) const
  * PKey::Decrypt -- Decrypt supplied cyphertext into its original plaintext.                   *
  *                                                                                             *
  *    This routine will process the supplied cyphertext by breaking it up into blocks and      *
- *    then decrypting each block in turn. The block size is dependant upon the key. By NOT     *
+ *    then decrypting each block in turn. The block size is dependent upon the key. By NOT     *
  *    embedding this information into the cypher data, it makes the encryption more secure.    *
  *                                                                                             *
  * INPUT:   source   -- Pointer to the cypher text to be decrypted.                            *

--- a/common/ramfile.cpp
+++ b/common/ramfile.cpp
@@ -226,8 +226,8 @@ int RAMFileClass::Open(char const*, int access)
  * RAMFileClass::Open -- Opens the RAM based file.                                             *
  *                                                                                             *
  *    This will open the ram based file for read or write. If the file is opened for write,    *
- *    the the 'file' can be written up to the limit of the buffer's size. If the file is       *
- *    opened for read, then the buffer is presumed to hold the data to be read.                *
+ *    then the 'file' can be written up to the limit of the buffer's size. If the file is      *
+ *    opened for reading, then the buffer is presumed to hold the data to be read.             *
  *                                                                                             *
  * INPUT:                                                                                      *
  *                                                                                             *

--- a/common/rawfile.cpp
+++ b/common/rawfile.cpp
@@ -408,7 +408,7 @@ void RawFileClass::Close(void)
         Handle = nullptr;
 
         /*
-        **	Clear any positioning information incase class is reused to open another file.
+        **	Clear any positioning information in case class is reused to open another file.
         */
         BiasStart = 0;
         BiasLength = -1;

--- a/common/rgb.h
+++ b/common/rgb.h
@@ -40,7 +40,7 @@ class HSVClass;
 
 /*
 **	Each color entry is represented by this class. It holds the values for the color
-**	guns. The gun values are recorded in device dependant format, but the interface
+**	guns. The gun values are recorded in device dependent format, but the interface
 **	uses gun values from 0 to 255.
 */
 class RGBClass
@@ -106,7 +106,7 @@ private:
     };
 
     /*
-    **	These hold the actual color gun values in machine dependant scale. This
+    **	These hold the actual color gun values in machine dependent scale. This
     **	means the values range from 0 to 63.
     */
     unsigned char Red;

--- a/common/search.h
+++ b/common/search.h
@@ -38,7 +38,7 @@
  *   IndexClass<T>::IndexClass -- Constructor for index handler.                               *
  *   IndexClass<T>::Invalidate_Archive -- Invalidate the archive pointer.                      *
  *   IndexClass<T>::Is_Archive_Same -- Checks to see if archive pointer is same as index.      *
- *   IndexClass<T>::Is_Present -- Checks for presense of index entry.                          *
+ *   IndexClass<T>::Is_Present -- Checks for presence of index entry.                          *
  *   IndexClass<T>::Remove_Index -- Find matching index and remove it from system.             *
  *   IndexClass<T>::Search_For_Node -- Perform a search for the specified node ID              *
  *   IndexClass<T>::Set_Archive -- Records the node pointer into the archive.                  *
@@ -55,12 +55,12 @@
 /*
 **	This class is used to create and maintain an index. It does this by assigning a unique
 **	identifier number to the type objects that it is indexing. The regular binary sort and search
-**	function are used for speedy index retreival. Typical use of this would be to index pointers to
+**	function are used for speedy index retrieval. Typical use of this would be to index pointers to
 **	normal data objects, but it can be used to hold the data objects themselves. Keep in mind that
 **	the data object "T" is copied around by this routine in the internal tables so not only must
 **	it have a valid copy constructor, it must also be efficient. The internal algorithm will
 **	create an arbitrary number of default constructed objects of type "T". Make sure it has a
-**	default constructor that is effecient. The constructor need not perform any actual
+**	default constructor that is efficient. The constructor need not perform any actual
 **	initialization since this class has prior knowledge about the legality of these temporary
 **	objects and doesn't use them until after the copy constructor is used to initialize them.
 */
@@ -314,7 +314,7 @@ template <class T> bool IndexClass<T>::Increase_Table_Size(int amount)
  *                                                                                             *
  * INPUT:   none                                                                               *
  *                                                                                             *
- * OUTPUT:  Returns with number of recored indecies present.                                   *
+ * OUTPUT:  Returns with number of recored indices present.                                    *
  *                                                                                             *
  * WARNINGS:   none                                                                            *
  *                                                                                             *
@@ -327,7 +327,7 @@ template <class T> int IndexClass<T>::Count(void) const
 }
 
 /***********************************************************************************************
- * IndexClass<T>::Is_Present -- Checks for presense of index entry.                            *
+ * IndexClass<T>::Is_Present -- Checks for presence of index entry.                            *
  *                                                                                             *
  *    This routine will scan for the specified index entry. If it was found, then 'true' is    *
  *    returned.                                                                                *
@@ -392,7 +392,7 @@ template <class T> bool IndexClass<T>::Is_Present(int id) const
  *                                                                                             *
  * WARNINGS:   This routine presumes that the index exists. If it doesn't exist, then the      *
  *             default constructed object "T" is returned instead. To avoid this problem,      *
- *             always verfiy the existance of the index by calling Is_Present() first.         *
+ *             always verify the existence of the index by calling Is_Present() first.         *
  *                                                                                             *
  * HISTORY:                                                                                    *
  *   11/02/1996 JLB : Created.                                                                 *
@@ -585,9 +585,9 @@ template <class T> bool IndexClass<T>::Remove_Index(int id)
  *                                                                                             *
  *          ptr2  -- Pointer to second node.                                                   *
  *                                                                                             *
- * OUTPUT:  Returns with the comparision value between the two nodes.                          *
+ * OUTPUT:  Returns with the comparison value between the two nodes.                           *
  *                                                                                             *
- * WARNINGS:   This is highly dependant upon the layout of the NodeElement structure.          *
+ * WARNINGS:   This is highly dependent upon the layout of the NodeElement structure.          *
  *                                                                                             *
  * HISTORY:                                                                                    *
  *   11/02/1996 JLB : Created.                                                                 *

--- a/common/soundint.h
+++ b/common/soundint.h
@@ -27,7 +27,7 @@
  *                                                                         *
  *                  Last Update : June 23, 1995   [PWG]                    *
  *                                                                         *
- * This file is the include file for the Westwood Sound Sytem defines and  *
+ * This file is the include file for the Westwood Sound System defines and *
  * routines that are handled in an interrupt.
  *                                                                         *
  *-------------------------------------------------------------------------*
@@ -38,7 +38,7 @@
 #include <dsound.h>
 
 /*
-** Define the different type of sound compression avaliable to the westwood
+** Define the different type of sound compression available to the Westwood
 ** library.
 */
 typedef enum
@@ -50,7 +50,7 @@ typedef enum
 } SCompressType;
 
 /*
-**	This is the safety overrun margin for the sonarc compressed
+**	This is the safety overrun margin for the Sonarc compressed
 ** data frames.  This value should be equal the maximum 'order' times
 **	the maximum number of bytes per sample.  It should be evenly divisible
 **	by 16 to aid paragraph alignment.
@@ -97,7 +97,7 @@ typedef struct
     **	pointer rather than handle. The handle method is necessary when more than one
     **	sample could be playing simultaneously. The pointer method is necessary when
     **	the dealing with a sample that may have stopped behind the programmer's back and
-    **	this occurance is not otherwise determinable.  It is also used in
+    **	this occurrence is not otherwise determinable.  It is also used in
     ** conjunction with original size to unlock a sample which has been DPMI
     ** locked.
     */

--- a/common/soundio_openal.cpp
+++ b/common/soundio_openal.cpp
@@ -40,7 +40,7 @@ enum
 };
 
 /*
-** Define the different type of sound compression avaliable to the westwood
+** Define the different type of sound compression available to the Westwood
 ** library.
 */
 typedef enum
@@ -74,7 +74,7 @@ struct SampleTrackerType
     **	pointer rather than handle. The handle method is necessary when more than one
     **	sample could be playing simultaneously. The pointer method is necessary when
     **	the dealing with a sample that may have stopped behind the programmer's back and
-    **	this occurance is not otherwise determinable.  It is also used in
+    **	this occurrence is not otherwise determinable.  It is also used in
     ** conjunction with original size to unlock a sample which has been DPMI
     ** locked.
     */
@@ -244,7 +244,7 @@ static const char* Get_OpenAL_Error(ALenum error)
 {
     switch (error) {
     case AL_NO_ERROR:
-        return "No OpenAL error occured.";
+        return "No OpenAL error occurred.";
 
     case AL_INVALID_NAME:
         return "OpenAL invalid device name.";
@@ -821,7 +821,7 @@ bool Audio_Init(int bits_per_sample, bool stereo, int rate, bool reverse_channel
 
     if (device == nullptr) {
 
-        //CCDebugString("Error occured getting OpenAL device.\n");
+        //CCDebugString("Error occurred getting OpenAL device.\n");
 
         return false;
     }
@@ -843,7 +843,7 @@ bool Audio_Init(int bits_per_sample, bool stereo, int rate, bool reverse_channel
         return false;
     }
 
-    // Create placback buffers for all trackers.
+    // Create playback buffers for all trackers.
     for (int i = 0; i < MAX_SAMPLE_TRACKERS; ++i) {
         SampleTrackerType* st = &LockedData.SampleTracker[i];
 

--- a/common/tcpip.cpp
+++ b/common/tcpip.cpp
@@ -137,7 +137,7 @@ void TcpipManagerClass::Close(void)
         return;
 
         /*
-    ** Cancel any outstaning asyncronous events
+    ** Cancel any outstanding asynchronous events
     */
 #ifdef _WIN32
     if (Async) {
@@ -419,7 +419,7 @@ bool TcpipManagerClass::Add_Client(void)
     bool delay = true;
 
     /*
-    ** Accept the connection. If there is an error then dont do anything else
+    ** Accept the connection. If there is an error then don't do anything else
     */
     addrsize = sizeof(addr);
     ConnectSocket = accept(ListenSocket, (sockaddr*)&addr, &addrsize);

--- a/common/vector.h
+++ b/common/vector.h
@@ -539,7 +539,7 @@ template <class T> int DynamicVectorClass<T>::ID(T const& object)
  * DynamicVectorClass<T>::Add -- Add an element to the vector.                                 *
  *                                                                                             *
  *    Use this routine to add an element to the vector. The vector will automatically be       *
- *    resized to accomodate the new element IF the vector was allocated previously and the     *
+ *    resized to accommodate the new element IF the vector was allocated previously and the    *
  *    growth rate is not zero.                                                                 *
  *                                                                                             *
  * INPUT:   object   -- Reference to the object that will be added to the vector.              *
@@ -774,7 +774,7 @@ VectorClass<T>::VectorClass(VectorClass<T> const& vector)
 /***********************************************************************************************
  * VectorClass<T>::operator = -- The assignment operator.                                      *
  *                                                                                             *
- *    This the the assignment operator for vector objects. It will alter the existing lvalue   *
+ *    This is the assignment operator for vector objects. It will alter the existing lvalue    *
  *    vector to duplicate the rvalue one.                                                      *
  *                                                                                             *
  * INPUT:   vector   -- The rvalue vector to copy into the lvalue one.                         *

--- a/common/video.h
+++ b/common/video.h
@@ -81,7 +81,7 @@ void Set_Video_Cursor(void* cursor, int w, int h, int hotx, int hoty);
 /* Hardware blits supported? */
 #define VIDEO_BLITTER 1
 
-/* Hardware blits asyncronous? */
+/* Hardware blits asynchronous? */
 #define VIDEO_BLITTER_ASYNC 2
 
 /* Can palette changes be synced to vertical refresh? */
@@ -93,7 +93,7 @@ void Set_Video_Cursor(void* cursor, int w, int h, int hotx, int hoty);
 /* Can the blitter do filled rectangles? */
 #define VIDEO_COLOR_FILL 16
 
-/* Is there no hardware assistance avaailable at all? */
+/* Is there no hardware assistance available at all? */
 #define VIDEO_NO_HARDWARE_ASSIST 32
 
 unsigned Get_Video_Hardware_Capabilities();

--- a/common/wincomm.h
+++ b/common/wincomm.h
@@ -30,7 +30,7 @@
  *---------------------------------------------------------------------------------------------*
  * Overview:                                                                                   *
  *                                                                                             *
- *   These classes was created to replace the greenleaf comms functions used in C&C DOS with   *
+ *   These classes was created to replace the Greenleaf comms functions used in C&C DOS with   *
  *  WIN32 API calls.                                                                           *
  *                                                                                             *
  *---------------------------------------------------------------------------------------------*
@@ -64,14 +64,14 @@ typedef enum WinCommDialMethodType
 ** WinModemClass.
 **
 ** This class provides access to modems under Win95. The functions are designed to be more or less
-** drop in replacements for the Grenleaf comms functions.
+** drop in replacements for the Greenleaf comms functions.
 */
 
 class WinModemClass
 {
 
 public:
-    WinModemClass(void);          // WinModemClass Contructor
+    WinModemClass(void);          // WinModemClass Constructor
     virtual ~WinModemClass(void); // WinModemClass Destructor
 
     /*
@@ -220,12 +220,12 @@ protected:
     unsigned char* SerialBuffer;
 
     /*
-    ** Overlap object for asyncronous reads from the serial port
+    ** Overlap object for asynchronous reads from the serial port
     */
     OVERLAPPED ReadOverlap;
 
     /*
-    ** Overlap object for asyncronous writes to the serial port
+    ** Overlap object for asynchronous writes to the serial port
     */
     OVERLAPPED WriteOverlap;
 
@@ -266,7 +266,7 @@ protected:
     int (*AbortFunction)(void);
 
     /*
-    ** Serial buffer for asyncronous reads
+    ** Serial buffer for asynchronous reads
     */
     char TempSerialBuffer[SIZE_OF_WINDOWS_SERIAL_BUFFER];
 };
@@ -275,9 +275,9 @@ protected:
 ** WinNullModemClass.
 **
 ** This class provides access to serial ports under Win95. The functions are designed to be more or less
-** drop in replacements for the Grenleaf comms functions.
+** drop in replacements for the Greenleaf comms functions.
 **
-** This class just overloads the WinModemClass members that arent required for direct serial communications
+** This class just overloads the WinModemClass members that aren't required for direct serial communications
 ** via a 'null modem' cable.
 */
 class WinNullModemClass : public WinModemClass

--- a/common/wsproto.h
+++ b/common/wsproto.h
@@ -41,7 +41,7 @@ class WinsockInterfaceClass;
 extern WinsockInterfaceClass* PacketTransport; // The object for interfacing with Winsock
 
 /*
-** Include compatability sockets header file.
+** Include compatibility sockets header file.
 */
 #include "sockets.h"
 
@@ -56,10 +56,10 @@ extern WinsockInterfaceClass* PacketTransport; // The object for interfacing wit
 #define WINSOCK_MAJOR_VER 1 // 	that we require
 
 //#define WS_RECEIVE_BUFFER_LEN	32768		// Length of our temporary receive buffer. Needs to be more that the max
-//packet size which is about 550 bytes. #define SOCKET_BUFFER_SIZE		32768		// Length of winsocks internal
+//packet size which is about 550 bytes. #define SOCKET_BUFFER_SIZE		32768		// Length of Winsock's internal
 //buffer.
 #define WS_RECEIVE_BUFFER_LEN 1024       // Length of our temporary receive buffer.
-#define SOCKET_BUFFER_SIZE    1024 * 128 // Length of winsocks internal buffer.
+#define SOCKET_BUFFER_SIZE    1024 * 128 // Length of Winsock's internal buffer.
 
 #define PLANET_WESTWOOD_HANDLE_MAX 20 // Max length of a WChat handle
 

--- a/common/wwkeyboard.cpp
+++ b/common/wwkeyboard.cpp
@@ -181,7 +181,7 @@ KeyNumType WWKeyboardClass::Get(void)
  *                                                                                             *
  * INPUT:		int	 	- the key to insert into the buffer          								  *
  *                                                                                             *
- * OUTPUT:     bool		- true if key is sucessfuly inserted.							              *
+ * OUTPUT:     bool		- true if key is successfully inserted.                                *
  *                                                                                             *
  * WARNINGS:   none							                                                        *
  *                                                                                             *
@@ -253,7 +253,7 @@ bool WWKeyboardClass::Put_Key_Message(unsigned short vk_key, bool release)
  *                                                                                             *
  *          release  -- Is this a mouse button release?                                        *
  *                                                                                             *
- * OUTPUT:  bool; Was the event stored sucessfully into the keyboard buffer?                   *
+ * OUTPUT:  bool; Was the event stored successfully into the keyboard buffer?                  *
  *                                                                                             *
  * WARNINGS:   none                                                                            *
  *                                                                                             *
@@ -878,7 +878,7 @@ void WWKeyboardClass::Clear(void)
  *                                                                                             *
  *          wParam   -- The windows specific word parameter (meaning depends on message).      *
  *                                                                                             *
- *          lParam   -- The windows specific long word parameter (meaning is message dependant)*
+ *          lParam   -- The windows specific long word parameter (meaning is message dependent)*
  *                                                                                             *
  * OUTPUT:  bool; Was this keyboard message recognized and processed? A 'false' return value   *
  *                means that the message should be processed normally.                         *
@@ -897,7 +897,7 @@ bool WWKeyboardClass::Message_Handler(HWND window, UINT message, UINT wParam, LO
 
     /*
     **	Examine the message to see if it is one that should be processed. Only keyboard and
-    **	pertinant mouse messages are processed.
+    **	pertinent mouse messages are processed.
     */
     switch (message) {
 
@@ -1004,7 +1004,7 @@ bool WWKeyboardClass::Message_Handler(HWND window, UINT message, UINT wParam, LO
         break;
 
     /*
-    **	If the message is not pertinant to the keyboard system,
+    **	If the message is not pertinent to the keyboard system,
     **	then do nothing.
     */
     default:

--- a/common/wwmouse.cpp
+++ b/common/wwmouse.cpp
@@ -222,7 +222,7 @@ void WWMouseClass::Process_Mouse(void)
                 Low_Show_Mouse(x, y);
             }
             //
-            // Finally unlock the destination surface as we have sucessfully
+            // Finally unlock the destination surface as we have successfully
             // updated the mouse.
             //
             Screen->Unlock();
@@ -329,7 +329,7 @@ void WWMouseClass::Low_Show_Mouse(int x, int y)
     //
     if (!State) {
         //
-        // Try to lock the screen til we sucessfully get a lock.
+        // Try to lock the screen til we successfully get a lock.
         //
         if (Screen->Lock()) {
             //
@@ -474,7 +474,7 @@ void WWMouseClass::Draw_Mouse(GraphicViewPortClass* scr)
         EraseFlags = true;
 
         //
-        // Try to lock the screen  - dont do video stuff if we cant.
+        // Try to lock the screen  - don't do video stuff if we can't.
         //
         if (scr->Lock()) {
             //

--- a/redalert/aircraft.cpp
+++ b/redalert/aircraft.cpp
@@ -250,7 +250,7 @@ AircraftClass::AircraftClass(AircraftType classid, HousesType house)
     NavCom = TARGET_NONE;
 
     /*
-    ** Keep count of the number of units created. Dont track cargo planes as they are created
+    ** Keep count of the number of units created. Don't track cargo planes as they are created
     ** automatically, not bought.
     */
     //	if (/*classid != AIRCRAFT_CARGO && */ Session.Type == GAME_INTERNET) {
@@ -2264,7 +2264,7 @@ void AircraftClass::Debug_Dump(MonoClass* mono) const
 /***********************************************************************************************
  * AircraftClass::Active_Click_With -- Handles clicking over specified object.                 *
  *                                                                                             *
- *    This routine is used when the player clicks over the speicifed object. It will assign    *
+ *    This routine is used when the player clicks over the specified object. It will assign    *
  *    the appropriate mission to the aircraft.                                                 *
  *                                                                                             *
  * INPUT:   action   -- The action that was nominally determined by the What_Action function.  *

--- a/redalert/anim.cpp
+++ b/redalert/anim.cpp
@@ -164,7 +164,7 @@ COORDINATE AnimClass::Sort_Y(void) const
  * AnimClass::Center_Coord -- Determine center of animation.                                   *
  *                                                                                             *
  *    This support function will return the "center" of the animation. The actual coordinate   *
- *    of the animation may be dependant on if the the animation is attached to an object.      *
+ *    of the animation may be dependent on if the animation is attached to an object.          *
  *    In such a case, it must factor in the object's location.                                 *
  *                                                                                             *
  * INPUT:   none                                                                               *
@@ -726,7 +726,7 @@ AnimClass::~AnimClass(void)
  *                                                                                             *
  * OUTPUT:  none                                                                               *
  *                                                                                             *
- * WARNINGS:   Speed is of upmost importance.                                                  *
+ * WARNINGS:   Speed is of utmost importance.                                                  *
  *                                                                                             *
  * HISTORY:                                                                                    *
  *   05/31/1994 JLB : Created.                                                                 *

--- a/redalert/bar.cpp
+++ b/redalert/bar.cpp
@@ -189,7 +189,7 @@ void ProgressBarClass::Redraw(void) const
     }
 
     /*
-    **	The working "length" of the bargraph is dependant on whether the
+    **	The working "length" of the bargraph is dependent on whether the
     **	bargraph is horizontal or vertical.
     */
     int size = Is_Horizontal() ? w : h;

--- a/redalert/building.cpp
+++ b/redalert/building.cpp
@@ -995,7 +995,7 @@ void BuildingClass::AI(void)
     if (IsGoingToBlow && CountDown == 0) {
 #ifdef REMASTER_BUILD
         /*
-        ** Maybe trigger an achivement. ST - 11/14/2019 1:53PM
+        ** Maybe trigger an achievement. ST - 11/14/2019 1:53PM
         */
         TechnoTypeClass const* object_type = Techno_Type_Class();
         if (object_type) {
@@ -1014,7 +1014,7 @@ void BuildingClass::AI(void)
     }
 
     /*
-    **	Turret equiped buildings must handle turret rotation logic here. This entails
+    **	Turret equipped buildings must handle turret rotation logic here. This entails
     **	rotating the turret to the desired facing as well as figuring out what that
     **	desired facing should be.
     */
@@ -1802,8 +1802,8 @@ void BuildingClass::Drop_Debris(TARGET source)
         }
 
         /*
-        **	Smoke and fire only appear on terrestrail cells. They should not appear on
-        **	rivers, clifs, or water cells.
+        **	Smoke and fire only appear on terrestrial cells. They should not appear on
+        **	rivers, cliffs, or water cells.
         */
         if (cellptr->Is_Clear_To_Move(SPEED_TRACK, true, true)) {
 
@@ -3226,7 +3226,7 @@ bool BuildingClass::Captured(HouseClass* newowner)
 #endif
 #ifdef REMASTER_BUILD
         /*
-        ** Maybe trigger an achivement. ST - 11/14/2019 1:53PM
+        ** Maybe trigger an achievement. ST - 11/14/2019 1:53PM
         */
         if (newowner->IsHuman) {
             TechnoTypeClass const* object_type = Techno_Type_Class();
@@ -4714,7 +4714,7 @@ bool BuildingClass::Revealed(HouseClass* house)
  *    This routine is called when the exact mode of the building isn't known. By examining     *
  *    the building's condition, this routine will assign an appropriate mission.               *
  *                                                                                             *
- * INPUT:   initial  -- This this being called during scenario init?                           *
+ * INPUT:   initial  -- Is this being called during scenario init?                             *
  *                                                                                             *
  * OUTPUT:  none                                                                               *
  *                                                                                             *
@@ -5749,7 +5749,7 @@ void BuildingClass::Rotation_AI(void)
  * BuildingClass::Charging_AI -- Handles the special charging logic for Tesla coils.           *
  *                                                                                             *
  *    This handles the special logic required of the charging tesla coil. It requires special  *
- *    processing since its charge up is dependant upon the target and power surplus of the     *
+ *    processing since its charge up is dependent upon the target and power surplus of the     *
  *    owning house.                                                                            *
  *                                                                                             *
  * INPUT:   none                                                                               *

--- a/redalert/ccini.cpp
+++ b/redalert/ccini.cpp
@@ -1295,7 +1295,7 @@ bool CCINIClass::Put_TerrainType(char const* section, char const* entry, Terrain
  *                      located.                                                               *
  *                                                                                             *
  * OUTPUT:  Returns with the building list (as a bitfield). If the entry could not be          *
- *          found, the the default value is returned instead.                                  *
+ *          found, then the default value is returned instead.                                 *
  *                                                                                             *
  * WARNINGS:   none                                                                            *
  *                                                                                             *

--- a/redalert/cell.cpp
+++ b/redalert/cell.cpp
@@ -1348,7 +1348,7 @@ void CellClass::Draw_It(int x, int y, bool objects) const
             break;
 
         /*
-        **	Large number of objects can be effeciently sorted by using
+        **	Large number of objects can be efficiently sorted by using
         **	a quicksort.
         */
         default:
@@ -1811,7 +1811,7 @@ int CellClass::Reduce_Wall(int damage)
 
                     /*
                     **	The zone calculation changes now for non-crushable zone sensitive
-                    **	travellers.
+                    **	travelers.
                     */
                     if (wall.IsCrushable) {
                         Map.Zone_Reset(MZONEF_NORMAL);
@@ -2224,7 +2224,7 @@ bool CellClass::Goodie_Check(FootClass* object)
 
         /*
         **	Pick a random crate powerup according to the shares allotted to each powerup.
-        **	In solo play, the bonus item is dependant upon the rules control.
+        **	In solo play, the bonus item is dependent upon the rules control.
         */
         CrateType powerup;
         if (Session.Type == GAME_NORMAL) {
@@ -2916,7 +2916,7 @@ void CellClass::Shimmer(void)
  *    calculation. Only blockages that cannot be circumvented are considered to make a cell    *
  *    impassable. All other obstructions can either be destroyed or are temporary.             *
  *                                                                                             *
- * INPUT:   loco     -- The locomotion type to use when determining passablility.              *
+ * INPUT:   loco     -- The locomotion type to use when determining passability.               *
  *                                                                                             *
  *          ignoreinfantry -- Should infantry in the cell be ignored for movement purposes?    *
  *                                                                                             *
@@ -2963,7 +2963,7 @@ bool CellClass::Is_Clear_To_Move(SpeedType loco,
 
     /*
     **	Check the occupy bits for passable legality. If ignore infantry is true, then
-    **	don't consider infnatry.
+    **	don't consider infantry.
     */
     int composite = Flag.Composite;
     if (ignoreinfantry) {

--- a/redalert/cell.h
+++ b/redalert/cell.h
@@ -116,7 +116,7 @@ public:
     **	same number if they are contiguous (terrain consideration only). There
     **	are basically two kinds of zones. The difference being determined by
     **	walls that can be crushed by movement. A vehicle that can crush walls
-    **	will only consider the CrushZone. All other terrestrial travellers will
+    **	will only consider the CrushZone. All other terrestrial travelers will
     **	use the normal Zone.
     */
     unsigned char Zones[MZONE_COUNT];
@@ -198,7 +198,7 @@ public:
     **	This array of bit flags is used to indicate which sub positions
     **	within the cell are either occupied or are soon going to be
     **	occupied. For vehicles, the cells that the vehicle is passing over
-    **	will be flagged with the vehicle bit. For infantry, the the sub
+    **	will be flagged with the vehicle bit. For infantry, the sub
     **	position the infantry is stopped at or headed toward will be marked.
     **	The sub positions it passes over will NOT be marked.
     */

--- a/redalert/conquer.cpp
+++ b/redalert/conquer.cpp
@@ -2708,7 +2708,7 @@ void Unselect_All(void)
     //	CurrentObject[0]->Unselect();
     //}
 
-    // Added some error handling incase there was an issue removing the object - JAS 6/28/2019
+    // Added some error handling in case there was an issue removing the object - JAS 6/28/2019
     while (CurrentObject.Count()) {
 
         int count_before = CurrentObject.Count();
@@ -2745,7 +2745,7 @@ void Unselect_All_Except(ObjectClass* object)
 /***********************************************************************************************
  * Fading_Table_Name -- Builds a theater specific fading table name.                           *
  *                                                                                             *
- *    This routine builds a standard fading table name. This name is dependant on the theater  *
+ *    This routine builds a standard fading table name. This name is dependent on the theater  *
  *    being played, since each theater has its own palette.                                    *
  *                                                                                             *
  * INPUT:   base  -- The base name of this fading table. The base name can be no longer than   *
@@ -3179,7 +3179,7 @@ void CC_Draw_Shape(void const* shapefile,
  * OUTPUT:  Returns with the rectangle that encloses the shape.                                *
  *                                                                                             *
  * WARNINGS:   This routine uses brute force and is slow. It is presumed that the results      *
- *             will be cached for subsiquent reuse.                                            *
+ *             will be cached for subsequent reuse.                                            *
  *                                                                                             *
  * HISTORY:                                                                                    *
  *   07/22/1996 JLB : Created.                                                                 *
@@ -3713,7 +3713,7 @@ void Handle_View(int view, int action)
                 Coord_Whole(Cell_Coord(Scen.Views[view] - (MAP_CELL_W * 4 * RESFACTOR) - (5 * RESFACTOR))));
 
             /*
-            ** Win95 scrolling logic cant handle just jumps in screen position so redraw the lot.
+            ** Win95 scrolling logic can't handle just jumps in screen position so redraw the lot.
             */
             Map.Flag_To_Redraw(true);
         } else {
@@ -3887,7 +3887,7 @@ static bool Change_Local_Dir(int cd)
         _initialised = true;
     }
 
-    // No local folders with cd data dectected so we can't load any.
+    // No local folders with cd data detected so we can't load any.
     if (_detected == 0) {
         return false;
     }
@@ -4526,7 +4526,7 @@ static void Do_Record_Playback(void)
 }
 
 /***********************************************************************************************
- * Hires_Load -- Allocates memory for, and loads, a resolution dependant file.                 *
+ * Hires_Load -- Allocates memory for, and loads, a resolution dependent file.                 *
  *                                                                                             *
  *                                                                                             *
  *                                                                                             *

--- a/redalert/defines.h
+++ b/redalert/defines.h
@@ -1565,7 +1565,7 @@ typedef enum InfantryType : char
     INFANTRY_C7,       // Civilian
     INFANTRY_C8,       // Civilian
     INFANTRY_C9,       // Civilian
-    INFANTRY_C10,      // Nikumba
+    INFANTRY_C10,      // Nikoomba
     INFANTRY_EINSTEIN, // Einstein
     INFANTRY_DELPHI,   // Agent "Delphi"
     INFANTRY_CHAN,     // Dr. Chan

--- a/redalert/display.cpp
+++ b/redalert/display.cpp
@@ -1855,7 +1855,7 @@ ObjectClass* DisplayClass::Cell_Object(CELL cell, int x, int y) const
  *    This will draw the tactical map at the recorded position.   This                         *
  *    routine is used whenever the tactical map moves or needs to be                           *
  *    completely redrawn. It will handle making the necessary adjustments                      *
- *    to accomodate a moving cursor.                                                           *
+ *    to accommodate a moving cursor.                                                          *
  *                                                                                             *
  * INPUT:      forced   -- bool; force redraw of the entire display?                           *
  *                                                                                             *
@@ -4170,7 +4170,7 @@ void DisplayClass::Mouse_Left_Held(int x, int y)
     }
 }
 
-// Needed to accomodate Glyphx client sidebar. ST - 4/12/2019 5:29PM
+// Needed to accommodate GlyphX client sidebar. ST - 4/12/2019 5:29PM
 extern int GlyphXClientSidebarWidthInLeptons;
 
 /***********************************************************************************************
@@ -4202,7 +4202,7 @@ void DisplayClass::Set_Tactical_Position(COORDINATE coord)
                  TacLeptonWidth,
                  TacLeptonHeight,
                  Cell_To_Lepton(MapCellWidth) + GlyphXClientSidebarWidthInLeptons,
-                 Cell_To_Lepton(MapCellHeight)); // Needed to accomodate Glyphx client sidebar. ST - 4/12/2019 5:29PM
+                 Cell_To_Lepton(MapCellHeight)); // Needed to accommodate GlyphX client sidebar. ST - 4/12/2019 5:29PM
     //	Confine_Rect(&xx, &yy, TacLeptonWidth, TacLeptonHeight, Cell_To_Lepton(MapCellWidth),
     // Cell_To_Lepton(MapCellHeight));
 #else

--- a/redalert/dllinterface.cpp
+++ b/redalert/dllinterface.cpp
@@ -481,7 +481,7 @@ int DLLForceMouseY = 0;
 
 CNC_Event_Callback_Type DLLExportClass::EventCallback = NULL;
 
-// Needed to accomodate Glyphx client sidebar. ST - 4/12/2019 5:29PM
+// Needed to accommodate GlyphX client sidebar. ST - 4/12/2019 5:29PM
 int GlyphXClientSidebarWidthInLeptons = 0;
 
 bool MPlayerIsHuman[MAX_PLAYERS];
@@ -503,7 +503,7 @@ int GetRandSeed()
 
     return abs(static_cast<int>(microseconds_since_epoch.time_since_epoch().count()));
 #endif
-    // for mingw compatility
+    // for mingw compatibility
     return GetTickCount();
 }
 
@@ -1031,7 +1031,7 @@ extern "C" __declspec(dllexport) bool __cdecl CNC_Select_Object(uint64 player_id
 }
 
 /**************************************************************************************************
- * GlyphX_Assign_Houses -- Replacement for Assign_Houses in INI.CPP / SCNEARIO.CPP
+ * GlyphX_Assign_Houses -- Replacement for Assign_Houses in INI.CPP / SCENARIO.CPP
  *
  * In:
  *
@@ -1394,7 +1394,7 @@ extern "C" __declspec(dllexport) bool __cdecl CNC_Start_Instance_Variation(int s
     } else {
         if (MPSuperWeaponDisable) {
             /*
-            ** Write over the tecb level settings we just loaded from the Rules ini
+            ** Write over the tech level settings we just loaded from the Rules ini
             */
             Rule.GPSTechLevel = 100;
             Rule.ParaInfantryTechLevel = 100;
@@ -1631,7 +1631,7 @@ extern "C" __declspec(dllexport) bool __cdecl CNC_Start_Custom_Instance(const ch
     } else {
         if (MPSuperWeaponDisable) {
             /*
-            ** Write over the tecb level settings we just loaded from the Rules ini
+            ** Write over the tech level settings we just loaded from the Rules ini
             */
             Rule.GPSTechLevel = 100;
             Rule.ParaInfantryTechLevel = 100;
@@ -1751,7 +1751,7 @@ extern "C" __declspec(dllexport) bool __cdecl CNC_Advance_Instance(uint64 player
     /*
     ** Shouldn't really need to do this, but I like the idea of always running the main loop in the context of the same
     *player.
-    ** Might make tbe bugs more repeatable and consistent. ST - 3/15/2019 11:58AM
+    ** Might make the bugs more repeatable and consistent. ST - 3/15/2019 11:58AM
     */
     if (player_id != 0) {
         DLLExportClass::Set_Player_Context(player_id);
@@ -6999,7 +6999,7 @@ void DLLExportClass::Refresh_Player_Control_Flags(void)
 }
 
 /**************************************************************************************************
- * Logic_Switch_Player_Context -- Called when the internal game locic needs to switch player context
+ * Logic_Switch_Player_Context -- Called when the internal game logic needs to switch player context
  *
  * In:
  *
@@ -7015,7 +7015,7 @@ void Logic_Switch_Player_Context(ObjectClass* object)
 }
 
 /**************************************************************************************************
- * DLLExportClass::Logic_Switch_Player_Context -- Called when the internal game locic needs to switch player context
+ * DLLExportClass::Logic_Switch_Player_Context -- Called when the internal game logic needs to switch player context
  *
  * In:
  *
@@ -7045,7 +7045,7 @@ void DLLExportClass::Logic_Switch_Player_Context(ObjectClass* object)
 }
 
 /**************************************************************************************************
- * Logic_Switch_Player_Context -- Called when the internal game locic needs to switch player context
+ * Logic_Switch_Player_Context -- Called when the internal game logic needs to switch player context
  *
  * In:
  *
@@ -7061,7 +7061,7 @@ void Logic_Switch_Player_Context(HouseClass* object)
 }
 
 /**************************************************************************************************
- * DLLExportClass::Logic_Switch_Player_Context -- Called when the internal game locic needs to switch player context
+ * DLLExportClass::Logic_Switch_Player_Context -- Called when the internal game logic needs to switch player context
  *
  * In:
  *
@@ -7333,7 +7333,7 @@ void DLLExportClass::Sell_Mode(uint64 player_id)
 }
 
 /**************************************************************************************************
- * DLLExportClass::Sell -- Sell's a player's speceific building.
+ * DLLExportClass::Sell -- Sells a player's specific building.
  *
  * In:
  *

--- a/redalert/egos.cpp
+++ b/redalert/egos.cpp
@@ -623,7 +623,7 @@ void Show_Who_Was_Responsible(void)
     } while (length > 0);
 
     /*
-    ** Work out which palette entries the font needs so we dont fade those colors.
+    ** Work out which palette entries the font needs so we don't fade those colors.
     */
     memset(PaletteLUT, 1, sizeof(PaletteLUT));
     int pcolor = PCOLOR_GREEN;
@@ -803,7 +803,7 @@ void Show_Who_Was_Responsible(void)
         }
 
         /*
-        ** Stop calling Theme.AI after a while so a different song doesnt start playing
+        ** Stop calling Theme.AI after a while so a different song doesn't start playing
         */
         Call_Back();
         Frame_Limiter();
@@ -821,7 +821,7 @@ void Show_Who_Was_Responsible(void)
         }
 
         /*
-        ** Blit all but the top and bottom of the hid page. This is beacuse the text print doesn't
+        ** Blit all but the top and bottom of the hid page. This is because the text print doesn't
         ** clip vertically and looks ugly when it suddenly appears and disappears.
         */
         HidPage.Blit(SeenBuff,

--- a/redalert/findpath.cpp
+++ b/redalert/findpath.cpp
@@ -155,8 +155,8 @@ static CELL StartLocation;
  *      If a point is on a line then the following function holds true:    *
  *      (x - x2)(z1 - z2) = (z - z2)(x1 - x2) given x,z a point on the     *
  *      line (x1,z1),(x2,z2).                                              *
- *      If the right side is > then the left side then the point is on one *
- *      side of the line and if the right side is < the the left side, then*
+ *      If the right side is > than the left side then the point is on one *
+ *      side of the line and if the right side is < than the left side, then*
  *      the point is on the other side of the line.  By subtracting one side*
  *      from the other we can determine on what side (if any) the point is on*
  *      by testing the side of the resulting subtraction.                  *
@@ -591,7 +591,7 @@ PathType* FootClass::Find_Path(CELL dest, FacingType* final_moves, int maxlen, M
 
                     /*
                     **	If we reached destination while in this loop, we
-                    **	know that either the destination is impassible (if
+                    **	know that either the destination is impassable (if
                     **	we are ignoring) or that we need to up our threat
                     ** tolerance and try again.
                     */
@@ -680,7 +680,7 @@ PathType* FootClass::Find_Path(CELL dest, FacingType* final_moves, int maxlen, M
 
                     /*
                     **	If we reached destination while in this loop, we
-                    **	know that either the destination is impassible (if
+                    **	know that either the destination is impassable (if
                     **	we are ignoring) or that we need to up our threat
                     ** tolerance and try again.
                     */
@@ -782,7 +782,7 @@ end_of_list:
  *                                                                                             *
  *          search   -- Direction of search (1=clock, -1=counterclock).                        *
  *                                                                                             *
- *          olddir   -- Facing impassible direction from start.                                *
+ *          olddir   -- Facing impassable direction from start.                                *
  *                                                                                             *
  *          callback -- Function pointer for determining if a cell is                          *
  *                      passable or not.                                                       *
@@ -902,8 +902,8 @@ bool FootClass::Follow_Edge(CELL start,
                 /*
                 **	Perform special diagonal check. If the edge follower would cross the
                 **	diagonal or fall on the diagonal line from the source, then consider
-                **	that cell impassible. Otherwise, the find path algorithm will fail
-                **	when there are two impassible locations located on a diagonal
+                **	that cell impassable. Otherwise, the find path algorithm will fail
+                **	when there are two impassable locations located on a diagonal
                 **	that is lined up between the source and destination location.
                 **
                 ** P.S. It might help if you check the right cell rather than using

--- a/redalert/foot.cpp
+++ b/redalert/foot.cpp
@@ -325,7 +325,7 @@ bool FootClass::Basic_Path(void)
         cell = As_Cell(NavCom);
 
         /*
-        **	When the navigation computer is set to a location that is impassible, then
+        **	When the navigation computer is set to a location that is impassable, then
         **	find a nearby cell that can be entered and try to head toward that instead.
         **	EXCEPT when that cell is very close -- then just bail.
         */

--- a/redalert/house.cpp
+++ b/redalert/house.cpp
@@ -84,7 +84,7 @@
  *   HouseClass::Is_Allowed_To_Ally -- Determines if this house is allied to make allies.      *
  *   HouseClass::Is_Ally -- Checks to see if the object is an ally.                            *
  *   HouseClass::Is_Ally -- Determines if the specified house is an ally.                      *
- *   HouseClass::Is_Hack_Prevented -- Is production of the specified type and id prohibted?    *
+ *   HouseClass::Is_Hack_Prevented -- Is production of the specified type and id prohibited?   *
  *   HouseClass::Is_No_YakMig -- Determines if no more yaks or migs should be allowed.         *
  *   HouseClass::MPlayer_Defeated -- multiplayer; house is defeated                            *
  *   HouseClass::Make_Ally -- Make the specified house an ally.                                *
@@ -3112,7 +3112,7 @@ bool HouseClass::Place_Special_Blast(SpecialWeaponType id, CELL cell)
     }
 #ifdef REMASTER_BUILD
     /*
-    ** Maybe trigger an achivement. ST - 12/2/2019 11:25AM
+    ** Maybe trigger an achievement. ST - 12/2/2019 11:25AM
     */
     if (IsHuman && fired && what) {
         On_Achievement_Event(this, "SUPERWEAPON_FIRED", what);
@@ -7578,7 +7578,7 @@ bool HouseClass::Is_No_YakMig(void) const
 }
 
 /***********************************************************************************************
- * HouseClass::Is_Hack_Prevented -- Is production of the specified type and id prohibted?      *
+ * HouseClass::Is_Hack_Prevented -- Is production of the specified type and id prohibited?     *
  *                                                                                             *
  *    This is a special hack check routine to see if the object type and id specified is       *
  *    prevented from being produced. The Yak and the Mig are so prevented if there would be    *
@@ -7736,7 +7736,7 @@ bool HouseClass::Is_Allowed_To_Ally(HousesType house) const
     }
 
     /*
-    **	Alliances (outside of scneario init time) are allowed only if
+    **	Alliances (outside of scenario init time) are allowed only if
     **	this is a multiplayer game. Otherwise, they are prohibited.
     */
     if (Session.Type == GAME_NORMAL) {

--- a/redalert/house.h
+++ b/redalert/house.h
@@ -936,7 +936,7 @@ private:
 public:
     /*
     **	This structure is used to record a build request as determined by
-    **	the house AI processing. Higher priority build requests take precidence.
+    **	the house AI processing. Higher priority build requests take precedence.
     */
     struct BuildChoiceClass
     {

--- a/redalert/idata.cpp
+++ b/redalert/idata.cpp
@@ -44,7 +44,7 @@
  *   InfantryTypeClass::Prep_For_Add -- Prepares the scenario editor for adding of infantry obj*
  *   InfantryTypeClass::Read_INI -- Fetches infantry override values from the INI database.    *
  *   InfantryTypeClass::operator delete -- Frees an infantry type class object.                *
- *   InfantryTypeClass::operator new -- Allocate an infanty type class object.                 *
+ *   InfantryTypeClass::operator new -- Allocate an infantry type class object.                *
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #include "function.h"
@@ -1082,7 +1082,7 @@ InfantryTypeClass::InfantryTypeClass(InfantryType type,
 }
 
 /***********************************************************************************************
- * InfantryTypeClass::operator new -- Allocate an infanty type class object.                   *
+ * InfantryTypeClass::operator new -- Allocate an infantry type class object.                  *
  *                                                                                             *
  *    This will allocate an infantry type class object from the special memory pool of that    *
  *    purpose.                                                                                 *

--- a/redalert/infantry.cpp
+++ b/redalert/infantry.cpp
@@ -1511,7 +1511,7 @@ MoveType InfantryClass::Can_Enter_Cell(CELL cell, FacingType) const
                 if (!obj->Is_Techno() || !((TechnoClass*)obj)->Is_Cloaked(this)) {
 
                     /*
-                    **	Any non-allied blockage is considered impassible if the infantry
+                    **	Any non-allied blockage is considered impassable if the infantry
                     **	is not equipped with a weapon.
                     */
                     if (Combat_Damage() <= 0)

--- a/redalert/init.cpp
+++ b/redalert/init.cpp
@@ -296,7 +296,7 @@ bool Init_Game(int, char*[])
     Session.MaxPlayers = Rule.MaxPlayers;
 
     /*
-    **	Initialize the game object heaps as well as other rules-dependant buffer allocations.
+    **	Initialize the game object heaps as well as other rules-dependent buffer allocations.
     */
     Init_Heaps();
 
@@ -1165,7 +1165,7 @@ bool Select_Game(bool fade)
     }
 
     /*
-    ** If this isnt an internet game that set the unit build rate to its default value
+    ** If this isn't an internet game that set the unit build rate to its default value
     */
     if (Session.Type != GAME_INTERNET) {
         UnitBuildPenalty = 100;
@@ -1592,7 +1592,7 @@ bool Parse_Command_Line(int argc, char* argv[])
                     break;
 
                 /*
-                **	Hussled recharge timer.
+                **	Hustled recharge timer.
                 */
                 case 'H':
                     Special.IsSpeedBuild = true;
@@ -1721,7 +1721,7 @@ long Obfuscate(char const* string)
 
     /*
     **	Transform the buffer into a number. This transformation is character
-    **	order dependant.
+    **	order dependent.
     */
     long code = Calculate_CRC(buffer, length);
 
@@ -1936,7 +1936,7 @@ void Load_Title_Page(bool visible)
 /***********************************************************************************************
  * Init_Color_Remaps -- Initialize the text remap tables.                                      *
  *                                                                                             *
- *    There are various color scheme remap tables that are dependant upon the color remap      *
+ *    There are various color scheme remap tables that are dependent upon the color remap      *
  *    information embedded within the palette control file. This routine will fetch that       *
  *    data and build the text remap tables as indicated.                                       *
  *                                                                                             *
@@ -2266,7 +2266,7 @@ static void Init_Fonts(void)
  * Init_CDROM_Access -- Initialize the CD-ROM access handler.                                  *
  *                                                                                             *
  *    This routine is called to setup the CD-ROM access or emulation handler. It will ensure   *
- *    that the appropriate CD-ROM is present (dependant on the RequiredCD global).             *
+ *    that the appropriate CD-ROM is present (dependent on the RequiredCD global).             *
  *                                                                                             *
  * INPUT:   none                                                                               *
  *                                                                                             *

--- a/redalert/list.cpp
+++ b/redalert/list.cpp
@@ -593,7 +593,7 @@ int ListClass::Add_Scroll_Bar(void)
 
         /*
         **	Everything has been created successfully. Flag the list box to be
-        **	redrawn because it now must be made narrower to accomodate the new
+        **	redrawn because it now must be made narrower to accommodate the new
         **	slider gadgets.
         */
         Flag_To_Redraw();
@@ -735,8 +735,8 @@ void ListClass::Draw_Entry(int index, int x, int y, int width, int selected)
  * - Up arrow (if active)                                                                      *
  * - Down arrow (if active)                                                                    *
  * - Scroll gadget (if active)                                                                 *
- *                                                                                             * * INPUT:   object   --
- *Pointer to the object to be added right after this one.                *
+ *                                                                                             *
+ * INPUT:   object   -- Pointer to the object to be added right after this one.                *
  *                                                                                             *
  * OUTPUT:  Returns with a pointer to the head of the list.                                    *
  *                                                                                             *

--- a/redalert/list.h
+++ b/redalert/list.h
@@ -589,7 +589,7 @@ template <class T> int TListClass<T>::Add_Scroll_Bar(void)
 
         /*
         **	Everything has been created successfully. Flag the list box to be
-        **	redrawn because it now must be made narrower to accomodate the new
+        **	redrawn because it now must be made narrower to accommodate the new
         **	slider gadgets.
         */
         Flag_To_Redraw();

--- a/redalert/logic.cpp
+++ b/redalert/logic.cpp
@@ -32,7 +32,7 @@
  * Functions:                                                                                  *
  *   LogicClass::AI -- Handles AI logic processing for game objects.                           *
  *   LogicClass::Debug_Dump -- Displays logic class status to the mono screen.                 *
- *   LogicClass::Detach -- Detatch the specified target from the logic system.                 *
+ *   LogicClass::Detach -- Detach the specified target from the logic system.                  *
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #include "function.h"
@@ -446,14 +446,14 @@ void LogicClass::AI(void)
 }
 
 /***********************************************************************************************
- * LogicClass::Detach -- Detatch the specified target from the logic system.                   *
+ * LogicClass::Detach -- Detach the specified target from the logic system.                    *
  *                                                                                             *
  *    This routine is called when the specified target object is about to be removed from the  *
  *    game system and all references to it must be severed. The only thing that the logic      *
  *    system looks for in this case is to see if the target refers to a trigger and if so,     *
  *    it scans through the trigger list and removes all references to it.                      *
  *                                                                                             *
- * INPUT:   target   -- The target to remove from the sytem.                                   *
+ * INPUT:   target   -- The target to remove from the system.                                  *
  *                                                                                             *
  * OUTPUT:  none                                                                               *
  *                                                                                             *

--- a/redalert/monoc.h
+++ b/redalert/monoc.h
@@ -182,9 +182,6 @@ private:
     //		static MonoPageType * MonoRAM;
 
     /*
-    ** This the the arrays of characters used for drawing boxes.
-    */
-    /*
     **	This is a private structure that is used to control which characters
     **	are used when a box is drawn. Line drawing on the monochrome screen is
     **	really made up of characters. This specifies which characters to use.
@@ -200,6 +197,10 @@ private:
         unsigned char BottomLeft;
         unsigned char LeftEdge;
     };
+
+    /*
+    ** These are the arrays of characters used for drawing boxes.
+    */
     static BoxDataType const CharData[4];
 
     /*

--- a/redalert/netdlg.cpp
+++ b/redalert/netdlg.cpp
@@ -2044,7 +2044,7 @@ static int Net_Join_Dialog(void)
     TTimerClass<SystemTimerClass> lastclick_timer; // time b/w send periods
     int lastclick_idx = 0;                         // index of item last clicked on
     RemapControlType* scheme = GadgetClass::Get_Color_Scheme();
-    Session.Options.ScenarioDescription[0] = 0; // Flag that we dont know the scenario name yet
+    Session.Options.ScenarioDescription[0] = 0; // Flag that we don't know the scenario name yet
 
     char* item;
     unsigned long starttime;
@@ -2275,7 +2275,7 @@ static int Net_Join_Dialog(void)
 
         /*
         ** Kludge to make sure we redraw the message input line when it loses focus.
-        ** If we dont do this then the cursor doesnt disappear.
+        ** If we don't do this then the cursor doesn't disappear.
         */
         if (messages_have_focus) {
             if (name_edt.Has_Focus()) {
@@ -3127,8 +3127,8 @@ static int Net_Join_Dialog(void)
                                         Session.ScenarioDigest,
                                         Session.ScenarioIsOfficial)) {
 
-                    Session.Options.ScenarioIndex = 1; // We dont care what it
-                                                       // is as long as it isnt -1
+                    Session.Options.ScenarioIndex = 1; // We don't care what it
+                                                       // is as long as it isn't -1
 
                     /*
                     ** We have the scenario. Tell the host that I am ready to go.
@@ -3144,7 +3144,7 @@ static int Net_Join_Dialog(void)
                 } else {
 #ifndef FIXIT_VERSION_3 //	Removed restriction on downloading official maps.
                     /*
-                    ** Oh dear. Thats a scenario I don't have. Request that the host sends the
+                    ** Oh dear. That's a scenario I don't have. Request that the host sends the
                     **	scenario to me provided it's not an official scenario.
                     **
                     ** If the file is received OK then we will get a true return value and the
@@ -3154,8 +3154,8 @@ static int Net_Join_Dialog(void)
                         Session.Options.ScenarioIndex = -1;
                     } else {
 #endif
-                        Session.Options.ScenarioIndex = 1; // We dont care what it
-                                                           // is as long as it isnt -1
+                        Session.Options.ScenarioIndex = 1; // We don't care what it
+                                                           // is as long as it isn't -1
 #ifdef FIXIT_VERSION_3
                         if (bSpecialAftermathScenario(Session.Options.ScenarioDescription))
                             break;
@@ -3165,7 +3165,7 @@ static int Net_Join_Dialog(void)
                             break;
                         } else {
                             /*
-                            ** Make sure we dont time-out because of the download
+                            ** Make sure we don't time-out because of the download
                             */
                         }
 #ifndef FIXIT_VERSION_3
@@ -5563,7 +5563,7 @@ static int Net_New_Dialog(void)
 
                 /*
                 ** Set up the scenario info so the remote player can match the scenario on his machine
-                ** or request a download if it doesnt exist
+                ** or request a download if it doesn't exist
                 */
                 strcpy(Session.GPacket.ScenarioInfo.Scenario,
                        Session.Scenarios[Session.Options.ScenarioIndex]->Description());
@@ -5697,7 +5697,7 @@ static int Net_New_Dialog(void)
         bool send_scenario = false;
         WWDebugString("RA95 - About to wait for 'GO' response.");
         CDTimerClass<SystemTimerClass> response_timer; // timeout timer for waiting for responses
-        response_timer = 60 * 10; // Wait for 10 seconds. If we dont hear by then assume someone crashed
+        response_timer = 60 * 10; // Wait for 10 seconds. If we don't hear by then assume someone crashed
 
         do {
             Ipx.Service();
@@ -8337,7 +8337,7 @@ static int Net_Fake_New_Dialog(void)
                 Session.GPacket.Command = NET_GAME_OPTIONS;
                 /*
                 ** Set up the scenario info so the remote player can match the scenario on his machine
-                ** or request a download if it doesnt exist
+                ** or request a download if it doesn't exist
                 */
                 strcpy(Session.GPacket.ScenarioInfo.Scenario,
                        Session.Scenarios[Session.Options.ScenarioIndex]->Description());
@@ -8398,7 +8398,7 @@ static int Net_Fake_New_Dialog(void)
                     }
 
                     /*
-                    ** See if that file is available now. Its fatal if it isnt.
+                    ** See if that file is available now. It's fatal if it isn't.
                     */
                     if (!file.Is_Available()) {
 
@@ -8558,7 +8558,7 @@ static int Net_Fake_New_Dialog(void)
         WWDebugString("RA95 - About to wait for 'GO' response.\n");
 
         CDTimerClass<SystemTimerClass> response_timer; // timeout timer for waiting for responses
-        response_timer = 60 * 30; // Wait for 30 seconds. If we dont hear by then assume someone crashed
+        response_timer = 60 * 30; // Wait for 30 seconds. If we don't hear by then assume someone crashed
 
         do {
             Ipx.Service();
@@ -8829,7 +8829,7 @@ static int Net_Fake_Join_Dialog(void)
     int lastclick_idx = 0;                         // index of item last clicked on
     RemapControlType* scheme = GadgetClass::Get_Color_Scheme();
     int ready_to_go = 0;
-    Session.Options.ScenarioDescription[0] = 0; // Flag that we dont know the scenario name yet
+    Session.Options.ScenarioDescription[0] = 0; // Flag that we don't know the scenario name yet
     int width;
     int height;
 
@@ -9209,7 +9209,7 @@ static int Net_Fake_Join_Dialog(void)
                                 Session.Read_Scenario_Descriptions();
 
                                 /*
-                                ** See if that scenario is available now. Its pretty fatal if it isnt.
+                                ** See if that scenario is available now. It's pretty fatal if it isn't.
                                 */
                                 Session.Options.ScenarioIndex = -1;
                                 for (i = 0; i < Session.Scenarios.Count(); i++) {
@@ -9224,7 +9224,7 @@ static int Net_Fake_Join_Dialog(void)
                     }
 
                     /*
-                    ** If the scenario that the host wants to play doesnt exist locally then we
+                    ** If the scenario that the host wants to play doesn't exist locally then we
                     **	need to request that it is sent. If we can identify the scenario locally then
                     **	we need to fix up the file name so we load the right one.
                     */
@@ -9234,8 +9234,8 @@ static int Net_Fake_Join_Dialog(void)
                                             Session.ScenarioDigest,
                                             Session.ScenarioIsOfficial)) {
 
-                        Session.Options.ScenarioIndex = 1; // We dont care what it
-                                                           // is as long as it isnt -1
+                        Session.Options.ScenarioIndex = 1; // We don't care what it
+                                                           // is as long as it isn't -1
 
                         /*
                         ** We have the scenario. Tell the host that I am ready to go.
@@ -9251,7 +9251,7 @@ static int Net_Fake_Join_Dialog(void)
                     } else {
 #ifndef FIXIT_VERSION_3 //	Removed restriction on downloading official maps.
                         /*
-                        ** Oh dear. Thats a scenario I dont have. Request that the host sends the
+                        ** Oh dear. That's a scenario I don't have. Request that the host sends the
                         **	scenario to me provided its not an official Westwood scenario.
                         **
                         ** If the file is received OK then we will get a true return value and the
@@ -9261,8 +9261,8 @@ static int Net_Fake_Join_Dialog(void)
                             Session.Options.ScenarioIndex = -1;
                         } else {
 #endif
-                            Session.Options.ScenarioIndex = 1; // We dont care what it
-                                                               // is as long as it isnt -1
+                            Session.Options.ScenarioIndex = 1; // We don't care what it
+                                                               // is as long as it isn't -1
 #ifdef FIXIT_VERSION_3
                             if (bSpecialAftermathScenario(Session.Options.ScenarioDescription))
                                 break;
@@ -9272,7 +9272,7 @@ static int Net_Fake_Join_Dialog(void)
                                 break;
                             } else {
                                 /*
-                                ** Make sure we dont time-out because of the download
+                                ** Make sure we don't time-out because of the download
                                 */
                             }
 #ifndef FIXIT_VERSION_3

--- a/redalert/object.cpp
+++ b/redalert/object.cpp
@@ -1552,7 +1552,7 @@ void ObjectClass::Detach_All(bool all)
     //	Unselect();
     //}
 
-    // Added some error handling incase there was an issue removing the object - JAS 6/28/2019
+    // Added some error handling in case there was an issue removing the object - JAS 6/28/2019
     if (all) {
         // Unselect();
         // Updated to function for multiplayer - 6/28/2019 JAS

--- a/redalert/radar.cpp
+++ b/redalert/radar.cpp
@@ -1930,14 +1930,14 @@ void RadarClass::Set_Radar_Position(CELL cell)
                 /*
                 ** Blit the section that is actually overlapping.
                 **
-                ** If the video card isnt able to blit overlapped regions then we have
+                ** If the video card isn't able to blit overlapped regions then we have
                 ** to do the blit in two stages via an intermediate buffer. The test to allow
                 ** overlapped blits is done in the library at the time of setting the video mode.
                 */
                 if (OverlappedVideoBlits || !HidPage.Get_IsDirectDraw()) {
 
                     /*
-                    ** Overlapped blits are OK or we dont have a video memory hid page so blits are
+                    ** Overlapped blits are OK or we don't have a video memory hid page so blits are
                     ** always done in software by the library anyway.
                     */
                     HidPage.Blit(HidPage,

--- a/redalert/rules.cpp
+++ b/redalert/rules.cpp
@@ -623,7 +623,7 @@ bool RulesClass::Heap_Maximums(CCINIClass& ini)
     }
 
     /*
-    **	Special case: double maximum animations to accomodate lots of action
+    **	Special case: double maximum animations to accommodate lots of action
     */
     AnimMax = max(AnimMax, 200);
 

--- a/redalert/scenario.cpp
+++ b/redalert/scenario.cpp
@@ -248,8 +248,8 @@ void ScenarioClass::Do_Fade_AI(void)
 /***********************************************************************************************
  * ScenarioClass::Set_Global_To -- Set scenario global to value specified.                     *
  *                                                                                             *
- *    This routine will set the global flag to the falue (true/false) specified. It will       *
- *    also scan for and spring any triggers that are dependant upon that global.               *
+ *    This routine will set the global flag to the value (true/false) specified. It will       *
+ *    also scan for and spring any triggers that are dependent upon that global.               *
  *                                                                                             *
  * INPUT:   global   -- The global flag to change.                                             *
  *                                                                                             *
@@ -1825,7 +1825,6 @@ int BGMessageBox(char const* msg, int btn1, int btn2)
  *    INI root file name for the specified scenario parameters.                                *
  *                                                                                             *
  * INPUT:                                                                                      *
- *         buf         buffer to store filename in; must be long enough for root.ext           *
  *       scenario      scenario number                                                         *
  *       player      player type for this game (GDI, NOD, multi-player, ...)                   *
  *       dir         directional parameter for this game (East/West)                           *
@@ -2042,9 +2041,9 @@ bool Read_Scenario_INI(char* fname, bool)
     /*
     ** Only force a CD check if this is a single player game or if its
     ** a multiplayer game on an official scenario. If its non-official
-    ** (a user scenario) then we dont care which CD is in because the
+    ** (a user scenario) then we don't care which CD is in because the
     ** scenario is stored locally on the hard drive. In this case, we
-    ** have already verified its existance. ST 3/1/97 4:52PM.
+    ** have already verified its existence. ST 3/1/97 4:52PM.
     */
 #ifdef FIXIT_VERSION_3 //	Avoid CD check if official scenario was downloaded.
     if ((Session.Type == GAME_NORMAL || Session.ScenarioIsOfficial) && _stricmp(Scen.ScenarioName, "download.tmp")) {

--- a/redalert/scenario.h
+++ b/redalert/scenario.h
@@ -293,7 +293,7 @@ public:
 
     /*
     **	If the map selection is to be skipped then this flag will be true. If this
-    **	ins't a one time only scenario, then the next scenario will have the same
+    **	isn't a one time only scenario, then the next scenario will have the same
     **	name as the current one but will be for variation "B".
     */
     unsigned IsNoMapSel : 1;

--- a/redalert/sendfile.cpp
+++ b/redalert/sendfile.cpp
@@ -74,7 +74,7 @@ extern bool Is_Mission_Aftermath(char* file_name);
  * INPUT:    ptr to buffer to copy file name into                                              *
  *           game type - 0 for modem/null modem, 1 otherwise                                   *
  *                                                                                             *
- * OUTPUT:   true if file sucessfully downloaded                                               *
+ * OUTPUT:   true if file successfully downloaded                                              *
  *                                                                                             *
  * WARNINGS: None                                                                              *
  *                                                                                             *

--- a/redalert/session.h
+++ b/redalert/session.h
@@ -181,15 +181,15 @@ typedef enum SerialCommandType
     SERIAL_SIGN_OFF = 102,      // Bogus, dudes, my boss is coming; I'm outta here!
     SERIAL_GO = 103,            // OK, dudes, jump into the game loop!
     SERIAL_MESSAGE = 104,       // Here's a message
-    SERIAL_TIMING = 105,        // timimg packet
+    SERIAL_TIMING = 105,        // timing packet
     SERIAL_SCORE_SCREEN = 106,  // player at score screen
     SERIAL_LOADGAME = 107,      // Start the game, loading a saved game first
     SERIAL_LAST_COMMAND,        // last command
-    SERIAL_REQ_SCENARIO = 1000, // Reqest that host sends the scenario file to the other players.
+    SERIAL_REQ_SCENARIO = 1000, // Request that host sends the scenario file to the other players.
     SERIAL_FILE_INFO = 1001,    // Info about the file that is going to be transferred
     SERIAL_FILE_CHUNK = 1002,   // A chunk of scenario
     SERIAL_READY_TO_GO = 1003,  // Sent in response to a 'GO' command
-    SERIAL_NO_SCENARIO = 1004   // Scenario isnt available on remote machine so we cant play
+    SERIAL_NO_SCENARIO = 1004   // Scenario isn't available on remote machine so we can't play
 } SerialCommandType;
 
 //...........................................................................
@@ -212,11 +212,11 @@ typedef enum NetCommandType
     NET_MESSAGE,             // Here's a message
     NET_PING,                // I'm pinging you to take a time measurement
     NET_LOADGAME,            // start a game by loading a saved game
-    NET_REQ_SCENARIO = 1000, // Reqest that host sends the scenario file to the other players.
+    NET_REQ_SCENARIO = 1000, // Request that host sends the scenario file to the other players.
     NET_FILE_INFO = 1001,    // Info about the file that is going to be transferred
     NET_FILE_CHUNK = 1002,   // A chunk of scenario
     NET_READY_TO_GO = 1003,  // Sent in response to a 'GO' command
-    NET_NO_SCENARIO = 1004   // Scenario isnt available on remote machine so we cant play
+    NET_NO_SCENARIO = 1004   // Scenario isn't available on remote machine so we can't play
 } NetCommandType;
 
 //---------------------------------------------------------------------------

--- a/redalert/sidebar.cpp
+++ b/redalert/sidebar.cpp
@@ -245,7 +245,7 @@ void SidebarClass::One_Time(void)
     Column[1].One_Time(1);
 
     /*
-    **	Load the sidebar shape in at this time. (Hi-Res sidebar is theater dependant)
+    **	Load the sidebar shape in at this time. (Hi-Res sidebar is theater dependent)
     */
     if (SidebarShape == NULL) {
         SidebarShape = (void*)MFCD::Retrieve("SIDEBAR.SHP");

--- a/redalert/startup.cpp
+++ b/redalert/startup.cpp
@@ -680,7 +680,7 @@ void Emergency_Exit(int code)
     }
 
     /*
-    ** Clear out the video buffers so we dont glitch when we lose focus
+    ** Clear out the video buffers so we don't glitch when we lose focus
     */
     VisiblePage.Clear();
     HiddenPage.Clear();

--- a/redalert/stats.cpp
+++ b/redalert/stats.cpp
@@ -782,7 +782,7 @@ void Send_Statistics_Packet(void)
 
 #ifndef WOLAPI_INTEGRATION //	ajw - 'PacketLater' is no longer ever used.
         /*
-        ** If a player disconnected then dont send the packet at this time - save it for later
+        ** If a player disconnected then don't send the packet at this time - save it for later
         */
         if (completion == COMPLETION_PLAYER_1_WON_BY_DISCONNECTION
             || completion == COMPLETION_PLAYER_2_WON_BY_DISCONNECTION) {

--- a/redalert/target.cpp
+++ b/redalert/target.cpp
@@ -441,7 +441,7 @@ BuildingClass* As_Building(TARGET target, bool check_active)
  * Target_Legal -- Determines if the specified target is legal.                                *
  *                                                                                             *
  *    This routine is used to check for the legality of the target value specified. It is      *
- *    necessary to call this routine if there is doubt about the the legality of the target.   *
+ *    necessary to call this routine if there is doubt about the legality of the target.       *
  *    It is possible for the unit that a target value represents to be eliminated and thus     *
  *    rendering the target value invalid.                                                      *
  *                                                                                             *

--- a/redalert/tdata.cpp
+++ b/redalert/tdata.cpp
@@ -560,7 +560,7 @@ void TerrainTypeClass::Init_Heap(void)
  *                                                                                             *
  *    This routine will perform any special one time processing needed for the terrain         *
  *    object types. Typically, this would load up artwork for terrain objects that have        *
- *    artwork independant of the theater they appear in.                                       *
+ *    artwork independent of the theater they appear in.                                       *
  *                                                                                             *
  * INPUT:   none                                                                               *
  *                                                                                             *

--- a/redalert/team.cpp
+++ b/redalert/team.cpp
@@ -2657,7 +2657,7 @@ int TeamClass::TMission_Formation(void)
  * TeamClass::TMission_Attack -- Perform the team attack mission command.                      *
  *                                                                                             *
  *    This will tell the team to attack the quarry specified in the team command. If the team  *
- *    already has a target, this it is presumed that this target take precidence and it won't  *
+ *    already has a target, this it is presumed that this target take precedence and it won't  *
  *    be changed.                                                                              *
  *                                                                                             *
  * INPUT:   none                                                                               *

--- a/redalert/terrain.cpp
+++ b/redalert/terrain.cpp
@@ -358,7 +358,7 @@ void TerrainClass::Init(void)
 /***********************************************************************************************
  * TerrainClass::Can_Enter_Cell -- Determines if the terrain object can exist in the cell.     *
  *                                                                                             *
- *    This routine will examine the cell specified and determine if the the terrain object     *
+ *    This routine will examine the cell specified and determine if the terrain object         *
  *    can legally exist there.                                                                 *
  *                                                                                             *
  * INPUT:   cell  -- The cell to examine.                                                      *

--- a/redalert/tracker.cpp
+++ b/redalert/tracker.cpp
@@ -99,7 +99,7 @@ void Detach_This_From_All(TARGET target, bool all)
         ChronalVortex.Detach(target);
 
         /*
-        **	Removing a trigger type must also remove all triggers that are dependant
+        **	Removing a trigger type must also remove all triggers that are dependent
         **	upon that type.
         */
         if (As_TriggerType(target) != NULL) {

--- a/redalert/type.h
+++ b/redalert/type.h
@@ -194,7 +194,7 @@ public:
 };
 
 /***************************************************************************
-**	This the the common base class of game objects. Since these values
+**	This is the common base class of game objects. Since these values
 **	represent the unchanging object TYPES, this data is initialized at game
 **	start and not changed during play. It is "const" data.
 */
@@ -418,7 +418,7 @@ public:
     /*
     **	Does this object contain a crew?  If it does, then when the object is destroyed, there
     **	is a distinct possibility that infantry will "pop out". Only units with crews can
-    **	become "heros".
+    **	become "heroes".
     */
     unsigned IsCrew : 1;
 
@@ -645,7 +645,7 @@ public:
     unsigned IsFake : 1;
 
     /*
-    **	This flag controls whether the building is equiped with a dirt
+    **	This flag controls whether the building is equipped with a dirt
     **	bib or not. A building with a bib has a dirt patch automatically
     **	attached to the structure when it is placed.
     */

--- a/redalert/unit.cpp
+++ b/redalert/unit.cpp
@@ -3366,7 +3366,7 @@ MoveType UnitClass::Can_Enter_Cell(CELL cell, FacingType) const
 
                     /*
                     **	If this unit can crush infantry, and there is an enemy infantry in the
-                    **	cell, don't consider the cell impassible. This is true even if the unit
+                    **	cell, don't consider the cell impassable. This is true even if the unit
                     **	doesn't contain a legitimate weapon.
                     */
                     bool crusher = Class->IsCrusher;

--- a/redalert/vortex.cpp
+++ b/redalert/vortex.cpp
@@ -199,7 +199,7 @@ void ChronalVortexClass::Disappear(void)
  *                                                                                             *
  * OUTPUT:   Nothing                                                                           *
  *                                                                                             *
- * WARNINGS: This doesnt deactivate the vortex. Use Disappear to get rid of it permanently.    *
+ * WARNINGS: This doesn't deactivate the vortex. Use Disappear to get rid of it permanently.   *
  *                                                                                             *
  * HISTORY:                                                                                    *
  *    8/29/96 4:30PM ST : Created                                                              *
@@ -228,7 +228,7 @@ void ChronalVortexClass::Hide(void)
 void ChronalVortexClass::Show(void)
 {
     /*
-    ** Dont do anything if vortx is dying.
+    ** Don't do anything if vortex is dying.
     */
     if (!StartShutdown) {
 
@@ -357,7 +357,7 @@ void ChronalVortexClass::AI(void)
     int chance;
 
     /*
-    ** No AI if vortex isnt active
+    ** No AI if vortex isn't active
     */
     if (Active) {
 
@@ -845,7 +845,7 @@ void ChronalVortexClass::Render(void)
             /*
             ** Build a representation of the area of the screen where the vortex will be
             ** in an off-screen buffer.
-            ** This is necessary for clipping as we cant remap pixels from off screen if we build
+            ** This is necessary for clipping as we can't remap pixels from off screen if we build
             ** the image from the hidpage.
             */
             if (!RenderBuffer) {
@@ -1101,7 +1101,7 @@ void ChronalVortexClass::Setup_Remap_Tables(TheaterType theater)
 
     /*
     ** If the theater has changed then load the remap tables from disk if they exist or create
-    ** them if they dont.
+    ** them if they don't.
     */
     if (theater != Theater) {
 

--- a/redalert/warhead.h
+++ b/redalert/warhead.h
@@ -110,7 +110,7 @@ public:
     bool IsOrganic : 1;
 
     /*
-    **	The warhead damage is reduced depending on the the type of armor the
+    **	The warhead damage is reduced depending on the type of armor the
     **	defender has. This table is what gives weapons their "character".
     */
     fixed Modifier[ARMOR_COUNT];

--- a/redalert/weapon.cpp
+++ b/redalert/weapon.cpp
@@ -129,7 +129,7 @@ void* WeaponTypeClass::operator new(size_t)
  * WeaponTypeClass::operator delete -- Returns weapon type object back to special heap.        *
  *                                                                                             *
  *    This routine will return the weapon type object back to the heap so that the memory      *
- *    can be reused for subsiquent allocations of weapon type objects.                         *
+ *    can be reused for subsequent allocations of weapon type objects.                         *
  *                                                                                             *
  * INPUT:   pointer  -- Pointer to the weapon type object to return to the special heap.       *
  *                                                                                             *

--- a/redalert/wol_gsup.cpp
+++ b/redalert/wol_gsup.cpp
@@ -2383,7 +2383,7 @@ bool WOL_GameSetupDialog::AcceptParams(char* szParams)
         //		//	Advance string pointer to next param.
         //		szRemaining += iLen + 1;
         //	There is a digest.
-        szToken = strtok(NULL, szDelimiter); //	(Digests can't have spaces in the them.)
+        szToken = strtok(NULL, szDelimiter); //	(Digests can't have spaces in them.)
                                              // debugprint( "digest: '%s'\n", szToken );
         if (!szToken)
             return false;

--- a/tiberiandawn/aadata.cpp
+++ b/tiberiandawn/aadata.cpp
@@ -691,7 +691,7 @@ bool AircraftTypeClass::Create_And_Place(CELL, HousesType) const
 }
 
 /***********************************************************************************************
- * ATC::Init -- load up terrain set dependant sidebar icons                                    *
+ * ATC::Init -- load up terrain set dependent sidebar icons                                    *
  *                                                                                             *
  *                                                                                             *
  *                                                                                             *

--- a/tiberiandawn/aircraft.cpp
+++ b/tiberiandawn/aircraft.cpp
@@ -45,7 +45,7 @@
  *   AircraftClass::Fire_Coord -- Calculates the point of origin for a bullet.                 *
  *   AircraftClass::Fire_Direction -- Determines the direction of fire.                        *
  *   AircraftClass::Good_Fire_Location -- Searches for and finds a good spot to fire from.     *
- *   AircraftClass::Good_LZ -- Locates a good spot ot land.                                    *
+ *   AircraftClass::Good_LZ -- Locates a good spot to land.                                    *
  *   AircraftClass::In_Which_Layer -- Determine which render layer the aircraft lies.          *
  *   AircraftClass::Init -- Initialize the aircraft system to an empty state.                  *
  *   AircraftClass::Is_LZ_Clear -- Determines if landing zone is free for landing.             *
@@ -237,7 +237,7 @@ AircraftClass::AircraftClass(AircraftType classid, HousesType house)
     ReinforcementStart = -1;
 
     /*
-    ** Keep count of the number of units created. Dont track cargo planes as they are created
+    ** Keep count of the number of units created. Don't track cargo planes as they are created
     ** automatically, not bought.
     */
     if (classid != AIRCRAFT_CARGO && GameToPlay == GAME_INTERNET) {
@@ -2039,7 +2039,7 @@ void AircraftClass::Debug_Dump(MonoClass* mono) const
 /***********************************************************************************************
  * AircraftClass::Active_Click_With -- Handles clicking over specified object.                 *
  *                                                                                             *
- *    This routine is used when the player clicks over the speicifed object. It will assign    *
+ *    This routine is used when the player clicks over the specified object. It will assign    *
  *    the appropriate mission to the aircraft.                                                 *
  *                                                                                             *
  * INPUT:   action   -- The action that was nominally determined by the What_Action function.  *
@@ -2049,7 +2049,7 @@ void AircraftClass::Debug_Dump(MonoClass* mono) const
  * OUTPUT:  none                                                                               *
  *                                                                                             *
  * WARNINGS:   This routine will alter the game sequence and causes an event packet to be      *
- *             propogated to all connected machines.                                           *
+ *             propagated to all connected machines.                                           *
  *                                                                                             *
  * HISTORY:                                                                                    *
  *   06/19/1995 JLB : Created.                                                                 *
@@ -2085,7 +2085,7 @@ void AircraftClass::Active_Click_With(ActionType action, ObjectClass* object)
  * OUTPUT:  none                                                                               *
  *                                                                                             *
  * WARNINGS:   This routine will affect the game sequence and causes an event object to be     *
- *             propogated to all connected machines.                                           *
+ *             propagated to all connected machines.                                           *
  *                                                                                             *
  * HISTORY:                                                                                    *
  *   06/19/1995 JLB : Created.                                                                 *
@@ -2127,7 +2127,7 @@ void AircraftClass::Active_Click_With(ActionType action, CELL cell)
  * OUTPUT:  none                                                                               *
  *                                                                                             *
  * WARNINGS:   The mission specified will be executed at an indeterminate future game frame.   *
- *             This is controlled by net/modem propogation delay.                              *
+ *             This is controlled by net/modem propagation delay.                              *
  *                                                                                             *
  * HISTORY:                                                                                    *
  *   06/19/1995 JLB : Created.                                                                 *
@@ -2569,7 +2569,7 @@ RadioMessageType AircraftClass::Receive_Message(RadioClass* from, RadioMessageTy
         return (RADIO_NEGATIVE);
 
     /*
-    **	Something disasterous has happened to the object in contact with. Fall back
+    **	Something disastrous has happened to the object in contact with. Fall back
     **	and regroup. This means that any landing process is immediately aborted.
     */
     case RADIO_RUN_AWAY:
@@ -2915,7 +2915,7 @@ TARGET AircraftClass::Good_Fire_Location(TARGET target) const
  * AircraftClass::Cell_Seems_Ok -- Checks to see if a cell is good to enter.                   *
  *                                                                                             *
  *    This routine examines the navigation computers of other aircraft in order to see if the  *
- *    specified cell is safe to fly to. The intent of this routine is to avoid unneccessary    *
+ *    specified cell is safe to fly to. The intent of this routine is to avoid unnecessary     *
  *    mid-air collisions.                                                                      *
  *                                                                                             *
  * INPUT:   cell     -- The cell to examine for clear airspace.                                *
@@ -3109,7 +3109,7 @@ int AircraftClass::Mission_Enter(void)
 }
 
 /***********************************************************************************************
- * AircraftClass::Good_LZ -- Locates a good spot ot land.                                      *
+ * AircraftClass::Good_LZ -- Locates a good spot to land.                                      *
  *                                                                                             *
  *    This routine is used when helicopters need a place to land, but there are no obvious     *
  *    spots (i.e., helipad) available. It will try to land near a friendly helipad or friendly *
@@ -3307,7 +3307,7 @@ int AircraftClass::Rearm_Delay(bool second) const
  *    meaningless.                                                                             *
  *                                                                                             *
  * INPUT:   control  -- The range control parameter;                                           *
- *                      -1 = range doesn't matter -- return -1 for compatability reasons.      *
+ *                      -1 = range doesn't matter -- return -1 for compatibility reasons.      *
  *                      0  = short range scan                                                  *
  *                      1  = long range scan                                                   *
  *                                                                                             *

--- a/tiberiandawn/aircraft.h
+++ b/tiberiandawn/aircraft.h
@@ -240,7 +240,7 @@ private:
 
     /*
     **	This is the jitter tracker to be used when the aircraft is a helicopter and
-    **	is flying. It is most noticable when the helicopter is hovering.
+    **	is flying. It is most noticeable when the helicopter is hovering.
     */
     unsigned char Jitter;
 

--- a/tiberiandawn/anim.cpp
+++ b/tiberiandawn/anim.cpp
@@ -159,7 +159,7 @@ COORDINATE AnimClass::Sort_Y(void) const
  * AnimClass::Center_Coord -- Determine center of animation.                                   *
  *                                                                                             *
  *    This support function will return the "center" of the animation. The actual coordinate   *
- *    of the animation may be dependant on if the the animation is attached to an object.      *
+ *    of the animation may be dependent on if the animation is attached to an object.          *
  *    In such a case, it must factor in the object's location.                                 *
  *                                                                                             *
  * INPUT:   none                                                                               *
@@ -760,7 +760,7 @@ AnimClass::~AnimClass(void)
  *                                                                                             *
  * OUTPUT:  none                                                                               *
  *                                                                                             *
- * WARNINGS:   Speed is of upmost importance.                                                  *
+ * WARNINGS:   Speed is of utmost importance.                                                  *
  *                                                                                             *
  * HISTORY:                                                                                    *
  *   05/31/1994 JLB : Created.                                                                 *
@@ -879,7 +879,7 @@ void AnimClass::AI(void)
             /*
             **	During the biggest stage (covers the most ground), perform any ground altering
             **	action required. This masks craters and scorch marks, so that they appear
-            **	naturally rather than "popping" into existance while in plain sight.
+            **	naturally rather than "popping" into existence while in plain sight.
             */
             if (Class->Start + stage == Class->Biggest) {
                 Middle();
@@ -1033,7 +1033,7 @@ void AnimClass::Start(void)
 
     /*
     **	If the stage where collateral effects occur is the first stage of the animation, then
-    **	perform this action now. Subsiquent checks against this stage value starts with the
+    **	perform this action now. Subsequent checks against this stage value starts with the
     **	second frame of the animation.
     */
     if (!Class->Biggest) {

--- a/tiberiandawn/anim.h
+++ b/tiberiandawn/anim.h
@@ -199,7 +199,7 @@ private:
     /*
     **	If this animation is invisible, then this flag will be true. An invisible
     **	animation is one that is created for the sole purpose of keeping all
-    **	machines syncronised. It will not be displayed.
+    **	machines synchronized. It will not be displayed.
     */
     unsigned IsInvisible : 1;
 

--- a/tiberiandawn/bdata.cpp
+++ b/tiberiandawn/bdata.cpp
@@ -38,7 +38,7 @@
  *   BuildingTypeClass::Dimensions -- Fetches the pixel dimensions of the building.            *
  *   BuildingTypeClass::Display -- Renders a generic view of building.                         *
  *   BuildingTypeClass::Full_Name -- Fetches the full name text number.                        *
- *   BuildingTypeClass::Height -- Determins the height of the building in icons.               *
+ *   BuildingTypeClass::Height -- Determines the height of the building in icons.              *
  *   BuildingTypeClass::Init -- Performs theater specific initialization.                      *
  *   BuildingTypeClass::Init_Anim -- Initialize an animation control for a building.           *
  *   BuildingTypeClass::Legal_Placement -- Determines if building can be legally placed at pos.*
@@ -50,7 +50,7 @@
  *   BuildingTypeClass::Repair_Cost -- Determines cost per "step" of repair.                   *
  *   BuildingTypeClass::Repair_Step -- Determines the repair step rate.                        *
  *   BuildingTypeClass::Who_Can_Build_Me -- Determines which factory can create the building.  *
- *   BuildingTypeClass::Width -- Determines width of bulding in icons.                         *
+ *   BuildingTypeClass::Width -- Determines width of building in icons.                        *
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #include "function.h"
@@ -3548,7 +3548,7 @@ BuildingTypeClass const* const BuildingTypeClass::Pointers[STRUCT_COUNT] = {
     &ClassWeapon,        //	STRUCT_WEAP
     &ClassGTower,        //	STRUCT_GTOWER
     &ClassATower,        //	STRUCT_ATOWER
-    &ClassObelisk,       //	STRUCT_OBLISK
+    &ClassObelisk,       //	STRUCT_OBELISK
     &ClassCommand,       //	STRUCT_RADAR
     &ClassTurret,        //	STRUCT_TURRET
     &ClassConst,         //	STRUCT_CONST
@@ -4360,7 +4360,7 @@ short const* BuildingTypeClass::Overlap_List(void) const
 }
 
 /***********************************************************************************************
- * BuildingTypeClass::Width -- Determines width of bulding in icons.                           *
+ * BuildingTypeClass::Width -- Determines width of building in icons.                          *
  *                                                                                             *
  *    Use this routine to determine the width of the building type in icons.                   *
  *                                                                                             *
@@ -4380,7 +4380,7 @@ int BuildingTypeClass::Width(void) const
 }
 
 /***********************************************************************************************
- * BuildingTypeClass::Height -- Determins the height of the building in icons.                 *
+ * BuildingTypeClass::Height -- Determines the height of the building in icons.                *
  *                                                                                             *
  *    Use this routine to find the height of the building in icons.                            *
  *                                                                                             *

--- a/tiberiandawn/building.cpp
+++ b/tiberiandawn/building.cpp
@@ -588,7 +588,7 @@ void BuildingClass::Draw_It(int x, int y, WindowNumberType window)
                 } else {
 
                     /*
-                    **	Special render stage for silos. The stage is dependant on the current
+                    **	Special render stage for silos. The stage is dependent on the current
                     **	Tiberium collected as it relates to Tiberium capacity.
                     */
                     if (*this == STRUCT_STORAGE) {
@@ -1016,7 +1016,7 @@ void BuildingClass::AI(void)
 
     /*
     **	If a change of animation was requested, then make the change
-    **	now. The building animation system acts independantly but subordinate
+    **	now. The building animation system acts independently but subordinate
     **	to the mission state machine system. By performing the animation change-up
     **	here, the mission AI system is ensured of immediate visual affect when it
     **	decides to change the animation state of the building.
@@ -1237,7 +1237,7 @@ void BuildingClass::AI(void)
     if (IsGoingToBlow && CountDown.Expired()) {
 #ifdef REMASTER_BUILD
         /*
-        ** Maybe trigger an achivement. ST - 11/14/2019 1:53PM
+        ** Maybe trigger an achievement. ST - 11/14/2019 1:53PM
         */
         TechnoTypeClass const* object_type = Techno_Type_Class();
         if (object_type) {
@@ -1263,7 +1263,7 @@ void BuildingClass::AI(void)
     }
 
     /*
-    **	Turret equiped buildings must handle turret rotation logic here. This entails
+    **	Turret equipped buildings must handle turret rotation logic here. This entails
     **	rotating the turret to the desired facing as well as figuring out what that
     **	desired facing should be.
     */
@@ -1554,7 +1554,7 @@ ResultType BuildingClass::Take_Damage(int& damage, int distance, WarheadType war
             }
 
             /*
-            **	A destuction of the Temple by an ion cannon requires a global
+            **	A destruction of the Temple by an ion cannon requires a global
             **	remembering of this fact. The finale uses this information to
             **	play the correct movie.
             */
@@ -1562,7 +1562,7 @@ ResultType BuildingClass::Take_Damage(int& damage, int distance, WarheadType war
                 TempleIoned = true;
 #ifdef REMASTER_BUILD
                 /*
-                ** Maybe trigger an achivement if the structure is owned by an AI house in campaign mode. ST -
+                ** Maybe trigger an achievement if the structure is owned by an AI house in campaign mode. ST -
                 *11/14/2019 1:53PM
                 */
                 if (GameToPlay == GAME_NORMAL && !House->IsHuman && source && source->House && source->House->IsHuman) {
@@ -3595,7 +3595,7 @@ bool BuildingClass::Captured(HouseClass* newowner)
         }
 #ifdef REMASTER_BUILD
         /*
-        ** Maybe trigger an achivement. ST - 11/14/2019 1:53PM
+        ** Maybe trigger an achievement. ST - 11/14/2019 1:53PM
         */
         if (newowner->IsHuman) {
             TechnoTypeClass const* object_type = Techno_Type_Class();
@@ -4887,7 +4887,7 @@ bool BuildingClass::Revealed(HouseClass* house)
  *    This routine is called when the exact mode of the building isn't known. By examining     *
  *    the building's condition, this routine will assign an appropriate mission.               *
  *                                                                                             *
- * INPUT:   initial  -- This this being called during scenario init?                           *
+ * INPUT:   initial  -- Is this being called during scenario init?                             *
  *                                                                                             *
  * OUTPUT:  none                                                                               *
  *                                                                                             *

--- a/tiberiandawn/building.h
+++ b/tiberiandawn/building.h
@@ -108,7 +108,7 @@ public:
     unsigned IsSurvivorless : 1;
 
     /*
-    **	These state control variables are used by the oblisk for the charging
+    **	These state control variables are used by the obelisk for the charging
     **	animation.
     */
     unsigned IsCharging : 1;
@@ -116,7 +116,7 @@ public:
 
     /*
     **	A building that has been captured will not contain the full compliment
-    **	of crew. This is true even if it subsiquently gets captured back.
+    **	of crew. This is true even if it subsequently gets captured back.
     */
     unsigned IsCaptured : 1;
 

--- a/tiberiandawn/bullet.cpp
+++ b/tiberiandawn/bullet.cpp
@@ -615,7 +615,7 @@ void BulletClass::Detach(TARGET target, bool all)
  *                                                                                             *
  *    This routine is used to take a bullet object that is in limbo and transition it to the   *
  *    game system. A bullet object so transitioned, will be drawn and logic processing         *
- *    performed. In effect, it comes into existance.                                           *
+ *    performed. In effect, it comes into existence.                                           *
  *                                                                                             *
  * INPUT:   coord -- The location where the bullet object is to appear.                        *
  *                                                                                             *

--- a/tiberiandawn/ccini.cpp
+++ b/tiberiandawn/ccini.cpp
@@ -729,7 +729,7 @@ bool CCINIClass::Put_TerrainType(char const* section, char const* entry, Terrain
  *                      located.                                                               *
  *                                                                                             *
  * OUTPUT:  Returns with the building list (as a bitfield). If the entry could not be          *
- *          found, the the default value is returned instead.                                  *
+ *          found, then the default value is returned instead.                                      *
  *                                                                                             *
  * WARNINGS:   none                                                                            *
  *                                                                                             *

--- a/tiberiandawn/cell.cpp
+++ b/tiberiandawn/cell.cpp
@@ -1940,7 +1940,7 @@ long CellClass::Tiberium_Adjust(bool pregame)
 /***********************************************************************************************
  * CellClass::Goodie_Check -- Performs crate discovery logic.                                  *
  *                                                                                             *
- *    Call this routine whenever an object enters a cell. It will check for the existance      *
+ *    Call this routine whenever an object enters a cell. It will check for the existence      *
  *    of a crate and generate any "goodie" it might contain.                                   *
  *                                                                                             *
  * INPUT:   object   -- Pointer to the object that is triggering this crate.                   *
@@ -2708,7 +2708,7 @@ void CellClass::Override_Land_Type(LandType type)
  *    calculation. Only blockages that cannot be circumvented are considered to make a cell    *
  *    impassable. All other obstructions can either be destroyed or are temporary.             *
  *                                                                                             *
- * INPUT:   loco     -- The locomotion type to use when determining passablility.              *
+ * INPUT:   loco     -- The locomotion type to use when determining passibility.              *
  *                                                                                             *
  *          ignoreinfantry -- Should infantry in the cell be ignored for movement purposes?    *
  *                                                                                             *
@@ -2751,7 +2751,7 @@ bool CellClass::Is_Clear_To_Move(bool ignoreinfantry, bool ignorevehicles) const
 
     /*
     **	Check the occupy bits for passable legality. If ignore infantry is true, then
-    **	don't consider infnatry.
+    **	don't consider infantry.
     */
     int composite = Flag.Composite;
     if (ignoreinfantry) {

--- a/tiberiandawn/cell.h
+++ b/tiberiandawn/cell.h
@@ -67,7 +67,7 @@ public:
 
     /*
     **	If any part of this cell is visible (even just peeking out from under the shadow),
-    **	this this flag will be true. Mapped cells always have this flag set, but unmapped
+    **	then this flag will be true. Mapped cells always have this flag set, but unmapped
     **	cells might not -- it depends on where the shadow edge is located.
     */
     unsigned IsVisible : 1;
@@ -156,7 +156,7 @@ public:
     **	This array of bit flags is used to indicate which sub positions
     **	within the cell are either occupied or are soon going to be
     **	occupied. For vehicles, the cells that the vehicle is passing over
-    **	will be flagged with the vehicle bit. For infantry, the the sub
+    **	will be flagged with the vehicle bit. For infantry, the sub
     **	position the infantry is stopped at or headed toward will be marked.
     **	The sub positions it passes over will NOT be marked.
     */

--- a/tiberiandawn/conquer.cpp
+++ b/tiberiandawn/conquer.cpp
@@ -2281,7 +2281,7 @@ void Unselect_All(void)
     //	CurrentObject[0]->Unselect();
     //}
 
-    // Added some error handling incase there was an issue removing the object - JAS 6/28/2019
+    // Added some error handling in case there was an issue removing the object - JAS 6/28/2019
     while (CurrentObject.Count()) {
 
         int count_before = CurrentObject.Count();
@@ -2318,7 +2318,7 @@ void Unselect_All_Except(ObjectClass* object)
 /***********************************************************************************************
  * Fading_Table_Name -- Builds a theater specific fading table name.                           *
  *                                                                                             *
- *    This routine builds a standard fading table name. This name is dependant on the theater  *
+ *    This routine builds a standard fading table name. This name is dependent on the theater  *
  *    being played, since each theater has its own palette.                                    *
  *                                                                                             *
  * INPUT:   base  -- The base name of this fading table. The base name can be no longer than   *
@@ -2397,7 +2397,7 @@ void const* Get_Radar_Icon(void const* shapefile, int shapenum, int frames, int 
 
     /*
     ** Allocate a position to store our icons.  If the alloc fails then
-    ** we dont add these icons to the set.
+    ** we don't add these icons to the set.
     **/
     buffer = new char[(icon_width * icon_height * 9 * frames) + 2];
     if (!buffer)
@@ -3514,7 +3514,7 @@ static bool Change_Local_Dir(int cd)
         _initialised = true;
     }
 
-    // No local folders with cd data dectected so we can't load any.
+    // No local folders with cd data detected so we can't load any.
     if (_detected == 0) {
         return false;
     }
@@ -3883,9 +3883,9 @@ static void Do_Record_Playback(void)
     }
 }
 /***************************************************************************
- * HIRES_RETRIEVE -- retrieves a resolution dependant file						*
+ * HIRES_RETRIEVE -- retrieves a resolution dependent file                 *
  *                                                                         *
- * INPUT:		char * file name of the file to retrieve							*
+ * INPUT:		char * file name of the file to retrieve                   *
  *                                                                         *
  * OUTPUT:     none                                                        *
  *                                                                         *

--- a/tiberiandawn/defines.h
+++ b/tiberiandawn/defines.h
@@ -61,7 +61,7 @@
 //#define BONUS_MISSIONS
 
 /**********************************************************************
-** Handle expansion scnearios as a set of single missions with all
+** Handle expansion scenarios as a set of single missions with all
 **	necessary information self contained within the mission file.
 */
 #ifndef DEMO
@@ -637,7 +637,7 @@ typedef enum MPHType : unsigned char
 
 /**********************************************************************
 **	General audio volume is enumerated by these identifiers. Since small
-**	volume variations are usually unnoticable when specifying the volume
+**	volume variations are usually unnoticeable when specifying the volume
 **	to play a sample, this enumeration list creates more readable code.
 */
 typedef enum VolType : unsigned char
@@ -997,8 +997,8 @@ typedef enum InfantryType : signed char
     INFANTRY_C7,      // Civilian
     INFANTRY_C8,      // Civilian
     INFANTRY_C9,      // Civilian
-    INFANTRY_C10,     // Nikumba
-    INFANTRY_MOEBIUS, // Dr. Moebius
+    INFANTRY_C10,     // Nikoomba
+    INFANTRY_MOEBIUS, // Dr. Mobius
     INFANTRY_DELPHI,  // Agent "Delphi"
     INFANTRY_CHAN,    // Dr. Chan
 
@@ -1034,9 +1034,9 @@ typedef enum UnitType : signed char
     UNIT_MCV,       // Mobile construction vehicle.
     UNIT_BIKE,      // Nod recon motor-bike.
     UNIT_TRIC,      // Triceratops
-    UNIT_TREX,      //	Tyranosaurus Rex
+    UNIT_TREX,      //	Tyrannosaurus Rex
     UNIT_RAPT,      //	Velociraptor
-    UNIT_STEG,      //	Stegasaurus
+    UNIT_STEG,      //	Stegosaurus
 
 #ifdef PETROGLYPH_EXAMPLE_MOD
     UNIT_NUKE_TANK, // Mammoth with a nuke
@@ -1072,7 +1072,7 @@ typedef enum UnitType : signed char
 #define UNITF_STEG      (1L << UNIT_STEG)
 
 /**********************************************************************
-**	The variuos aircraft types are enumerated here. These include helicopters
+**	The various aircraft types are enumerated here. These include helicopters
 **	as well as traditional aircraft.
 */
 typedef enum AircraftType : signed char
@@ -1098,7 +1098,7 @@ typedef enum AircraftType : signed char
 
 /**********************************************************************
 **	The game templates are enumerated here. These are the underlying
-**	terrain art. This includes everything from water to clifs. If the
+**	terrain art. This includes everything from water to cliffs. If the
 **	terrain is broken up into icons, is not transparent, and is drawn
 **	as the bottom most layer, then it is a template.
 */
@@ -2653,7 +2653,7 @@ typedef enum SerialCommandType : unsigned short
     SERIAL_SIGN_OFF = 102,     // Bogus, dudes, my boss is coming; I'm outta here!
     SERIAL_GO = 103,           // OK, dudes, jump into the game loop!
     SERIAL_MESSAGE = 104,      // Here's a message
-    SERIAL_TIMING = 105,       // timimg packet
+    SERIAL_TIMING = 105,       // timing packet
     SERIAL_SCORE_SCREEN = 106, // player at score screen
     SERIAL_READY_TO_GO = 107,  // Host is ready to start the game
     SERIAL_LAST_COMMAND        // last command

--- a/tiberiandawn/display.cpp
+++ b/tiberiandawn/display.cpp
@@ -2056,7 +2056,7 @@ ObjectClass* DisplayClass::Cell_Object(CELL cell, int x, int y)
  *    This will draw the tactical map at the recorded position.   This                         *
  *    routine is used whenever the tactical map moves or needs to be                           *
  *    completely redrawn. It will handle making the necessary adjustments                      *
- *    to accomodate a moving cursor.                                                           *
+ *    to accommodate a moving cursor.                                                          *
  *                                                                                             *
  * INPUT:      forced   -- bool; force redraw of the entire display?                           *
  *                                                                                             *
@@ -4072,7 +4072,7 @@ void DisplayClass::Mouse_Left_Held(int x, int y)
     }
 }
 
-// Needed to accomodate Glyphx client sidebar. ST - 4/12/2019 5:29PM
+// Needed to accommodate GlyphX client sidebar. ST - 4/12/2019 5:29PM
 extern int GlyphXClientSidebarWidthInLeptons;
 
 /***********************************************************************************************
@@ -4104,7 +4104,7 @@ void DisplayClass::Set_Tactical_Position(COORDINATE coord)
                  TacLeptonWidth,
                  TacLeptonHeight,
                  Cell_To_Lepton(MapCellWidth) + GlyphXClientSidebarWidthInLeptons,
-                 Cell_To_Lepton(MapCellHeight)); // Needed to accomodate Glyphx client sidebar. ST - 4/12/2019 5:29PM
+                 Cell_To_Lepton(MapCellHeight)); // Needed to accommodate GlyphX client sidebar. ST - 4/12/2019 5:29PM
 #else
     int xx = Coord_X(coord) - Cell_To_Lepton(MapCellX);
     int yy = Coord_Y(coord) - Cell_To_Lepton(MapCellY);

--- a/tiberiandawn/dllinterface.cpp
+++ b/tiberiandawn/dllinterface.cpp
@@ -455,7 +455,7 @@ int DLLForceMouseY = 0;
 
 CNC_Event_Callback_Type DLLExportClass::EventCallback = NULL;
 
-// Needed to accomodate Glyphx client sidebar. ST - 4/12/2019 5:29PM
+// Needed to accommodate GlyphX client sidebar. ST - 4/12/2019 5:29PM
 int GlyphXClientSidebarWidthInLeptons = 0;
 
 bool MPlayerIsHuman[MAX_PLAYERS];
@@ -1527,7 +1527,7 @@ extern "C" __declspec(dllexport) bool __cdecl CNC_Advance_Instance(uint64 player
     /*
     ** Shouldn't really need to do this, but I like the idea of always running the main loop in the context of the same
     *player.
-    ** Might make tbe bugs more repeatable and consistent. ST - 3/15/2019 11:58AM
+    ** Might make the bugs more repeatable and consistent. ST - 3/15/2019 11:58AM
     */
     if (player_id != 0) {
         DLLExportClass::Set_Player_Context(player_id);
@@ -6177,7 +6177,7 @@ void DLLExportClass::Reset_Player_Context(void)
 }
 
 /**************************************************************************************************
- * Logic_Switch_Player_Context -- Called when the internal game locic needs to switch player context
+ * Logic_Switch_Player_Context -- Called when the internal game logic needs to switch player context
  *
  * In:
  *
@@ -6193,7 +6193,7 @@ void Logic_Switch_Player_Context(ObjectClass* object)
 }
 
 /**************************************************************************************************
- * DLLExportClass::Logic_Switch_Player_Context -- Called when the internal game locic needs to switch player context
+ * DLLExportClass::Logic_Switch_Player_Context -- Called when the internal game logic needs to switch player context
  *
  * In:
  *
@@ -6223,7 +6223,7 @@ void DLLExportClass::Logic_Switch_Player_Context(ObjectClass* object)
 }
 
 /**************************************************************************************************
- * Logic_Switch_Player_Context -- Called when the internal game locic needs to switch player context
+ * Logic_Switch_Player_Context -- Called when the internal game logic needs to switch player context
  *
  * In:
  *
@@ -6239,7 +6239,7 @@ void Logic_Switch_Player_Context(HouseClass* object)
 }
 
 /**************************************************************************************************
- * DLLExportClass::Logic_Switch_Player_Context -- Called when the internal game locic needs to switch player context
+ * DLLExportClass::Logic_Switch_Player_Context -- Called when the internal game logic needs to switch player context
  *
  * In:
  *
@@ -6513,7 +6513,7 @@ void DLLExportClass::Sell_Mode(uint64 player_id)
 }
 
 /**************************************************************************************************
- * DLLExportClass::Sell -- Sell's a player's speceific building.
+ * DLLExportClass::Sell -- Sells a player's specific building.
  *
  * In:
  *

--- a/tiberiandawn/facing.cpp
+++ b/tiberiandawn/facing.cpp
@@ -64,7 +64,7 @@ FacingClass::FacingClass(void)
  * FacingClass::Set_Desired -- Sets the desired facing  value.                                 *
  *                                                                                             *
  *    This routine is used to set the desired facing value without altering the current        *
- *    facing setting. Typicall use of this routine is when a vehicle needs to face a           *
+ *    facing setting. Typical use of this routine is when a vehicle needs to face a            *
  *    direction, but currently isn't facing the correct direction. After this routine is       *
  *    called, it is presumed that subsequent calls to Rotation_Adjust() will result in the     *
  *    eventual alignment of the current facing.                                                *

--- a/tiberiandawn/factory.cpp
+++ b/tiberiandawn/factory.cpp
@@ -475,7 +475,7 @@ void FactoryClass::Set(TechnoClass& object)
 /***********************************************************************************************
  * FactoryClass::Suspend -- Temporarily stop production.                                       *
  *                                                                                             *
- *    This routine will suspend production until a subsiquent call to Start() or Abandon().    *
+ *    This routine will suspend production until a subsequent call to Start() or Abandon().    *
  *    Typical use of this function is when the player puts production on hold or when there    *
  *    is insufficient funds.                                                                   *
  *                                                                                             *

--- a/tiberiandawn/findpath.cpp
+++ b/tiberiandawn/findpath.cpp
@@ -177,7 +177,7 @@ static CELL StartLocation;
  *      (x - x2)(z1 - z2) = (z - z2)(x1 - x2) given x,z a point on the     *
  *      line (x1,z1),(x2,z2).                                              *
  *      If the right side is > then the left side then the point is on one *
- *      side of the line and if the right side is < the the left side, then*
+ *      side of the line and if the right side is < the left side, then    *
  *      the point is on the other side of the line.  By subtracting one side*
  *      from the other we can determine on what side (if any) the point is on*
  *      by testing the side of the resulting subtraction.                  *
@@ -226,8 +226,8 @@ int Point_Relative_To_Line(int x, int z, int x1, int z1, int x2, int z2)
  *               destx    - the dest x position for this path segment      *
  *               desty    - the dest y position for this path segment      *
  *                                                                         *
- * OUTPUT:      TRUE    - loop has been sucessfully unravelled             *
- *               FALSE  - loop can not be unravelled so abort follow edge  *
+ * OUTPUT:      TRUE    - loop has been successfully unraveled             *
+ *               FALSE  - loop can not be unraveled so abort follow edge   *
  *                                                                         *
  * WARNINGS:   none                                                        *
  *                                                                         *
@@ -692,7 +692,7 @@ PathType* FootClass::Find_Path(CELL dest, FacingType* final_moves, int maxlen, M
 
                     /*
                     ** If the cell is passable then we have been completely
-                    ** sucessful.  If the cell is not passable then continue.
+                    ** successful.  If the cell is not passable then continue.
                     */
                     if ((Passable_Cell(next, FACING_NONE, threat, threshhold)) || (next == dest)) {
                         Draw_Cell_Point(next, true, threat_stage);
@@ -703,7 +703,7 @@ PathType* FootClass::Find_Path(CELL dest, FacingType* final_moves, int maxlen, M
 
                     /*
                     **	If we reached destination while in this loop, we
-                    **	know that either the destination is impassible (if
+                    **	know that either the destination is impassable (if
                     **	we are ignoring) or that we need to up our threat
                     ** tolerance and try again.
                     */
@@ -820,7 +820,7 @@ PathType* FootClass::Find_Path(CELL dest, FacingType* final_moves, int maxlen, M
 
                     /*
                     **	If we reached destination while in this loop, we
-                    **	know that either the destination is impassible (if
+                    **	know that either the destination is impassable (if
                     **	we are ignoring) or that we need to up our threat
                     ** tolerance and try again.
                     */
@@ -928,7 +928,7 @@ end_of_list:
  *                                                                                             *
  *          search   -- Direction of search (1=clock, -1=counterclock).                        *
  *                                                                                             *
- *          olddir   -- Facing impassible direction from start.                                *
+ *          olddir   -- Facing impassable direction from start.                                *
  *                                                                                             *
  *          callback -- Function pointer for determining if a cell is                          *
  *                      passable or not.                                                       *
@@ -1052,8 +1052,8 @@ bool FootClass::Follow_Edge(CELL start,
                 /*
                 **	Perform special diagonal check. If the edge follower would cross the
                 **	diagonal or fall on the diagonal line from the source, then consider
-                **	that cell impassible. Otherwise, the find path algorithm will fail
-                **	when there are two impassible locations located on a diagonal
+                **	that cell impassable. Otherwise, the find path algorithm will fail
+                **	when there are two impassable locations located on a diagonal
                 **	that is lined up between the source and destination location.
                 **
                 ** P.S. It might help if you check the right cell rather than using

--- a/tiberiandawn/foot.cpp
+++ b/tiberiandawn/foot.cpp
@@ -57,11 +57,11 @@
  *   FootClass::Mission_Hunt -- Handles the default hunt order.                                *
  *   FootClass::Mission_Move -- AI process for moving a vehicle to its destination.            *
  *   FootClass::Offload_Tiberium_Bail -- Fetches the Tiberium to offload per step.             *
- *   FootClass::Override_Mission -- temporarily overides a units mission                       *
+ *   FootClass::Override_Mission -- temporarily overrides a units mission                      *
  *   FootClass::Per_Cell_Process -- Perform action based on once-per-cell condition.           *
  *   FootClass::Receive_Message -- Movement related radio messages are handled here.           *
  *   FootClass::Rescue_Mission -- Calls this unit to the rescue.                               *
- *   FootClass::Restore_Mission -- Restores an overidden mission                               *
+ *   FootClass::Restore_Mission -- Restores an overridden mission                              *
  *   FootClass::Sell_Back -- Causes this object to be sold back.                               *
  *   FootClass::Set_Speed -- Initiate unit movement physics.                                   *
  *   FootClass::Sort_Y -- Determine the sort coordinate for foot class objects.                *
@@ -359,7 +359,7 @@ bool FootClass::Basic_Path(void)
         cell = As_Cell(NavCom);
 
         /*
-        **	When the navigation computer is set to a location that is impassible, then
+        **	When the navigation computer is set to a location that is impassable, then
         **	find a nearby cell that can be entered and try to head toward that instead.
         **	EXCEPT when that cell is very close -- then just bail.
         */
@@ -1434,17 +1434,17 @@ void FootClass::Per_Cell_Process(bool center)
 }
 
 /***************************************************************************
- * FootClass::Override_Mission -- temporarily overides a units mission     *
+ * FootClass::Override_Mission -- temporarily overrides a units mission    *
  *                                                                         *
  *                                                                         *
  *                                                                         *
- * INPUT:		MissionType mission - the mission we want to overide        *
- *					TARGET	   tarcom  - the new target we want to overide		*
- *					TARGET		navcom  - the new navigation point to overide	*
+ * INPUT:		MissionType mission - the mission we want to override      *
+ *					TARGET	   tarcom  - the new target we want to override		*
+ *					TARGET		navcom  - the new navigation point to override	*
  *                                                                         *
  * OUTPUT:		none                                                        *
  *                                                                         *
- * WARNINGS:   If a mission is already overidden, the current mission is   *
+ * WARNINGS:   If a mission is already overridden, the current mission is  *
  *					just re-assigned.															*
  *                                                                         *
  * HISTORY:                                                                *
@@ -1459,7 +1459,7 @@ void FootClass::Override_Mission(MissionType mission, TARGET tarcom, TARGET navc
 }
 
 /***************************************************************************
- * FootClass::Restore_Mission -- Restores an overidden mission             *
+ * FootClass::Restore_Mission -- Restores an overridden mission            *
  *                                                                         *
  * INPUT:		none                                                        *
  *                                                                         *
@@ -1548,7 +1548,7 @@ RadioMessageType FootClass::Receive_Message(RadioClass* from, RadioMessageType m
 
     /*
     **	Checks to see if this unit needs to move somewhere. If it is already in motion,
-    **	then it doesn't need furthur movement instructions.
+    **	then it doesn't need further movement instructions.
     */
     case RADIO_NEED_TO_MOVE:
         param = (long)NavCom;

--- a/tiberiandawn/gscreen.cpp
+++ b/tiberiandawn/gscreen.cpp
@@ -297,7 +297,7 @@ void GScreenClass::Input(KeyNumType& key, int& x, int& y)
  * GScreenClass::Add_A_Button -- Add a gadget to the game input system.                        *
  *                                                                                             *
  *    This will add a gadget to the game input system. The gadget will be processed in         *
- *    subsiquent calls to the GScreenClass::Input() function.                                  *
+ *    subsequent calls to the GScreenClass::Input() function.                                  *
  *                                                                                             *
  * INPUT:   gadget   -- Reference to the gadget that will be added to the input system.        *
  *                                                                                             *

--- a/tiberiandawn/house.cpp
+++ b/tiberiandawn/house.cpp
@@ -57,7 +57,7 @@
  *   HouseClass::Flag_To_Lose -- Flags the house to die soon.                                  *
  *   HouseClass::Flag_To_Win -- Flags the house to win soon.                                   *
  *   HouseClass::Harvested -- Adds Tiberium to the harvest storage.                            *
- *   HouseClass::Has_Nuke_Device -- Deteremines if the house has a nuclear device.             *
+ *   HouseClass::Has_Nuke_Device -- Determines if the house has a nuclear device.              *
  *   HouseClass::HouseClass -- Constructor for a house object.                                 *
  *   HouseClass::Init -- init's in preparation for new scenario                                *
  *   HouseClass::Init_Air_Strike -- Add (or reset) the air strike sidebar button.              *
@@ -552,7 +552,7 @@ bool HouseClass::Can_Build(TechnoTypeClass const* type, HousesType house) const
         return (false);
 
         /*
-        **	The computer can always build everthing.
+        **	The computer can always build everything.
         */
 #ifdef USE_RA_AI
     if (!IsHuman && GameToPlay == GAME_NORMAL)
@@ -563,7 +563,7 @@ bool HouseClass::Can_Build(TechnoTypeClass const* type, HousesType house) const
 #endif
 
     /*
-    **	Perform some equivalency fixups for the building existance flags.
+    **	Perform some equivalency fixups for the building existence flags.
     */
     long flags = ActiveBScan;
 
@@ -2780,7 +2780,7 @@ bool HouseClass::Place_Special_Blast(SpecialWeaponType id, CELL cell)
     }
 #ifdef REMASTER_BUILD
     /*
-    ** Maybe trigger an achivement. ST - 12/2/2019 11:25AM
+    ** Maybe trigger an achievement. ST - 12/2/2019 11:25AM
     */
     if (IsHuman && fired && what) {
         On_Achievement_Event(this, "SUPERWEAPON_FIRED", what);
@@ -4662,7 +4662,7 @@ fixed HouseClass::Power_Fraction(void) const
 }
 
 /***********************************************************************************************
- * HouseClass::Has_Nuke_Device -- Deteremines if the house has a nuclear device.               *
+ * HouseClass::Has_Nuke_Device -- Determines if the house has a nuclear device.                *
  *                                                                                             *
  *    This routine checks to see if the house has a nuclear device to launch. A nuclear        *
  *    device is available when the necessary parts have been retrieved in earlier scenarios    *
@@ -8024,7 +8024,7 @@ bool HouseClass::Is_Allowed_To_Ally(HousesType house) const
     }
 
     /*
-    **	Alliances (outside of scneario init time) are allowed only if
+    **	Alliances (outside of scenario init time) are allowed only if
     **	this is a multiplayer game. Otherwise, they are prohibited.
     */
     // if (Session.Type == GAME_NORMAL) {

--- a/tiberiandawn/house.h
+++ b/tiberiandawn/house.h
@@ -166,7 +166,7 @@ public:
     unsigned IsAirstrikePending : 1;
 
     /*
-    **	This records the existance of the three nuke weapon pieces.
+    **	This records the existence of the three nuke weapon pieces.
     */
     unsigned NukePieces : 3;
 
@@ -906,7 +906,7 @@ public:
 
     /*
     **	This structure is used to record a build request as determined by
-    **	the house AI processing. Higher priority build requests take precidence.
+    **	the house AI processing. Higher priority build requests take precedence.
     */
     struct BuildChoiceClass
     {

--- a/tiberiandawn/idata.cpp
+++ b/tiberiandawn/idata.cpp
@@ -105,7 +105,7 @@ static InfantryTypeClass const E1(INFANTRY_E1,          // Infantry type number.
                                   false,                // Is this a female type?
                                   true,                 // Is a leader type?
                                   true,                 // Has crawling animation frames?
-                                  false,                // Is this a civlian?
+                                  false,                // Is this a civilian?
                                   false,                // Always use the given name for the infantry?
                                   false,                // Is this a "fraidycat" run-away type infantry?
                                   false,                // Can this infantry type capture a building?
@@ -175,7 +175,7 @@ static InfantryTypeClass const E2(INFANTRY_E2,         // Infantry type number.
                                   false,               // Is this a female type?
                                   true,                // Is a leader type?
                                   true,                // Has crawling animation frames?
-                                  false,               // Is this a civlian?
+                                  false,               // Is this a civilian?
                                   false,               // Always use the given name for the infantry?
                                   false,               // Is this a "fraidycat" run-away type infantry?
                                   false,               // Can this infantry type capture a building?
@@ -244,7 +244,7 @@ static InfantryTypeClass const E3(INFANTRY_E3,       // Infantry type number.
                                   false,             // Is this a female type?
                                   true,              // Is a leader type?
                                   true,              // Has crawling animation frames?
-                                  false,             // Is this a civlian?
+                                  false,             // Is this a civilian?
                                   false,             // Always use the given name for the infantry?
                                   false,             // Is this a "fraidycat" run-away type infantry?
                                   false,             // Can this infantry type capture a building?
@@ -314,7 +314,7 @@ static InfantryTypeClass const E4(INFANTRY_E4,            // Infantry type numbe
                                   false,                  // Is this a female type?
                                   true,                   // Is a leader type?
                                   true,                   // Has crawling animation frames?
-                                  false,                  // Is this a civlian?
+                                  false,                  // Is this a civilian?
                                   false,                  // Always use the given name for the infantry?
                                   false,                  // Is this a "fraidycat" run-away type infantry?
                                   false,                  // Can this infantry type capture a building?
@@ -382,7 +382,7 @@ static InfantryTypeClass const E5(INFANTRY_E5,           // Infantry type number
                                   false,                 // Is this a female type?
                                   true,                  // Is a leader type?
                                   true,                  // Has crawling animation frames?
-                                  false,                 // Is this a civlian?
+                                  false,                 // Is this a civilian?
                                   false,                 // Always use the given name for the infantry?
                                   false,                 // Is this a "fraidycat" run-away type infantry?
                                   false,                 // Can this infantry type capture a building?
@@ -452,7 +452,7 @@ static InfantryTypeClass const E7(INFANTRY_E7,        // Infantry type number.
                                   false,              // Is this a female type?
                                   false,              // Is a leader type?
                                   false,              // Has crawling animation frames?
-                                  false,              // Is this a civlian?
+                                  false,              // Is this a civilian?
                                   false,              // Always use the given name for the infantry?
                                   false,              // Is this a "fraidycat" run-away type infantry?
                                   true,               // Can this infantry type capture a building?
@@ -522,7 +522,7 @@ static InfantryTypeClass const Commando(INFANTRY_RAMBO,     // Infantry type num
                                         false,              // Is this a female type?
                                         true,               // Is a leader type?
                                         true,               // Has crawling animation frames?
-                                        false,              // Is this a civlian?
+                                        false,              // Is this a civilian?
                                         false,              // Always use the given name for the infantry?
                                         false,              // Is this a "fraidycat" run-away type infantry?
                                         false,              // Can this infantry type capture a building?
@@ -592,7 +592,7 @@ static InfantryTypeClass const C1(INFANTRY_C1,         // Infantry type number.
                                   false,               // Is this a female type?
                                   true,                // Is a leader type?
                                   false,               // Has crawling animation frames?
-                                  true,                // Is this a civlian?
+                                  true,                // Is this a civilian?
                                   true,                // Always use the given name for the infantry?
                                   true,                // Is this a "fraidycat" run-away type infantry?
                                   false,               // Can this infantry type capture a building?
@@ -659,7 +659,7 @@ static InfantryTypeClass const C2(INFANTRY_C2,         // Infantry type number.
                                   false,               // Is this a female type?
                                   false,               // Is a leader type?
                                   false,               // Has crawling animation frames?
-                                  true,                // Is this a civlian?
+                                  true,                // Is this a civilian?
                                   true,                // Always use the given name for the infantry?
                                   true,                // Is this a "fraidycat" run-away type infantry?
                                   false,               // Can this infantry type capture a building?
@@ -727,7 +727,7 @@ static InfantryTypeClass const C3(INFANTRY_C3,         // Infantry type number.
                                   true,                // Is this a female type?
                                   false,               // Is a leader type?
                                   false,               // Has crawling animation frames?
-                                  true,                // Is this a civlian?
+                                  true,                // Is this a civilian?
                                   true,                // Always use the given name for the infantry?
                                   true,                // Is this a "fraidycat" run-away type infantry?
                                   false,               // Can this infantry type capture a building?
@@ -794,7 +794,7 @@ static InfantryTypeClass const C4(INFANTRY_C4,         // Infantry type number.
                                   true,                // Is this a female type?
                                   false,               // Is a leader type?
                                   false,               // Has crawling animation frames?
-                                  true,                // Is this a civlian?
+                                  true,                // Is this a civilian?
                                   true,                // Always use the given name for the infantry?
                                   true,                // Is this a "fraidycat" run-away type infantry?
                                   false,               // Can this infantry type capture a building?
@@ -861,7 +861,7 @@ static InfantryTypeClass const C5(INFANTRY_C5,         // Infantry type number.
                                   false,               // Is this a female type?
                                   false,               // Is a leader type?
                                   false,               // Has crawling animation frames?
-                                  true,                // Is this a civlian?
+                                  true,                // Is this a civilian?
                                   true,                // Always use the given name for the infantry?
                                   true,                // Is this a "fraidycat" run-away type infantry?
                                   false,               // Can this infantry type capture a building?
@@ -928,7 +928,7 @@ static InfantryTypeClass const C6(INFANTRY_C6,         // Infantry type number.
                                   false,               // Is this a female type?
                                   false,               // Is a leader type?
                                   false,               // Has crawling animation frames?
-                                  true,                // Is this a civlian?
+                                  true,                // Is this a civilian?
                                   true,                // Always use the given name for the infantry?
                                   true,                // Is this a "fraidycat" run-away type infantry?
                                   false,               // Can this infantry type capture a building?
@@ -995,7 +995,7 @@ static InfantryTypeClass const C7(INFANTRY_C7,         // Infantry type number.
                                   false,               // Is this a female type?
                                   true,                // Is a leader type?
                                   false,               // Has crawling animation frames?
-                                  true,                // Is this a civlian?
+                                  true,                // Is this a civilian?
                                   true,                // Always use the given name for the infantry?
                                   true,                // Is this a "fraidycat" run-away type infantry?
                                   false,               // Can this infantry type capture a building?
@@ -1062,7 +1062,7 @@ static InfantryTypeClass const C8(INFANTRY_C8,         // Infantry type number.
                                   false,               // Is this a female type?
                                   false,               // Is a leader type?
                                   false,               // Has crawling animation frames?
-                                  true,                // Is this a civlian?
+                                  true,                // Is this a civilian?
                                   true,                // Always use the given name for the infantry?
                                   true,                // Is this a "fraidycat" run-away type infantry?
                                   false,               // Can this infantry type capture a building?
@@ -1129,7 +1129,7 @@ static InfantryTypeClass const C9(INFANTRY_C9,         // Infantry type number.
                                   false,               // Is this a female type?
                                   false,               // Is a leader type?
                                   false,               // Has crawling animation frames?
-                                  true,                // Is this a civlian?
+                                  true,                // Is this a civilian?
                                   true,                // Always use the given name for the infantry?
                                   true,                // Is this a "fraidycat" run-away type infantry?
                                   false,               // Can this infantry type capture a building?
@@ -1198,7 +1198,7 @@ static InfantryTypeClass const C10(INFANTRY_C10,       // Infantry type number.
                                    false,              // Is this a female type?
                                    false,              // Is a leader type?
                                    false,              // Has crawling animation frames?
-                                   true,               // Is this a civlian?
+                                   true,               // Is this a civilian?
                                    true,               // Always use the given name for the infantry?
                                    true,               // Is this a "fraidycat" run-away type infantry?
                                    false,              // Can this infantry type capture a building?
@@ -1265,7 +1265,7 @@ static InfantryTypeClass const Moebius(INFANTRY_MOEBIUS,  // Infantry type numbe
                                        false,             // Is this a female type?
                                        false,             // Is a leader type?
                                        false,             // Has crawling animation frames?
-                                       true,              // Is this a civlian?
+                                       true,              // Is this a civilian?
                                        true,              // Always use the given name for the infantry?
                                        true,              // Is this a "fraidycat" run-away type infantry?
                                        false,             // Can this infantry type capture a building?
@@ -1332,7 +1332,7 @@ static InfantryTypeClass const Delphi(INFANTRY_DELPHI,  // Infantry type number.
                                       false,            // Is this a female type?
                                       false,            // Is a leader type?
                                       false,            // Has crawling animation frames?
-                                      true,             // Is this a civlian?
+                                      true,             // Is this a civilian?
                                       true,             // Always use the given name for the infantry?
                                       true,             // Is this a "fraidycat" run-away type infantry?
                                       false,            // Can this infantry type capture a building?
@@ -1399,7 +1399,7 @@ static InfantryTypeClass const DrChan(INFANTRY_CHAN,    // Infantry type number.
                                       false,            // Is this a female type?
                                       false,            // Is a leader type?
                                       false,            // Has crawling animation frames?
-                                      true,             // Is this a civlian?
+                                      true,             // Is this a civilian?
                                       true,             // Always use the given name for the infantry?
                                       true,             // Is this a "fraidycat" run-away type infantry?
                                       false,            // Can this infantry type capture a building?
@@ -1896,7 +1896,7 @@ void InfantryTypeClass::One_Time(void)
 }
 
 /***********************************************************************************************
- * ITC::Init -- load up terrain set dependant sidebar icons                                    *
+ * ITC::Init -- load up terrain set dependent sidebar icons                                    *
  *                                                                                             *
  *                                                                                             *
  *                                                                                             *
@@ -1947,7 +1947,7 @@ void InfantryTypeClass::Init(TheaterType theater)
  *                                                                                             *
  * INPUT:   intheory -- If no regard is to be given to whether the construction building is    *
  *                      currently busy, then this flag should be true. In such a case, only    *
- *                      the existance of the building is sufficient to achieve success.        *
+ *                      the existence of the building is sufficient to achieve success.        *
  *                                                                                             *
  *          legal    -- Should building prerequisite legality checks be performed as well?     *
  *                      For building placements, this is usually false. For sidebar button     *

--- a/tiberiandawn/infantry.cpp
+++ b/tiberiandawn/infantry.cpp
@@ -260,7 +260,7 @@ InfantryClass::InfantryClass(InfantryType classid, HousesType house)
     Ammo = Class->MaxAmmo;
 
     /*
-    ** Keep count of the number of units created. Dont track civilians.
+    ** Keep count of the number of units created. Don't track civilians.
     */
     if (!Class->IsCivilian && GameToPlay == GAME_INTERNET) {
         House->InfantryTotals.Increment_Unit_Total((int)classid);
@@ -1077,7 +1077,7 @@ void InfantryClass::AI(void)
     if (Fear) {
 
         /*
-        **	Nikumba is really a coward at heart. He never becomes un-afraid.
+        **	Nikoomba is really a coward at heart. He never becomes un-afraid.
         */
         if (*this != INFANTRY_C10) {
             Fear--;
@@ -1695,7 +1695,7 @@ MoveType InfantryClass::Can_Enter_Cell(CELL cell, FacingType) const
                     if (!obj->Is_Techno() || !((TechnoClass*)obj)->Is_Cloaked(this)) {
 
                         /*
-                        **	Any non-allied blockage is considered impassible if the infantry
+                        **	Any non-allied blockage is considered impassable if the infantry
                         **	is not equipped with a weapon.
                         */
                         if (Class->Primary == WEAPON_NONE)
@@ -1739,7 +1739,7 @@ MoveType InfantryClass::Can_Enter_Cell(CELL cell, FacingType) const
     }
 
     /*
-    **	If foot soldiers cannot travel on the cell -- consider it impassible.
+    **	If foot soldiers cannot travel on the cell -- consider it impassable.
     */
     if (retval == MOVE_OK && !IsTethered && !Ground[cellptr->Land_Type()].Cost[SPEED_FOOT]) {
         return (MOVE_NO);
@@ -2541,7 +2541,7 @@ TARGET InfantryClass::Greatest_Threat(ThreatType threat) const
         break; // Added. ST - 4/24/2019 11:02AM
 
     /*
-    **	Dragon missile equiped soldiers are also assumed to carry a Stinger missile. As such,
+    **	Dragon missile equipped soldiers are also assumed to carry a Stinger missile. As such,
     **	they will consider aircraft a legal target.
     */
     default:

--- a/tiberiandawn/infantry.h
+++ b/tiberiandawn/infantry.h
@@ -64,7 +64,7 @@ public:
 
     /*
     **	Certain infantry will either perform some comment or say something after an
-    **	amount of time has expired subsiquent to an significant event. This is the
+    **	amount of time has expired subsequent to an significant event. This is the
     **	timer the counts down.
     */
     TCountDownTimerClass Comment;

--- a/tiberiandawn/init.cpp
+++ b/tiberiandawn/init.cpp
@@ -166,7 +166,7 @@ bool Init_Game(int, char*[])
     Set_Shape_Buffer(new unsigned char[SHAPE_BUFFER_SIZE], SHAPE_BUFFER_SIZE);
 
     /*
-    **	Bootstrap enough of the system so that the error dialog box can sucessfully
+    **	Bootstrap enough of the system so that the error dialog box can successfully
     **	be displayed.
     */
     CCDebugString("C&C95 - About to register CCLOCAL.MIX\n");
@@ -182,7 +182,7 @@ bool Init_Game(int, char*[])
 
         /*
         ** On low resolution mode, we want to load the DOS version fonts present in LOCAL.MIX.
-        ** Load it first and and find the fonts there. Else, on high resolution, use
+        ** Load it first and find the fonts there. Else, on high resolution, use
         ** Windows CCLOCAL.MIX
         */
 
@@ -441,7 +441,7 @@ bool Init_Game(int, char*[])
 
     /*
     **	These are sound card specific, but the install program would have
-    **	copied the coorect versions to the hard drive.
+    **	copied the correct versions to the hard drive.
     */
     CCDebugString("C&C95 - About to register SPEECH.MIX\n");
     if (CCFileClass("SPEECH.MIX").Is_Available()) {
@@ -783,7 +783,7 @@ bool Select_Game(bool fade)
         ScenarioInit--;
 
         /*
-        ** If we're playing back a recording, load all pertinant values & skip
+        ** If we're playing back a recording, load all pertinent values & skip
         ** the menu loop.  Hide the now-useless mouse pointer.
         */
         if (PlaybackGame && RecordFile.Is_Available()) {
@@ -1101,7 +1101,7 @@ bool Select_Game(bool fade)
 
 #ifdef FORCE_WINSOCK
                 /*
-                ** Handle being spawned from WChat. Intermnet play based on IPX code now.
+                ** Handle being spawned from WChat. Internet play based on IPX code now.
                 */
                 case GAME_INTERNET:
                     break;
@@ -1178,7 +1178,7 @@ bool Select_Game(bool fade)
                 Play_Intro(false);
                 Hide_Mouse();
 
-                // verify existance of movie file before playing this sequence.
+                // verify existence of movie file before playing this sequence.
                 if (CCFileClass("TRAILER.VQA").Is_Available()) {
                     Fade_Palette_To(BlackPalette, FADE_PALETTE_MEDIUM, Call_Back);
                     VisiblePage.Clear();
@@ -1445,7 +1445,7 @@ bool Select_Game(bool fade)
     Call_Back();
 
     /*
-    ** This is desperately sad isnt it?
+    ** This is desperately sad isn't it?
     */
     Hide_Mouse();
     Hide_Mouse();
@@ -1724,7 +1724,7 @@ bool Parse_Command_Line(int argc, char* argv[])
                  "  -SOCKET   = Network Socket ID (0 - 16383)\n"
                  "  -STEALTH  = Hide multiplayer names (\"Boss mode\")\r\n"
                  "  -MESSAGES = Allow messages from outside this game.\r\n"
-                 "  -o        = Enable compatability with version 1.07.\r\n"
+                 "  -o        = Enable compatibility with version 1.07.\r\n"
 #ifdef JAPANESE
                  "  -ENGLISH  = Enable English keyboard compatibility.\r\n"
 #endif
@@ -1739,7 +1739,7 @@ bool Parse_Command_Line(int argc, char* argv[])
                  "     E : Elite defense mode disable (attacker advantage).\r\n"
                  "     D : Deploy reversal allowed for construction yard.\r\n"
                  "     F : Fleeing from direct immediate threats is enabled.\r\n"
-                 "     H : Hussled recharge time.\r\n"
+                 "     H : Hustled recharge time.\r\n"
                  "     G : Growth for Tiberium slowed in multiplay.\r\n"
                  "     I : Inert weapons -- no damage occurs.\r\n"
                  "     J : 7th grade sound effects.\r\n"
@@ -2048,7 +2048,7 @@ bool Parse_Command_Line(int argc, char* argv[])
 
 #ifdef CHEAT_KEYS
                 /*
-                **	Hussled recharge timer.
+                **	Hustled recharge timer.
                 */
                 case 'H':
                     Special.IsSpeedBuild = true;
@@ -2263,7 +2263,7 @@ int Version_Number(void)
  * Init_CDROM_Access -- Initialize the CD-ROM access handler.                                  *
  *                                                                                             *
  *    This routine is called to setup the CD-ROM access or emulation handler. It will ensure   *
- *    that the appropriate CD-ROM is present (dependant on the RequiredCD global).             *
+ *    that the appropriate CD-ROM is present (dependent on the RequiredCD global).             *
  *                                                                                             *
  * INPUT:   none                                                                               *
  *                                                                                             *
@@ -2467,7 +2467,7 @@ long Obfuscate(char const* string)
 
     /*
     **	Transform the buffer into a number. This transformation is character
-    **	order dependant.
+    **	order dependent.
     */
     long code = Calculate_CRC(buffer, length);
 

--- a/tiberiandawn/jshell.cpp
+++ b/tiberiandawn/jshell.cpp
@@ -50,7 +50,7 @@
  * Small_Icon -- Create a small icon from a big one.                                           *
  *                                                                                             *
  *    This routine will extract the specified icon from the icon data file and convert that    *
- *    incon into a small (3x3) representation. Typicall use of this mini-icon is for the radar *
+ *    icon into a small (3x3) representation. Typical use of this mini-icon is for the radar   *
  *    map.                                                                                     *
  *                                                                                             *
  * INPUT:   iconptr  -- Pointer to the icon data file.                                         *

--- a/tiberiandawn/list.cpp
+++ b/tiberiandawn/list.cpp
@@ -559,7 +559,7 @@ int ListClass::Add_Scroll_Bar(void)
 
         /*
         **	Everything has been created successfully. Flag the list box to be
-        **	redrawn because it now must be made narrower to accomodate the new
+        **	redrawn because it now must be made narrower to accommodate the new
         **	slider gadgets.
         */
         Flag_To_Redraw();
@@ -700,13 +700,13 @@ void ListClass::Draw_Entry(int index, int x, int y, int width, int selected)
 /***********************************************************************************************
  * ListClass::Add -- Adds myself to list immediately after given object                        *
  *                                                                                             *
- * Adds the list box to the chain, immemdiately after the given object.  The order will be:    *
+ * Adds the list box to the chain, immediately after the given object.  The order will be:     *
  * - Listbox                                                                                   *
  * - Up arrow (if active)                                                                      *
  * - Down arrow (if active)                                                                    *
  * - Scroll gadget (if active)                                                                 *
- *                                                                                             * * INPUT:   object   --
- *Pointer to the object to be added right after this one.                *
+ *                                                                                             *
+ * INPUT:   object   -- Pointer to the object to be added right after this one.                *
  *                                                                                             *
  * OUTPUT:  Returns with a pointer to the head of the list.                                    *
  *                                                                                             *

--- a/tiberiandawn/loaddlg.cpp
+++ b/tiberiandawn/loaddlg.cpp
@@ -463,7 +463,7 @@ int LoadOptionsClass::Process(void)
             break;
 
         /*
-        ** If the user clicks on the list, see if the there is a new current
+        ** If the user clicks on the list, see if there is a new current
         ** item; if so, and if we're in SAVE mode, copy the list item into
         ** the save-game description field.
         */

--- a/tiberiandawn/mission.cpp
+++ b/tiberiandawn/mission.cpp
@@ -38,8 +38,8 @@
  *   MissionClass::MissionClass -- Default constructor for the mission object type.            *
  *   MissionClass::Mission_From_Name -- Fetch order pointer from its name.                     *
  *   MissionClass::Mission_Name -- Converts a mission number into an ASCII string.             *
- *   MissionClass::Overide_Mission -- temporarily overides the units mission                   *
- *   MissionClass::Restore_Mission -- Restores overidden mission                               *
+ *   MissionClass::Overide_Mission -- temporarily overrides the units mission                  *
+ *   MissionClass::Restore_Mission -- Restores overridden mission                              *
  *   MissionClass::Set_Mission -- Sets the mission to the specified value.                     *
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
@@ -442,17 +442,17 @@ char const* MissionClass::Mission_Name(MissionType mission)
 }
 
 /***********************************************************************************************
- * MissionClass::Override_Mission -- temporarily overides the units mission                    *
+ * MissionClass::Override_Mission -- temporarily overrides the units mission                   *
  *                                                                                             *
  *                                                                                             *
  *                                                                                             *
- * INPUT:      MissionType mission - the mission we want to overide                            *
- *               TARGET      tarcom  - the new target we want to overide                       *
- *               TARGET      navcom  - the new navigation point to overide                     *
+ * INPUT:      MissionType mission - the mission we want to override                           *
+ *               TARGET      tarcom  - the new target we want to override                      *
+ *               TARGET      navcom  - the new navigation point to override                    *
  *                                                                                             *
  * OUTPUT:      none                                                                           *
  *                                                                                             *
- * WARNINGS:   If a mission is already overidden, the current mission is                       *
+ * WARNINGS:   If a mission is already overridden, the current mission is                      *
  *               just re-assigned.                                                             *
  *                                                                                             *
  * HISTORY:                                                                                    *
@@ -470,7 +470,7 @@ void MissionClass::Override_Mission(MissionType mission, TARGET, TARGET)
 }
 
 /***********************************************************************************************
- * MissionClass::Restore_Mission -- Restores overidden mission                                 *
+ * MissionClass::Restore_Mission -- Restores overridden mission                                *
  *                                                                                             *
  * INPUT:      none                                                                            *
  *                                                                                             *

--- a/tiberiandawn/monoc.h
+++ b/tiberiandawn/monoc.h
@@ -182,7 +182,7 @@ private:
     static void* MonoSegment;
 
     /*
-    ** This the the arrays of characters used for drawing boxes.
+    ** These are the arrays of characters used for drawing boxes.
     */
     static BoxDataType const CharData[4];
 

--- a/tiberiandawn/msglist.cpp
+++ b/tiberiandawn/msglist.cpp
@@ -226,7 +226,7 @@ TextLabelClass* MessageListClass::Add_Message(char* txt,
         txtlabel = MessageList;
         while (txtlabel) {
             /*
-            ** Dont check for duplicates in multi-segment strings
+            ** Don't check for duplicates in multi-segment strings
             */
             if (!txtlabel->Segments) {
                 if (!strcmp(txtlabel->Text, txt) && txtlabel->Color == color && txtlabel->Style == style) {

--- a/tiberiandawn/netdlg.cpp
+++ b/tiberiandawn/netdlg.cpp
@@ -2417,7 +2417,7 @@ Get_Join_Responses(JoinStateType* joinstate, ListClass* gamelist, ColorListClass
             found = 1;
 
         /*
-        ** Dont add this player if its really me! (hack, hack)
+        ** Don't add this player if its really me! (hack, hack)
         */
         if (!strcmp(GPacket.Name, MPlayerName)) {
             found = 1;

--- a/tiberiandawn/object.cpp
+++ b/tiberiandawn/object.cpp
@@ -32,7 +32,7 @@
  * Functions:                                                                                  *
  *   ObjectClass::Debug_Dump -- Displays status of the object class to the mono monitor.       *
  *   ObjectClass::Detach_All -- Removes the object from all tracking systems.                  *
- *   ObjectClass::Detach_This_From_All -- Detatches this object from all others.               *
+ *   ObjectClass::Detach_This_From_All -- Detaches this object from all others.                *
  *   ObjectClass::Fire_Out -- Informs object that attached animation has finished.             *
  *   ObjectClass::Get_Mission -- Fetches the current mission of this object.                   *
  *   ObjectClass::Init -- Initializes the basic object system.                                 *
@@ -52,7 +52,7 @@
  *   ObjectClass::Unlimbo -- Brings the object into the game system.                           *
  *   ObjectClass::Unselect -- This will un-select the object if it was selected.               *
  *   ObjectClass::Value -- Fetches the target value of this object.                            *
- *   ObjectClass::What_Action -- Deteremines what action to perform on specified object.       *
+ *   ObjectClass::What_Action -- Determines what action to perform on specified object.        *
  *   ObjectClass::What_Am_I -- RTTI query of this object type.                                 *
  *   ObjectTypeClass::Cost_Of -- Returns the cost to buy this unit.                            *
  *   ObjectTypeClass::Dimensions -- Gets the dimensions of the object in pixels.               *
@@ -300,7 +300,7 @@ ObjectClass::ObjectClass(void)
  *                                                                                             *
  * INPUT:   none                                                                               *
  *                                                                                             *
- * OUTPUT:  Returns with the RTTI value that coresponds to the object's type.                  *
+ * OUTPUT:  Returns with the RTTI value that corresponds to the object's type.                 *
  *                                                                                             *
  * WARNINGS:   none                                                                            *
  *                                                                                             *
@@ -313,7 +313,7 @@ RTTIType ObjectClass::What_Am_I(void) const
 }
 
 /***********************************************************************************************
- * ObjectClass::What_Action -- Deteremines what action to perform on specified object.         *
+ * ObjectClass::What_Action -- Determines what action to perform on specified object.          *
  *                                                                                             *
  *    This routine will return that action that this object could perform if the mouse were    *
  *    clicked over the object specified.                                                       *
@@ -1245,7 +1245,7 @@ void ObjectClass::Detach_All(bool all)
     //	Unselect();
     //}
 
-    // Added some error handling incase there was an issue removing the object - JAS 6/28/2019
+    // Added some error handling in case there was an issue removing the object - JAS 6/28/2019
     if (all) {
         // Unselect();
         // Updated to function for multiplayer - 6/28/2019 JAS
@@ -1264,7 +1264,7 @@ void ObjectClass::Detach_All(bool all)
 }
 
 /***********************************************************************************************
- * ObjectClass::Detach_This_From_All -- Detatches this object from all others.                 *
+ * ObjectClass::Detach_This_From_All -- Detaches this object from all others.                  *
  *                                                                                             *
  *    This routine sweeps through all game objects and makes sure that it is no longer         *
  *    referenced by them. Typically, this is called in preparation for the object's death      *

--- a/tiberiandawn/session.h
+++ b/tiberiandawn/session.h
@@ -176,7 +176,7 @@ typedef enum SerialCommandType
     SERIAL_SIGN_OFF = 102,     // Bogus, dudes, my boss is coming; I'm outta here!
     SERIAL_GO = 103,           // OK, dudes, jump into the game loop!
     SERIAL_MESSAGE = 104,      // Here's a message
-    SERIAL_TIMING = 105,       // timimg packet
+    SERIAL_TIMING = 105,       // timing packet
     SERIAL_SCORE_SCREEN = 106, // player at score screen
     SERIAL_LOADGAME = 107,     // Start the game, loading a saved game first
     SERIAL_LAST_COMMAND        // last command

--- a/tiberiandawn/sidebar.cpp
+++ b/tiberiandawn/sidebar.cpp
@@ -220,7 +220,7 @@ void SidebarClass::One_Time(void)
     Column[1].One_Time(1);
 
     /*
-    **	Load the sidebar shape in at this time. (Hi-Res sidebar is theater dependant)
+    **	Load the sidebar shape in at this time. (Hi-Res sidebar is theater dependent)
     */
     if (SidebarShape1 == NULL) {
         SidebarShape1 = Hires_Retrieve("SIDE1.SHP");
@@ -1383,7 +1383,7 @@ void SidebarClass::StripClass::Deactivate(void)
  *          ptr2  -- Pointer to the second sidebar class object.                               *
  *                                                                                             *
  * OUTPUT:  Returns <0 if the first object can be produced before the second. It returns       *
- *          >0 if the reverse is true. It returns exactly 0 if the production scneario for     *
+ *          >0 if the reverse is true. It returns exactly 0 if the production scenario for     *
  *          both objects is the same.                                                          *
  *                                                                                             *
  * WARNINGS:   none                                                                            *

--- a/tiberiandawn/startup.cpp
+++ b/tiberiandawn/startup.cpp
@@ -247,7 +247,7 @@ int main(int argc, char** argv)
         Check_Use_Compressed_Shapes();
 
         /*
-        ** If there is not enough disk space free, dont allow the product to run.
+        ** If there is not enough disk space free, don't allow the product to run.
         */
         if (Disk_Space_Available() < INIT_FREE_DISK_SPACE) {
 #if (0) // PG

--- a/tiberiandawn/stats.cpp
+++ b/tiberiandawn/stats.cpp
@@ -598,7 +598,7 @@ void Send_Statistics_Packet(void)
         CCDebugString("C&C95 - Returned from Create_Comms_Packet.\n");
 
         /*
-        ** If a player disconnected then dont send the packet at this time - save it for later
+        ** If a player disconnected then don't send the packet at this time - save it for later
         */
         if (completion == COMPLETION_PLAYER_1_WON_BY_DISCONNECTION
             || completion == COMPLETION_PLAYER_2_WON_BY_DISCONNECTION) {

--- a/tiberiandawn/target.cpp
+++ b/tiberiandawn/target.cpp
@@ -370,7 +370,7 @@ BuildingClass* As_Building(TARGET target, bool check_active)
  * Target_Legal -- Determines if the specified target is legal.                                *
  *                                                                                             *
  *    This routine is used to check for the legality of the target value specified. It is      *
- *    necessary to call this routine if there is doubt about the the legality of the target.   *
+ *    necessary to call this routine if there is doubt about the legality of the target.       *
  *    It is possible for the unit that a target value represents to be eliminated and thus     *
  *    rendering the target value invalid.                                                      *
  *                                                                                             *

--- a/tiberiandawn/team.cpp
+++ b/tiberiandawn/team.cpp
@@ -55,7 +55,7 @@
 #include "mission.h"
 
 /*
-**	This array records the number of teams in existance of each type.
+**	This array records the number of teams in existence of each type.
 */
 unsigned char TeamClass::Number[TEAMTYPE_MAX];
 
@@ -230,7 +230,7 @@ void TeamClass::Assign_Mission_Target(TARGET new_target)
     /*
     **	If there is not currently an override on the current mission target
     ** then assign both MissionTarget and Target to the new target.  If
-    ** there is an overide, allow the team to keep fighting the overide but
+    ** there is an override, allow the team to keep fighting the override but
     ** make sure they pick up on the new mission when they are ready.
     */
     if (Target == MissionTarget || !Target_Legal(Target)) {
@@ -837,7 +837,7 @@ bool TeamClass::Remove(FootClass* obj, int typeindex)
  *                                                                                             *
  *    This routine will take the given index ID and scan for available objects of that type    *
  *    to recruit to the team. Recruiting will continue until that object type has either       *
- *    been exhausted or if the team's requirment for that type has been filled.                *
+ *    been exhausted or if the team's requirement for that type has been filled.               *
  *                                                                                             *
  * INPUT:   typeindex   -- The index for the object type to recruit. The index is used to      *
  *                         look into the type type's array of object types that make up this   *
@@ -943,7 +943,7 @@ void TeamClass::Detach(TARGET target, bool)
     Validate();
 
     /*
-    **	If the target to detatch matches the target of this team, then remove
+    **	If the target to detach matches the target of this team, then remove
     **	the target from this team's Tar/Nav com and let the chips fall
     **	where they may.
     */
@@ -1275,7 +1275,7 @@ void TeamClass::Coordinate_Move(void)
 }
 
 /***************************************************************************
- * Lagging_Units -- processes units that cant keep up with the pack        *
+ * Lagging_Units -- processes units that can't keep up with the pack       *
  *                                                                         *
  * INPUT:      none                                                        *
  *                                                                         *

--- a/tiberiandawn/techno.cpp
+++ b/tiberiandawn/techno.cpp
@@ -2893,17 +2893,17 @@ int TechnoClass::Weapon_Range(int which) const
 }
 
 /***************************************************************************
- * TechnoClass::Override_Mission -- temporarily overides a units mission   *
+ * TechnoClass::Override_Mission -- temporarily overrides a units mission  *
  *                                                                         *
  *                                                                         *
  *                                                                         *
- * INPUT:      MissionType mission - the mission we want to overide        *
- *               TARGET      tarcom  - the new target we want to overide   *
- *               TARGET      navcom  - the new navigation point to overide *
+ * INPUT:      MissionType mission - the mission we want to override       *
+ *               TARGET      tarcom  - the new target we want to override  *
+ *               TARGET      navcom  - the new navigation point to override*
  *                                                                         *
  * OUTPUT:      none                                                       *
  *                                                                         *
- * WARNINGS:   If a mission is already overidden, the current mission is   *
+ * WARNINGS:   If a mission is already overridden, the current mission is  *
  *               just re-assigned.                                         *
  *                                                                         *
  * HISTORY:                                                                *
@@ -2917,7 +2917,7 @@ void TechnoClass::Override_Mission(MissionType mission, TARGET tarcom, TARGET na
 }
 
 /***************************************************************************
- * TechnoClass::Restore_Mission -- Restores an overidden mission           *
+ * TechnoClass::Restore_Mission -- Restores an overridden mission          *
  *                                                                         *
  * INPUT:		none                                                        *
  *                                                                         *
@@ -3093,7 +3093,7 @@ ResultType TechnoClass::Take_Damage(int& damage, int distance, WarheadType warhe
  * TechnoTypeClass::Max_Passengers -- Fetches the maximum passengers allowed.                  *
  *                                                                                             *
  *    This routine will return with the maximum number of passengers allowed in this           *
- *    transport. This typically applies to APCs and possibley transport helicopters.           *
+ *    transport. This typically applies to APCs and possibly transport helicopters.            *
  *                                                                                             *
  * INPUT:   none                                                                               *
  *                                                                                             *
@@ -4407,7 +4407,7 @@ void TechnoClass::Enter_Idle_Mode(bool)
  *    used for transporter object. It will also display if the techno object is "primary"      *
  *    if necessary.                                                                            *
  *                                                                                             *
- * INPUT:   x,y   -- The pixel coordinate for the center of the first pip. Subsiquent pips     *
+ * INPUT:   x,y   -- The pixel coordinate for the center of the first pip. Subsequent pips     *
  *                   are drawn rightward.                                                      *
  *                                                                                             *
  *          window-- The window that pip clipping is relative to.                              *

--- a/tiberiandawn/terrain.cpp
+++ b/tiberiandawn/terrain.cpp
@@ -411,7 +411,7 @@ void TerrainClass::Init(void)
 /***********************************************************************************************
  * TerrainClass::Can_Enter_Cell -- Determines if the terrain object can exist in the cell.     *
  *                                                                                             *
- *    This routine will examine the cell specified and determine if the the terrain object     *
+ *    This routine will examine the cell specified and determine if the terrain object         *
  *    can legally exist there.                                                                 *
  *                                                                                             *
  * INPUT:   cell  -- The cell to examine.                                                      *

--- a/tiberiandawn/trigger.cpp
+++ b/tiberiandawn/trigger.cpp
@@ -722,7 +722,7 @@ bool TriggerClass::Spring(EventType event, CELL cell)
  * TriggerClass::Spring -- Trigger processing routine                                          *
  *                                                                                             *
  * This version of Spring is for house-specific triggers.                                      *
- * For a time-based trigger, 'data' will the the current WinTickCount.                         *
+ * For a time-based trigger, 'data' will be the current WinTickCount.                          *
  * For a credit-based trigger, 'data' will be the credits for the HouseClass                   *
  * containing this trigger.                                                                    *
  *                                                                                             *

--- a/tiberiandawn/type.h
+++ b/tiberiandawn/type.h
@@ -120,7 +120,7 @@ public:
     bool IsTiberiumDestroyer;
 
     /*
-    **	The warhead damage is reduced depending on the the type of armor the
+    **	The warhead damage is reduced depending on the type of armor the
     **	defender has. This table is what gives weapons their "character".
     */
     unsigned Modifier[ARMOR_COUNT];
@@ -274,7 +274,7 @@ public:
 };
 
 /***************************************************************************
-**	This the the common base class of game objects. Since these values
+**	This is the common base class of game objects. Since these values
 **	represent the unchanging object TYPES, this data is initialized at game
 **	start and not changed during play. It is "const" data.
 */
@@ -464,7 +464,7 @@ public:
     /*
     **	Is this object possible to be constructed?  Certain buildings and units cannot
     **	be constructed using normal means. They are either initially placed in the scenario
-    **	or can only arrive by pre arranged reinforcement scheduling. Civilian buildings and
+    **	or can only arrive by prearranged reinforcement scheduling. Civilian buildings and
     **	vehicles are typical examples of this type of object. They would set this flag to
     **	false.
     */
@@ -473,13 +473,13 @@ public:
     /*
     **	Does this object contain a crew?  If it does, then when the object is destroyed, there
     **	is a distinct possibility that infantry will "pop out". Only units with crews can
-    **	become "heros".
+    **	become "heroes".
     */
     unsigned IsCrew : 1;
 
     /*
     **	Is this object typically used to transport reinforcements or other cargo?
-    **	Transport aircraft, helicopters, and hovercraft are typicall examples of
+    **	Transport aircraft, helicopters, and hovercraft are typical examples of
     **	this.
     */
     unsigned IsTransporter : 1;
@@ -618,7 +618,7 @@ class BuildingTypeClass : public TechnoTypeClass
 
 public:
     /*
-    **	This flag controls whether the building is equiped with a dirt
+    **	This flag controls whether the building is equipped with a dirt
     **	bib or not. A building with a bib has a dirt patch automatically
     **	attached to the structure when it is placed.
     */
@@ -1685,7 +1685,7 @@ public:
     **	This is the frame that the animation is biggest. The biggest frame of animation
     **	will hide any changes to underlying ground (e.g., craters) that the animation
     **	causes, so these effects are delayed until this frame is reached. The end result
-    **	is to prevent the player from seeing craters "pop" into existance.
+    **	is to prevent the player from seeing craters "pop" into existence.
     */
     int Biggest;
 

--- a/tiberiandawn/unit.cpp
+++ b/tiberiandawn/unit.cpp
@@ -2209,7 +2209,7 @@ void UnitClass::Draw_It(int x, int y, WindowNumberType window)
             shapenum = TechnoClass::BodyShape[tfacing] + 32;
 
             /*
-            **	The shape to use for the rocket launcher is dependant on the
+            **	The shape to use for the rocket launcher is dependent on the
             **	ammo remaining.
             */
             if (*this == UNIT_MSAM) {
@@ -3227,13 +3227,13 @@ MoveType UnitClass::Can_Enter_Cell(CELL cell, FacingType) const
 
                     /*
                     **	If this unit can crush infantry, and there is an enemy infantry in the
-                    **	cell, don't consider the cell impassible. This is true even if the unit
+                    **	cell, don't consider the cell impassable. This is true even if the unit
                     **	doesn't contain a legitimate weapon.
                     */
                     if (!Class->IsCrusher || !obj->Class_Of().IsCrushable) {
 
                         /*
-                        **	Any non-allied blockage is considered impassible if the unit
+                        **	Any non-allied blockage is considered impassable if the unit
                         **	is not equipped with a weapon.
                         */
                         if (Class->Primary == WEAPON_NONE)
@@ -3469,7 +3469,7 @@ bool UnitClass::Stop_Driver(void)
         int temp = IsDown;
 
         /*
-        ** If the vehicle is down, pick it up so it doesnt interfere with
+        ** If the vehicle is down, pick it up so it doesn't interfere with
         ** our flags.
         */
         if (temp) {


### PR DESCRIPTION
The pull request fixes a lot of typos (mostly in typos, but one or two are in strings). Confusingly, the term "passible" has nothing to do with being able to pass or be passed, but rather refers to being able to experience emotion.

Various notes:
In `redalert/monoc.h`, the misplaced comment for `CharData[]` has been moved to be above it.
In `tiberiandawn/list.cpp` and `redalert/list.cpp`, `ListClass::Add`'s obviously broken comment box has been fixed.
In `tiberiandawn/init.cpp`, two typos in strings have been fixed in `Parse_Command_Line`.
In `common/soundio_openal.cpp`, a typo in a string was fixed in `Get_OpenAL_Error`.
In `redalert/scenario.cpp`, the line for `buf` has been removed from the comment box for `Set_Scenario_Name` since that argument was removed from the function itself.