### PR TITLE
Remove SaveLoadPadding

### DIFF
--- a/redalert/aircraft.h
+++ b/redalert/aircraft.h
@@ -271,7 +271,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[32];
 };
 
 #endif

--- a/redalert/anim.h
+++ b/redalert/anim.h
@@ -222,7 +222,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[24];
 };
 
 #endif

--- a/redalert/building.h
+++ b/redalert/building.h
@@ -382,7 +382,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[32];
 
     static COORDINATE const CenterOffset[BSIZE_COUNT];
 };

--- a/redalert/bullet.h
+++ b/redalert/bullet.h
@@ -167,7 +167,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[32];
 };
 
 #endif

--- a/redalert/cell.h
+++ b/redalert/cell.h
@@ -380,7 +380,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[28];
 };
 
 #endif

--- a/redalert/display.h
+++ b/redalert/display.h
@@ -352,7 +352,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[1024];
 };
 
 #endif

--- a/redalert/factory.h
+++ b/redalert/factory.h
@@ -178,7 +178,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[32];
 };
 
 #endif

--- a/redalert/foot.h
+++ b/redalert/foot.h
@@ -400,7 +400,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[16];
 };
 
 #endif

--- a/redalert/gscreen.h
+++ b/redalert/gscreen.h
@@ -122,7 +122,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[1024];
 };
 
 #endif

--- a/redalert/house.h
+++ b/redalert/house.h
@@ -1036,7 +1036,6 @@ public:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[256];
 };
 
 #endif

--- a/redalert/infantry.h
+++ b/redalert/infantry.h
@@ -257,7 +257,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[32];
 };
 
 #endif

--- a/redalert/map.h
+++ b/redalert/map.h
@@ -206,7 +206,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[1024];
 };
 
 #endif

--- a/redalert/object.h
+++ b/redalert/object.h
@@ -131,7 +131,6 @@ public:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[16];
 
     /*-----------------------------------------------------------------------------------
     **	Constructor & destructors.

--- a/redalert/overlay.h
+++ b/redalert/overlay.h
@@ -114,7 +114,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[8];
 };
 
 #endif

--- a/redalert/smudge.h
+++ b/redalert/smudge.h
@@ -109,7 +109,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[8];
 };
 
 #endif

--- a/redalert/special.h
+++ b/redalert/special.h
@@ -106,20 +106,6 @@ public:
     ** New modern balance setting.
     */
     unsigned ModernBalance : 1;
-
-    /*
-    ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
-    *save/load
-    */
-    // MBL 07.21.2020 - https://jaas.ea.com/browse/TDRA-7537
-    // Loading save files from Live and July Patch 3 Beta versions results in a crash
-    // Fixes issue from Change 738397 2020/07/17 14:06:03
-    //
-    // unsigned char SaveLoadPadding[128]; // Note: Never changed to 127 like TD did
-    //
-    // unsigned char SaveLoadPadding[124]; // Trying 124 like we did with TD - Failed
-    unsigned char SaveLoadPadding[128]; // Works with With last weeks saves (7/16/2020) and newest saves; Skyler says go
-                                        // with this.
 };
 #pragma pack(pop)
 

--- a/redalert/team.h
+++ b/redalert/team.h
@@ -287,7 +287,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[32];
 };
 
 #endif

--- a/redalert/teamtype.h
+++ b/redalert/teamtype.h
@@ -286,7 +286,6 @@ public:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[32];
 
     static char const* TMissions[TMISSION_COUNT];
 };

--- a/redalert/techno.h
+++ b/redalert/techno.h
@@ -248,7 +248,6 @@ public:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[16];
 
     /*---------------------------------------------------------------------
     **	Constructors, Destructors, and overloaded operators.

--- a/redalert/template.h
+++ b/redalert/template.h
@@ -106,7 +106,6 @@ public:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[8];
 };
 
 #endif

--- a/redalert/terrain.h
+++ b/redalert/terrain.h
@@ -173,7 +173,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[8];
 };
 
 #endif

--- a/redalert/trigger.h
+++ b/redalert/trigger.h
@@ -128,7 +128,6 @@ public:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[32];
 };
 
 #endif

--- a/redalert/unit.h
+++ b/redalert/unit.h
@@ -120,7 +120,6 @@ public:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[28];
 
     /*---------------------------------------------------------------------
     **	Constructors, Destructors, and overloaded operators.

--- a/redalert/vessel.h
+++ b/redalert/vessel.h
@@ -173,7 +173,6 @@ protected:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[32];
 };
 
 #endif

--- a/tiberiandawn/abstract.h
+++ b/tiberiandawn/abstract.h
@@ -72,7 +72,6 @@ public:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[8];
 
     /*-----------------------------------------------------------------------------------
     **	Constructor & destructors.

--- a/tiberiandawn/aircraft.h
+++ b/tiberiandawn/aircraft.h
@@ -277,7 +277,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[28];
 };
 
 #endif

--- a/tiberiandawn/anim.h
+++ b/tiberiandawn/anim.h
@@ -242,7 +242,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[24];
 };
 
 #endif

--- a/tiberiandawn/building.h
+++ b/tiberiandawn/building.h
@@ -321,7 +321,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[32];
 
     static COORDINATE const CenterOffset[BSIZE_COUNT];
 };

--- a/tiberiandawn/bullet.h
+++ b/tiberiandawn/bullet.h
@@ -173,7 +173,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[32];
 };
 
 #endif

--- a/tiberiandawn/cell.h
+++ b/tiberiandawn/cell.h
@@ -317,7 +317,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[28];
 };
 
 #endif

--- a/tiberiandawn/display.h
+++ b/tiberiandawn/display.h
@@ -344,7 +344,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[1024];
 };
 
 #endif

--- a/tiberiandawn/factory.h
+++ b/tiberiandawn/factory.h
@@ -176,7 +176,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[32];
 };
 
 #endif

--- a/tiberiandawn/foot.h
+++ b/tiberiandawn/foot.h
@@ -318,7 +318,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[16];
 };
 
 #endif

--- a/tiberiandawn/gscreen.h
+++ b/tiberiandawn/gscreen.h
@@ -128,7 +128,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[1024];
 };
 
 #endif

--- a/tiberiandawn/house.h
+++ b/tiberiandawn/house.h
@@ -941,6 +941,5 @@ public:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[256];
 };
 #endif

--- a/tiberiandawn/infantry.h
+++ b/tiberiandawn/infantry.h
@@ -261,7 +261,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[32];
 };
 
 #endif

--- a/tiberiandawn/map.h
+++ b/tiberiandawn/map.h
@@ -216,7 +216,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[1024];
 };
 
 #endif

--- a/tiberiandawn/object.h
+++ b/tiberiandawn/object.h
@@ -125,7 +125,6 @@ public:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[16];
 
     /*-----------------------------------------------------------------------------------
     **	Constructor & destructors.

--- a/tiberiandawn/overlay.h
+++ b/tiberiandawn/overlay.h
@@ -124,7 +124,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[8];
 };
 
 #endif

--- a/tiberiandawn/smudge.h
+++ b/tiberiandawn/smudge.h
@@ -121,7 +121,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[8];
 };
 
 #endif

--- a/tiberiandawn/special.h
+++ b/tiberiandawn/special.h
@@ -267,9 +267,7 @@ public:
     // Loading save files from Live and July Patch 3 Beta versions results in a crash
     // Fixes issue from Change 738397 2020/07/17 14:06:03
     //
-    // unsigned char SaveLoadPadding[127];
     //
-    unsigned char SaveLoadPadding[124];
 };
 #pragma pack(pop)
 

--- a/tiberiandawn/team.h
+++ b/tiberiandawn/team.h
@@ -262,7 +262,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[32];
 
     /*
     **	This records the success of each team type. As the team carries out its

--- a/tiberiandawn/teamtype.h
+++ b/tiberiandawn/teamtype.h
@@ -262,7 +262,6 @@ public:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[32];
 
 private:
     static char const* TMissions[TMISSION_COUNT];

--- a/tiberiandawn/techno.h
+++ b/tiberiandawn/techno.h
@@ -213,7 +213,6 @@ public:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[16];
 
     /*---------------------------------------------------------------------
     **	Constructors, Destructors, and overloaded operators.

--- a/tiberiandawn/template.h
+++ b/tiberiandawn/template.h
@@ -135,7 +135,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[8];
 };
 
 #endif

--- a/tiberiandawn/terrain.h
+++ b/tiberiandawn/terrain.h
@@ -197,7 +197,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[8];
 };
 
 #endif

--- a/tiberiandawn/trigger.h
+++ b/tiberiandawn/trigger.h
@@ -278,7 +278,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[32];
 };
 
 #endif

--- a/tiberiandawn/unit.h
+++ b/tiberiandawn/unit.h
@@ -222,7 +222,6 @@ private:
     ** Some additional padding in case we need to add data to the class and maintain backwards compatibility for
     *save/load
     */
-    unsigned char SaveLoadPadding[28];
 };
 
 #endif


### PR DESCRIPTION
SaveLoadPadding was a padding attribute added to keep compatibility with older
versions of the game. We keep breaking it al the time and it consumes RAM, so
get rid of it.

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>