### PR TITLE
Bugfix for SP AI failing to rebuild buildings on non-megamaps.

### DIFF
--- a/tiberiandawn/base.cpp
+++ b/tiberiandawn/base.cpp
@@ -170,16 +170,6 @@ void BaseClass::Read_INI(CCINIClass& ini)
         */
         node.Coord = atol(strtok(NULL, ","));
 
-#ifdef MEGAMAPS
-        /*
-        ** Convert the normal cell position to a new big map position.
-        */
-        if (Map.MapBinaryVersion == MAP_VERSION_NORMAL) {
-            CELL cell = Confine_Old_Cell(XY_Cell(Coord_X(node.Coord), Coord_Y(node.Coord)));
-            node.Coord = Cell_Coord(cell);
-        }
-#endif
-
         /*
         ** Add this node to the Base's list
         */


### PR DESCRIPTION
Don't remap coordinates for base nodes. It's unnecessary. (Also, the original code is buggy.)

See f46a7abfa6754c309b2a7e94e63b18a8568890fb from
https://github.com/ChthonVII/CnC_Remastered_Collection for further
details.

Fixes #806 