### PR TITLE
Fix template expansion explosion in MixFileClass

### DIFF
--- a/common/mixfile.cpp
+++ b/common/mixfile.cpp
@@ -47,3 +47,9 @@
 #include "ccfile.h"
 
 template class MixFileClass<CCFileClass>;
+
+/*
+**	This is the pointer to the first mixfile in the list of mixfiles registered
+**	with the mixfile system.
+*/
+template <class T, class TCRC> List<MixFileClass<T, TCRC>> MixFileClass<T, TCRC>::MixList;

--- a/common/mixfile.h
+++ b/common/mixfile.h
@@ -161,12 +161,6 @@ private:
     static List<MixFileClass<T, TCRC>> MixList;
 };
 
-/*
-**	This is the pointer to the first mixfile in the list of mixfiles registered
-**	with the mixfile system.
-*/
-template <class T, class TCRC> List<MixFileClass<T, TCRC>> MixFileClass<T, TCRC>::MixList;
-
 /***********************************************************************************************
  * MixFileClass::Free -- Uncaches a cached mixfile.                                            *
  *                                                                                             *

--- a/tools/mixtool/makemix.cpp
+++ b/tools/mixtool/makemix.cpp
@@ -39,6 +39,12 @@
 
 #include "utfargs.h"
 
+/*
+**	This is the pointer to the first mixfile in the list of mixfiles registered
+**	with the mixfile system.
+*/
+template <class T, class TCRC> List<MixFileClass<T, TCRC>> MixFileClass<T, TCRC>::MixList;
+
 void Print_Help()
 {
     char revision[12] = {0};


### PR DESCRIPTION
Previously, MixFileClass were declared in mixfile.h, which is included
in many .cpp files causing it to be expanded over and over again. This
commit fixes this problem by declaring its functions in the .cpp file
and exporting a MixFileClass<CCFileClass> instance.

Closes #777 

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>