### PR TITLE
Fixed setting of data file path for macOS

### DIFF
--- a/redalert/startup.cpp
+++ b/redalert/startup.cpp
@@ -292,7 +292,13 @@ int main(int argc, char* argv[])
     **	Remember the current working directory and drive.
     */
     Paths.Init("vanillara", CONFIG_FILE_NAME, "REDALERT.MIX", args.ArgV[0]);
+
+#ifdef __APPLE__
+    vc_chdir(Paths.User_Path());
+#else
     vc_chdir(Paths.Data_Path());
+#endif
+
     CDFileClass::Refresh_Search_Drives();
 
     if (Parse_Command_Line(args.ArgC, args.ArgV)) {

--- a/tiberiandawn/startup.cpp
+++ b/tiberiandawn/startup.cpp
@@ -210,7 +210,7 @@ int main(int argc, char** argv)
         printf("Zuwenig Hauptspeicher verf?gbar.\n");
 #else
 #ifdef FRENCH
-        printf("M‚moire vive (RAM) insuffisante.\n");
+        printf("Mï¿½moire vive (RAM) insuffisante.\n");
 #else
         printf("Insufficient RAM available.\n");
 #endif
@@ -226,7 +226,13 @@ int main(int argc, char** argv)
     **	Remember the current working directory and drive.
     */
     Paths.Init("vanillatd", "CONQUER.INI", "CONQUER.MIX", args.ArgV[0]);
+
+#ifdef __APPLE__
+    vc_chdir(Paths.User_Path());
+#else
     vc_chdir(Paths.Data_Path());
+#endif
+
     CDFileClass::Refresh_Search_Drives();
 
     if (Parse_Command_Line(args.ArgC, args.ArgV)) {


### PR DESCRIPTION
The path to the data files has to be set to the user library folder for macOS. This commit adjusts the paths for RA and TD.

Related to #795 