### PR TITLE
Fixes RawFile::Open returning true if fopen returns null.

### DIFF
--- a/common/bfiofile.cpp
+++ b/common/bfiofile.cpp
@@ -543,7 +543,7 @@ int BufferIOFileClass::Open(int rights)
         FilePos = 0;
         IsOpen = true;
     } else {
-        RawFileClass::Open(rights);
+        return RawFileClass::Open(rights);
     }
 
     return (true);

--- a/common/rawfile.cpp
+++ b/common/rawfile.cpp
@@ -288,6 +288,7 @@ int RawFileClass::Open(int rights)
         */
         if (Handle == nullptr) {
             Error(errno, false, Filename);
+            return (false);
         }
         break;
     }


### PR DESCRIPTION
Really fixes the issue with crashing on the repair pad when the DOS audio file for the EVA announcement is missing this time.