### PR TITLE
Choose local libraries over macOS Frameworks.

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -30,7 +30,7 @@ jobs:
 
     - name: Configure Vanilla Conquer
       run: |
-        cmake -G Ninja -DCMAKE_BUILD_TYPE=RelWithDebInfo -DMAP_EDITORTD=ON -DMAP_EDITORRA=ON -DBUILD_TOOLS=ON -B build
+        cmake -G Ninja -DOPENAL_LIBRARY=/usr/local/opt/openal-soft/lib/libopenal.dylib -DOPENAL_INCLUDE_DIR=/usr/local/opt/openal-soft/include/AL -DCMAKE_BUILD_TYPE=RelWithDebInfo -DMAP_EDITORTD=ON -DMAP_EDITORRA=ON -DBUILD_TOOLS=ON -B build
         
     - name: Build Vanilla Conquer
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -26,7 +26,7 @@ jobs:
         brew install sdl2
         brew install dylibbundler
         brew install imagemagick
-	brew install openal-soft
+	      brew install openal-soft
 
     - name: Configure Vanilla Conquer
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -26,6 +26,7 @@ jobs:
         brew install sdl2
         brew install dylibbundler
         brew install imagemagick
+	brew install openal-soft
 
     - name: Configure Vanilla Conquer
       run: |

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -26,7 +26,7 @@ jobs:
         brew install sdl2
         brew install dylibbundler
         brew install imagemagick
-	      brew install openal-soft
+        brew install openal-soft
 
     - name: Configure Vanilla Conquer
       run: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,7 @@ if(NOT MSVC)
         set(STATIC_LIBS "-static-libstdc++ -static-libgcc")
     else()
         set(CMAKE_CXX_FLAGS_DEBUG "-g3")
+        set(CMAKE_FIND_FRAMEWORK "NEVER")
     endif()
 
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w -Wwrite-strings -Werror=write-strings -fcheck-new -fsigned-char -fdata-sections -ffunction-sections -DNOMINMAX")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,7 +76,7 @@ if(NOT MSVC)
         set(STATIC_LIBS "-static-libstdc++ -static-libgcc")
     else()
         set(CMAKE_CXX_FLAGS_DEBUG "-g3")
-        set(CMAKE_FIND_FRAMEWORK "NEVER")
+        set(CMAKE_FIND_FRAMEWORK "LAST")
     endif()
 
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -w -Wwrite-strings -Werror=write-strings -fcheck-new -fsigned-char -fdata-sections -ffunction-sections -DNOMINMAX")


### PR DESCRIPTION
Previously on macOS, cmake was using the OpenAL library from the macOS Framework, bundles with the operation system. This library causes crashes of RA and TD. The added parameter ensures, that the locally installed OpenAL library (MacPorts, HomeBrew) is used instead. I tested openal-soft instead of the Framework library with no problems so far. Other systems should ignore the parameter.

You can verify that the parameter is working, when you take a look into the resulting app bundle. The libs folder will contain the OpenAL library also:

![image](https://user-images.githubusercontent.com/63508182/178330678-51987fd7-2675-49a1-beb1-41dec49dffe3.png)
