### PR TITLE
320x200: Skip interpolation routines and allocations on DOSMode

### DIFF
--- a/common/interpal.cpp
+++ b/common/interpal.cpp
@@ -51,7 +51,6 @@ extern GraphicViewPortClass SeenBuff;
 
 bool InterpolationPaletteChanged = false;
 
-unsigned char PaletteInterpolationTable[SIZE_OF_PALETTE][SIZE_OF_PALETTE] = {0};
 unsigned char* InterpolationPalette = nullptr;
 
 /***********************************************************************************************
@@ -73,9 +72,9 @@ void Read_Interpolation_Palette(char const* palette_file_name)
 {
     CCFileClass palette_file(palette_file_name);
 
-    if (palette_file.Is_Available()) {
+    if (InterpolationTable && palette_file.Is_Available()) {
         palette_file.Open(READ);
-        palette_file.Read(&PaletteInterpolationTable[0][0], 256 * 256);
+        palette_file.Read(&InterpolationTable->PaletteInterpolationTable[0][0], 256 * 256);
         palette_file.Close();
         InterpolationPaletteChanged = false;
     }
@@ -100,9 +99,9 @@ void Write_Interpolation_Palette(char const* palette_file_name)
 {
     CCFileClass palette_file(palette_file_name);
 
-    if (!palette_file.Is_Available()) {
+    if (InterpolationTable && !palette_file.Is_Available()) {
         palette_file.Open(WRITE);
-        palette_file.Write(&PaletteInterpolationTable[0][0], 256 * 256);
+        palette_file.Write(&InterpolationTable->PaletteInterpolationTable[0][0], 256 * 256);
         palette_file.Close();
     }
 }
@@ -121,7 +120,6 @@ void Write_Interpolation_Palette(char const* palette_file_name)
  *=========================================================================*/
 void Create_Palette_Interpolation_Table(void)
 {
-
     // Don't think we need this. ST - 12/20/2018 2:25PM
     // Asm_Create_Palette_Interpolation_Table();
 
@@ -206,7 +204,7 @@ void Create_Palette_Interpolation_Table(void)
                 }
             }
 
-            PaletteInterpolationTable[i][j] = (unsigned char)index_of_closest_color;
+            InterpolationTable->PaletteInterpolationTable[i][j] = (unsigned char)index_of_closest_color;
         }
     }
 

--- a/common/interpal.h
+++ b/common/interpal.h
@@ -18,10 +18,8 @@
 class GraphicBufferClass;
 class GraphicViewPortClass;
 
-#define SIZE_OF_PALETTE 256
 extern unsigned char* InterpolationPalette;
 extern bool InterpolationPaletteChanged;
-extern unsigned char PaletteInterpolationTable[SIZE_OF_PALETTE][SIZE_OF_PALETTE];
 
 void Interpolate_2X_Scale(GraphicBufferClass* source,
                           GraphicViewPortClass* dest,

--- a/common/vqapalette.cpp
+++ b/common/vqapalette.cpp
@@ -46,8 +46,10 @@ void VQA_SetPalette(uint8_t* palette, int numbytes, bool slowpal)
 
     Increase_Palette_Luminance(palette, 15, 15, 15, 63);
 
-    if (PalettesRead) {
-        memcpy(PaletteInterpolationTable, InterpolatedPalettes[PaletteCounter++], sizeof(PaletteInterpolationTable));
+    if (PalettesRead && InterpolationTable) {
+        void* paletteinterpol = (void*)&InterpolationTable->PaletteInterpolationTable;
+        size_t table_size = sizeof(InterpolationTable->PaletteInterpolationTable);
+        memcpy(paletteinterpol, InterpolatedPalettes[PaletteCounter++], table_size);
     }
 
     Set_Palette(palette);

--- a/common/winasm.h
+++ b/common/winasm.h
@@ -1,6 +1,18 @@
 #ifndef WINASM_H
 #define WINASM_H
 
+#define SIZE_OF_PALETTE 256
+
+struct InterpolationTable
+{
+    unsigned char PaletteInterpolationTable[SIZE_OF_PALETTE][SIZE_OF_PALETTE];
+    unsigned char LineBuffer[1600];
+    unsigned char TopLine[1600];
+    unsigned char BottomLine[1600];
+};
+
+extern struct InterpolationTable* InterpolationTable;
+
 void Asm_Interpolate(void* src, void* dst, int src_height, int src_width, int dst_pitch);
 void Asm_Interpolate_Line_Double(void* src, void* dst, int src_height, int src_width, int dst_pitch);
 void Asm_Interpolate_Line_Interpolate(void* src, void* dst, int src_height, int src_width, int dst_pitch);

--- a/redalert/conquer.cpp
+++ b/redalert/conquer.cpp
@@ -83,6 +83,7 @@
 #include "common/vqatask.h"
 #include "common/vqaloader.h"
 #include "common/settings.h"
+#include "common/winasm.h"
 
 #ifdef MPEGMOVIE
 #ifdef MCIMPEG
@@ -2268,6 +2269,11 @@ int Load_Interpolated_Palettes(char const* filename, bool add)
     int i;
     int start_palette;
 
+    if (!InterpolationTable) {
+        /* DOSMode should not interpolate anything. Don't allocate memory.  */
+        return 0;
+    }
+
     PalettesRead = false;
     CCFileClass file(filename);
 
@@ -2315,6 +2321,11 @@ int Load_Interpolated_Palettes(char const* filename, bool add)
 
 void Free_Interpolated_Palettes(void)
 {
+    if (!InterpolationTable) {
+        /* DOSMode should not interpolate anything.  */
+        return;
+    }
+
     for (int i = 0; i < ARRAY_SIZE(InterpolatedPalettes); i++) {
         if (InterpolatedPalettes[i]) {
             free(InterpolatedPalettes[i]);

--- a/redalert/init.cpp
+++ b/redalert/init.cpp
@@ -75,6 +75,7 @@
 
 #include "ramfile.h"
 #include "common/vqaconfig.h"
+#include "common/winasm.h"
 #include "intro.h"
 
 RemapControlType SidebarScheme;
@@ -165,6 +166,7 @@ static void Load_Prolog_Page(void)
 //#include    <locale.h>
 bool Init_Game(int, char*[])
 {
+    bool dosmode = (RESFACTOR == 1);
 /*
 **	Allocate the benchmark tracking objects only if the machine and
 **	compile flags indicate.
@@ -304,6 +306,13 @@ bool Init_Game(int, char*[])
     **	Initialize the animation system.
     */
     Anim_Init();
+
+    /*
+    **>-Initialize the interpolation table
+    */
+    if (!dosmode) {
+        InterpolationTable = new struct InterpolationTable();
+    }
 
 #ifdef MPEGMOVIE // Denzil 6/15/98
     if (Using_DVD()) {
@@ -2911,5 +2920,11 @@ void Free_Heaps(void)
     if (TheaterBuffer) {
         delete TheaterBuffer;
         TheaterBuffer = NULL;
+    }
+
+    /* Deallocate the interpolation table.  */
+    if (InterpolationTable) {
+        delete InterpolationTable;
+        InterpolationTable = NULL;
     }
 }

--- a/redalert/mapsel.cpp
+++ b/redalert/mapsel.cpp
@@ -38,6 +38,7 @@
 #include "function.h"
 #include "interpal.h"
 #include "common/settings.h"
+#include "common/winasm.h"
 
 void Cycle_Call_Back_Delay(int time, PaletteClass& pal);
 extern int ControlQ;
@@ -152,8 +153,10 @@ char const* Map_Selection(void)
 
     pseudoseenbuff->Clear();
     Animate_Frame(anim, *pseudoseenbuff, 1);
-    for (int x = 0; x < 256; x++)
-        memset(&PaletteInterpolationTable[x][0], x, 256);
+    if (InterpolationTable) {
+        for (int x = 0; x < 256; x++)
+            memset(&InterpolationTable->PaletteInterpolationTable[x][0], x, 256);
+    }
     Interpolate_2X_Scale(pseudoseenbuff, &SeenBuff, NULL, 1);
 
     int frame = 1;

--- a/redalert/score.cpp
+++ b/redalert/score.cpp
@@ -49,6 +49,7 @@
 #include "common/framelimit.h"
 #include "common/wsa.h"
 #include "common/settings.h"
+#include "common/winasm.h"
 
 #define SCORETEXT_X 184
 #define SCORETEXT_Y 8
@@ -1691,8 +1692,10 @@ void Multi_Score_Presentation(void)
     */
     pseudoseenbuff->Clear();
     Animate_Frame(anim, *pseudoseenbuff, 1);
-    for (int x = 0; x < 256; x++)
-        memset(&PaletteInterpolationTable[x][0], x, 256);
+    if (InterpolationTable) {
+        for (int x = 0; x < 256; x++)
+            memset(&InterpolationTable->PaletteInterpolationTable[x][0], x, 256);
+    }
     Interpolate_2X_Scale(pseudoseenbuff, &SeenBuff, 0, Settings.Video.InterpolationMode);
     ScorePalette.Set(FADE_PALETTE_FAST, Call_Back);
 

--- a/tiberiandawn/conquer.cpp
+++ b/tiberiandawn/conquer.cpp
@@ -67,6 +67,7 @@
 #include "common/vqatask.h"
 #include "common/vqaloader.h"
 #include "common/settings.h"
+#include "common/winasm.h"
 
 #define SHAPE_TRANS 0x40
 
@@ -2036,6 +2037,11 @@ int Load_Interpolated_Palettes(char const* filename, bool add)
     int i;
     int start_palette;
 
+    if (!InterpolationTable) {
+        /* DOSMode should not interpolate anything. Don't allocate memory.  */
+        return 0;
+    }
+
     PalettesRead = false;
     CCFileClass file(filename);
 
@@ -2075,6 +2081,11 @@ int Load_Interpolated_Palettes(char const* filename, bool add)
 
 void Free_Interpolated_Palettes(void)
 {
+    if (!InterpolationTable) {
+        /* DOSMode should not interpolate anything.  */
+        return;
+    }
+
     for (int i = 0; i < ARRAY_SIZE(InterpolatedPalettes); i++) {
         if (InterpolatedPalettes[i]) {
             free(InterpolatedPalettes[i]);
@@ -2135,7 +2146,8 @@ void Play_Movie(char const* name, ThemeType theme, bool clrscrn)
         return;
     }
 
-    memset(&PaletteInterpolationTable[0][0], 0, 65536);
+    if (InterpolationTable)
+        memset(&InterpolationTable->PaletteInterpolationTable[0][0], 0, 65536);
 
     if (name) {
         char fullname[_MAX_FNAME + _MAX_EXT];

--- a/tiberiandawn/function.h
+++ b/tiberiandawn/function.h
@@ -980,7 +980,6 @@ extern unsigned char* InterpolatedPalettes[100];
 extern bool PalettesRead;
 extern unsigned PaletteCounter;
 
-extern unsigned char PaletteInterpolationTable[SIZE_OF_PALETTE][SIZE_OF_PALETTE];
 extern unsigned char* InterpolationPalette;
 
 extern void Free_Interpolated_Palettes(void);

--- a/tiberiandawn/init.cpp
+++ b/tiberiandawn/init.cpp
@@ -46,6 +46,7 @@
 #include "common/vqaconfig.h"
 #include "common/wspudp.h"
 #include "common/paths.h"
+#include "common/winasm.h"
 #include <time.h>
 
 /****************************************
@@ -459,6 +460,11 @@ bool Init_Game(int, char*[])
         Rule.Process(RuleINI);
     }
 
+    /* Initialize the Interpolation Table.  */
+    if (Get_Resolution_Factor()) {
+        InterpolationTable = new struct InterpolationTable();
+    }
+
     /*
     **	Initialize the animation system.
     */
@@ -661,6 +667,11 @@ void Uninit_Game(void)
 
     WWDOS_Shutdown();
     delete[] Palette;
+
+    if (InterpolationTable) {
+        delete InterpolationTable;
+        InterpolationTable = NULL;
+    }
 }
 //#endif
 


### PR DESCRIPTION
DOSMode does not need to interpolate anything, and therefore should not
really allocate any array related to that.

This commit saves ~64k of execution memory. Enough for an extra
ScreenBuffer.

Please test 640x400 mode of TD. I could not test that because I don't have the assets anymore.

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>