### PR TITLE
[RA] Fixes InfantryClass::Movement_AI called after delete.

### DIFF
--- a/redalert/infantry.cpp
+++ b/redalert/infantry.cpp
@@ -3972,6 +3972,10 @@ void InfantryClass::Doing_AI(void)
  *=============================================================================================*/
 void InfantryClass::Movement_AI(void)
 {
+    if (!IsActive) {
+        return;
+    }
+
     /*
     **	Special hack check to ensure that infantry will never get stuck in a movement order if
     **	there is no place to go.


### PR DESCRIPTION
Movement_AI is called after Doing_AI which can delete the object, but doesn't check if this has occured.