### PR TITLE
Avoid structure padding in the PCX read/write code

### DIFF
--- a/common/filepcx.h
+++ b/common/filepcx.h
@@ -41,6 +41,8 @@
 #ifndef PCX_H
 #define PCX_H
 
+#pragma pack(push, 1)
+
 typedef struct
 {
     unsigned char red;
@@ -67,6 +69,8 @@ typedef struct
     short palette_type;
     char filler[58];
 } PCX_HEADER;
+
+#pragma pack(pop)
 
 class GraphicBufferClass;
 

--- a/common/keyframe.cpp
+++ b/common/keyframe.cpp
@@ -47,6 +47,8 @@
 
 #define Apply_Delta(buffer, delta) Apply_XOR_Delta((char*)(buffer), (char*)(delta))
 
+#pragma pack(push, 1)
+
 typedef struct
 {
     unsigned short frames;
@@ -57,6 +59,8 @@ typedef struct
     unsigned short largest_frame_size;
     short flags;
 } KeyFrameHeaderType;
+
+#pragma pack(pop)
 
 #define INITIAL_BIG_SHAPE_BUFFER_SIZE 12000 * 1024
 #define THEATER_BIG_SHAPE_BUFFER_SIZE 2000 * 1024


### PR DESCRIPTION
On RISC OS, as well as with some other older ARM toolchains, structures are padded for alignment, however the PCX code expects these structures to be a specific size.