### PR TITLE
Data path was not set to user path.

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   vanilla-macos:
-    runs-on: macos-10.15
+    runs-on: macos-12
 
     steps:
     - uses: actions/checkout@v2

--- a/common/cdfile.cpp
+++ b/common/cdfile.cpp
@@ -508,7 +508,7 @@ int CDFileClass::Open(char const* filename, int rights)
         return (BufferIOFileClass::Open(rights));
     }
 
-    if ((rights | WRITE)) {
+    if ((rights & WRITE)) {
         std::string write_path = Paths.User_Path();
         write_path += PathsClass::SEP;
         write_path += filename;

--- a/common/rawfile.h
+++ b/common/rawfile.h
@@ -107,6 +107,11 @@ public:
     int BiasStart;
     int BiasLength;
 
+    /*
+    **    This points to a copy of the filename as a NULL terminated string.
+    */
+    char* Filename;
+
 protected:
     /*
     **	This function returns the largest size a low level DOS read or write may
@@ -124,11 +129,6 @@ private:
     **	This is the low level DOS handle. A -1 indicates an empty condition.
     */
     FILE* Handle;
-
-    /*
-    **	This points to a copy of the filename as a NULL terminated string.
-    */
-    char* Filename;
 };
 
 /***********************************************************************************************

--- a/redalert/conquer.cpp
+++ b/redalert/conquer.cpp
@@ -80,6 +80,7 @@
 #include "interpal.h"
 #include "vortex.h"
 #include "common/framelimit.h"
+#include "common/paths.h"
 #include "common/vqatask.h"
 #include "common/vqaloader.h"
 #include "common/settings.h"
@@ -3875,22 +3876,27 @@ static bool Change_Local_Dir(int cd)
     static bool _initialised = false;
     static unsigned _detected = 0;
     static const char* _vol_labels[CD_COUNT] = {"allied", "soviet", "counterstrike", "aftermath", "."};
-    char vol_buff[512];
+    std::string paths[3] = {Paths.User_Path(), Paths.Data_Path(), Paths.Program_Path()};
 
     // Detect which if any of the discs have had their data copied to an appropriate local folder.
     if (!_initialised) {
         for (int i = 0; i < CD_COUNT; ++i) {
-            CCFileClass vol(_vol_labels[i]);
+            for (int j = 0; j < 3; ++j) {
+                std::string path = paths[j] + PathsClass::SEP + _vol_labels[i];
+                RawFileClass vol(path.c_str());
 
-            if (vol.Is_Directory()) {
-                CDFileClass::Refresh_Search_Drives();
-                snprintf(vol_buff, sizeof(vol_buff), "%s/", vol.Filename);
-                CDFileClass::Add_Search_Drive(vol_buff);
-                CCFileClass fc("MAIN.MIX");
+                if (vol.Is_Directory()) {
+                    CDFileClass::Refresh_Search_Drives();
+                    path += PathsClass::SEP;
+                    CDFileClass::Add_Search_Drive(path.c_str());
+                    CCFileClass fc("MAIN.MIX");
 
-                // Populate _detected as a bitfield for which discs we found a local copy of.
-                if (fc.Is_Available()) {
-                    _detected |= 1 << i;
+                    // Populate _detected as a bitfield for which discs we found a local copy of.
+                    if (fc.Is_Available()) {
+                        _detected |= 1 << i;
+                    }
+
+                    break;
                 }
             }
         }
@@ -3942,24 +3948,26 @@ static bool Change_Local_Dir(int cd)
 
     // If the data from the CD we want was detected, then double check it and set it as though we used the -CD command line.
     if (_detected & (1 << cd)) {
-        CCFileClass vol(_vol_labels[cd]);
+        for (int j = 0; j < 3; ++j) {
+            std::string path = paths[j] + PathsClass::SEP + _vol_labels[cd];
+            RawFileClass vol(path.c_str());
 
-        // Verify that the file is still available and hasn't been deleted out from under us.
-        if (vol.Is_Directory()) {
-            CDFileClass::Refresh_Search_Drives();
-            snprintf(vol_buff, sizeof(vol_buff), "%s/", vol.Filename);
-            CDFileClass::Add_Search_Drive(vol_buff);
+            if (vol.Is_Directory()) {
+                CDFileClass::Refresh_Search_Drives();
+                path += PathsClass::SEP;
+                CDFileClass::Add_Search_Drive(path.c_str());
 
-            // The file should be available if we reached this point.
-            assert(CCFileClass("MAIN.MIX").Is_Available());
+                // The file should be available if we reached this point.
+                assert(CCFileClass("MAIN.MIX").Is_Available());
 
-            CurrentCD = cd;
-            LastCD = cd;
-            Theme.Stop();
-            Reinit_Secondary_Mixfiles();
-            ThemeClass::Scan();
+                CurrentCD = cd;
+                LastCD = cd;
+                Theme.Stop();
+                Reinit_Secondary_Mixfiles();
+                ThemeClass::Scan();
 
-            return true;
+                return true;
+            }
         }
     }
 
@@ -4248,7 +4256,7 @@ bool Force_CD_Available(int cd)
 #endif
 
 #ifdef FRENCH
-                sprintf(buffer, "InsŠrez le %s", _cd_name[cd]);
+                sprintf(buffer, "Insï¿½rez le %s", _cd_name[cd]);
 #else
 #ifdef GERMAN
                 sprintf(buffer, "Bitte %s", _cd_name[cd]);
@@ -4259,7 +4267,7 @@ bool Force_CD_Available(int cd)
             } else {
 #ifdef DVD
 #ifdef FRENCH
-                sprintf(buffer, "InsŠrez le %s", _cd_name[4]);
+                sprintf(buffer, "Insï¿½rez le %s", _cd_name[4]);
 #else
 #ifdef GERMAN
                 sprintf(buffer, "Bitte %s", _cd_name[4]);

--- a/redalert/conquer.cpp
+++ b/redalert/conquer.cpp
@@ -3875,16 +3875,16 @@ static bool Change_Local_Dir(int cd)
     static bool _initialised = false;
     static unsigned _detected = 0;
     static const char* _vol_labels[CD_COUNT] = {"allied", "soviet", "counterstrike", "aftermath", "."};
-    char vol_buff[16];
+    char vol_buff[512];
 
     // Detect which if any of the discs have had their data copied to an appropriate local folder.
     if (!_initialised) {
         for (int i = 0; i < CD_COUNT; ++i) {
-            RawFileClass vol(_vol_labels[i]);
+            CCFileClass vol(_vol_labels[i]);
 
             if (vol.Is_Directory()) {
                 CDFileClass::Refresh_Search_Drives();
-                snprintf(vol_buff, sizeof(vol_buff), "%s/", _vol_labels[i]);
+                snprintf(vol_buff, sizeof(vol_buff), "%s/", vol.Filename);
                 CDFileClass::Add_Search_Drive(vol_buff);
                 CCFileClass fc("MAIN.MIX");
 
@@ -3942,12 +3942,12 @@ static bool Change_Local_Dir(int cd)
 
     // If the data from the CD we want was detected, then double check it and set it as though we used the -CD command line.
     if (_detected & (1 << cd)) {
-        RawFileClass vol(_vol_labels[cd]);
+        CCFileClass vol(_vol_labels[cd]);
 
         // Verify that the file is still available and hasn't been deleted out from under us.
         if (vol.Is_Directory()) {
             CDFileClass::Refresh_Search_Drives();
-            snprintf(vol_buff, sizeof(vol_buff), "%s/", _vol_labels[cd]);
+            snprintf(vol_buff, sizeof(vol_buff), "%s/", vol.Filename);
             CDFileClass::Add_Search_Drive(vol_buff);
 
             // The file should be available if we reached this point.

--- a/redalert/loaddlg.cpp
+++ b/redalert/loaddlg.cpp
@@ -47,6 +47,7 @@
 #include "loaddlg.h"
 #include "common/file.h"
 #include "common/framelimit.h"
+#include "common/paths.h"
 
 /***********************************************************************************************
  * LoadOptionsClass::LoadOptionsClass -- class constructor                                     *
@@ -641,10 +642,13 @@ void LoadOptionsClass::Fill_List(ListClass* list)
 {
     FileEntryClass* fdata; // for adding entries to 'Files'
     char descr[DESCRIP_MAX + 32];
+    char scan_path[_MAX_PATH];
+    char sep[2] = {0};
     unsigned scenario; // scenario #
     HousesType house;  // house
     Find_File_Data* ff = nullptr;
     int id;
+    bool found;
 
     /*
     ** Make sure the list is empty
@@ -664,12 +668,12 @@ void LoadOptionsClass::Fill_List(ListClass* list)
     /*
     ** Find all savegame files
     */
-    bool rc = Find_First("SAVEGAME.*", 0, &ff);
+    sep[0] = PathsClass::SEP;
+    snprintf(scan_path, sizeof(scan_path), "%s%s%s", Paths.User_Path(), sep, "SAVEGAME.*");
 
-    while (rc) {
-
+    found = Find_First(scan_path, 0, &ff);
+    while (found) {
         if (stricmp(ff->GetName(), NET_SAVE_FILE_NAME) != 0) {
-
             /*
             ** Extract the game ID from the filename
             */
@@ -704,9 +708,12 @@ void LoadOptionsClass::Fill_List(ListClass* list)
         /*
         ** Find the next file
         */
-        rc = Find_Next(ff);
+        found = Find_Next(ff);
     }
-    Find_Close(ff);
+
+    if (ff) {
+        Find_Close(ff);
+    }
 
     /*
     ** If saving a game, determine a unique file ID for the empty slot

--- a/redalert/saveload.cpp
+++ b/redalert/saveload.cpp
@@ -367,7 +367,7 @@ bool Save_Game(const char* file_name, const char* descr)
     /*
     **	Open the file
     */
-    BufferIOFileClass file(file_name);
+    CDFileClass file(file_name);
 
     FilePipe fpipe(&file);
 #ifdef REMASTER_BUILD
@@ -518,7 +518,7 @@ bool Load_Game(const char* file_name)
     /*
     **	Open the file
     */
-    RawFileClass file(file_name);
+    CDFileClass file(file_name);
     if (!file.Is_Available()) {
         return (false);
     }
@@ -1438,7 +1438,7 @@ bool Get_Savefile_Info(int id, char* buf, unsigned* scenp, HousesType* housep)
     **	Generate the filename to load
     */
     sprintf(name, "SAVEGAME.%03d", id);
-    BufferIOFileClass file(name);
+    CDFileClass file(name);
 
     FileStraw straw(file);
 

--- a/redalert/startup.cpp
+++ b/redalert/startup.cpp
@@ -54,12 +54,10 @@ void Print_Error_Exit(char* string);
 #ifdef _WIN32
 #include <direct.h>
 #include "common/utf.h"
-#define vc_chdir(x) _wchdir(UTF8To16(x))
 extern void Create_Main_Window(HANDLE instance, int command_show, int width, int height);
 HINSTANCE ProgramInstance;
 #else
 #include <unistd.h>
-#define vc_chdir(x) chdir(x)
 #endif
 extern bool RA95AlreadyRunning;
 void Check_Use_Compressed_Shapes(void);
@@ -292,7 +290,6 @@ int main(int argc, char* argv[])
     **	Remember the current working directory and drive.
     */
     Paths.Init("vanillara", CONFIG_FILE_NAME, "REDALERT.MIX", args.ArgV[0]);
-    vc_chdir(Paths.Data_Path());
     CDFileClass::Refresh_Search_Drives();
 
     if (Parse_Command_Line(args.ArgC, args.ArgV)) {

--- a/tiberiandawn/conquer.cpp
+++ b/tiberiandawn/conquer.cpp
@@ -3505,16 +3505,16 @@ static bool Change_Local_Dir(int cd)
     static bool _initialised = false;
     static unsigned _detected = 0;
     static const char* _vol_labels[CD_COUNT] = {"gdi", "nod", "covertops", "."};
-    char vol_buff[16];
+    char vol_buff[512];
 
     // Detect which if any of the discs have had their data copied to an appropriate local folder.
     if (!_initialised) {
         for (int i = 0; i < CD_COUNT; ++i) {
-            RawFileClass vol(_vol_labels[i]);
+            CCFileClass vol(_vol_labels[i]);
 
             if (vol.Is_Directory()) {
                 CDFileClass::Refresh_Search_Drives();
-                snprintf(vol_buff, sizeof(vol_buff), "%s/", _vol_labels[i]);
+                snprintf(vol_buff, sizeof(vol_buff), "%s/", vol.Filename);
                 CDFileClass::Add_Search_Drive(vol_buff);
                 CCFileClass fc("GENERAL.MIX");
 
@@ -3562,12 +3562,12 @@ static bool Change_Local_Dir(int cd)
 
     // If the data from the CD we want was detected, then double check it and set it as though we used the -CD command line.
     if (_detected & (1 << cd)) {
-        RawFileClass vol(_vol_labels[cd]);
+        CCFileClass vol(_vol_labels[cd]);
 
         // Verify that the file is still available and hasn't been deleted out from under us.
         if (vol.Is_Directory()) {
             CDFileClass::Refresh_Search_Drives();
-            snprintf(vol_buff, sizeof(vol_buff), "%s/", _vol_labels[cd]);
+            snprintf(vol_buff, sizeof(vol_buff), "%s/", vol.Filename);
             CDFileClass::Add_Search_Drive(vol_buff);
 
             // The file should be available if we reached this point.

--- a/tiberiandawn/startup.cpp
+++ b/tiberiandawn/startup.cpp
@@ -46,12 +46,10 @@ void Print_Error_Exit(char* string);
 #ifdef _WIN32
 #include <direct.h>
 #include "common/utf.h"
-#define vc_chdir(x) _wchdir(UTF8To16(x))
 extern void Create_Main_Window(HANDLE instance, int width, int height);
 HINSTANCE ProgramInstance;
 #else
 #include <unistd.h>
-#define vc_chdir(x) chdir(x)
 #endif
 
 extern int ReadyToQuit;
@@ -226,7 +224,6 @@ int main(int argc, char** argv)
     **	Remember the current working directory and drive.
     */
     Paths.Init("vanillatd", "CONQUER.INI", "CONQUER.MIX", args.ArgV[0]);
-    vc_chdir(Paths.Data_Path());
     CDFileClass::Refresh_Search_Drives();
 
     if (Parse_Command_Line(args.ArgC, args.ArgV)) {


### PR DESCRIPTION
The data path was never set to the user path, when the data files were placed in the user path (e.g. on macOS and other Unix-based OS).

This is an improved solution for bug #795 and replaces PR #798.