### PR TITLE
Additional mac os workflow

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   vanilla-macos:
-    runs-on: macos-10.15
+    runs-on: macos-12
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/macos_universal.yml
+++ b/.github/workflows/macos_universal.yml
@@ -1,0 +1,83 @@
+name: macos
+
+on:
+  workflow_dispatch:
+
+jobs:
+  vanilla-macos:
+    runs-on: macos-12
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: 'true'
+        fetch-depth: 0
+        ref: ${{ github.event.pull_request.head.sha }}
+        
+    - uses: seanmiddleditch/gha-setup-ninja@master
+    
+    - name: Set Git Info
+      id: gitinfo
+      run: echo "::set-output name=sha_short::$(git rev-parse --short HEAD)"
+      
+    - name: Install dependencies
+      run: |
+        wget -q https://github.com/macports/macports-base/releases/download/v2.7.2/MacPorts-2.7.2-12-Monterey.pkg
+        sudo installer -pkg ./MacPorts-2.7.2-12-Monterey.pkg -target /
+        export PATH="/opt/local/bin:/opt/local/sbin:$PATH"
+        sudo port selfupdate -N
+        sudo port install dylibbundler -N
+        sudo port install libsdl2 +universal -N
+        sudo port install openal-soft +universal -N
+        sudo port install imageMagick -N
+
+    - name: Configure Vanilla Conquer
+      run: |
+        export PATH="/opt/local/bin:/opt/local/sbin:$PATH"
+        cmake -G Ninja -DCMAKE_FIND_FRAMEWORK=LAST -DCMAKE_OSX_ARCHITECTURES="arm64;x86_64" -DCMAKE_BUILD_TYPE=RelWithDebInfo -DMAP_EDITORTD=ON -DMAP_EDITORRA=ON -DBUILD_TOOLS=ON -B build
+        
+    - name: Build Vanilla Conquer
+      run: |
+        export PATH="/opt/local/bin:/opt/local/sbin:$PATH"
+        cmake --build build
+        dsymutil build/vanillatd.app/Contents/MacOS/vanillatd -o build/vanillatd.dSYM
+        dsymutil build/vanillara.app/Contents/MacOS/vanillara -o build/vanillara.dSYM
+        dsymutil build/vanillamix -o build/vanillamix.dSYM
+        strip -Sx build/vanillatd.app/Contents/MacOS/vanillatd
+        strip -Sx build/vanillara.app/Contents/MacOS/vanillara
+        strip -Sx build/vanillamix
+        dylibbundler --create-dir --bundle-deps --overwrite-files --dest-dir ./build/vanillatd.app/Contents/libs --fix-file build/vanillatd.app/Contents/MacOS/vanillatd
+        dylibbundler --create-dir --bundle-deps --overwrite-files --dest-dir ./build/vanillara.app/Contents/libs --fix-file build/vanillara.app/Contents/MacOS/vanillara
+
+    - name: Create archives
+      run: |
+        mkdir artifact
+        7z a artifact/vanilla-conquer-macos-clang-universal2-${{ steps.gitinfo.outputs.sha_short }}.zip ./build/vanillatd.app ./build/vanillara.app ./build/vanillamix
+        7z a artifact/vanilla-conquer-macos-clang-universal2-${{ steps.gitinfo.outputs.sha_short }}-debug.zip ./build/vanillatd.dSYM ./build/vanillara.dSYM ./build/vanillamix.dSYM
+
+    - name: Upload artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: vanilla-conquer-macos-clang-universal2
+        path: artifact
+        
+    - name: Upload development release
+      if: ${{ github.event_name != 'pull_request' && github.ref == 'refs/heads/vanilla' }}
+      uses: softprops/action-gh-release@v1
+      with:
+        name: Development Build
+        tag_name: "latest"
+        prerelease: true
+        files: |
+          artifact/*
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Upload tagged release
+      if: ${{ startsWith(github.ref, 'refs/tags/') }}
+      uses: softprops/action-gh-release@v1
+      with:
+        files: |
+          artifact/*
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull requests updates the macOS workflow from the deprecated macOS version 10.15 to 12. It also adds a second macOS workflow to be run on demand (e.g. official releases) that builds universal binaries but takes around 50 minutes to finish.