### PR TITLE
Td ai improvements

### DIFF
--- a/tiberiandawn/building.cpp
+++ b/tiberiandawn/building.cpp
@@ -4130,7 +4130,7 @@ int BuildingClass::Mission_Deconstruction(void)
                         /* extra check to prevent building crew for Obelisk or AGT spawning
                            one cell above building foundation */
                         if (*this == STRUCT_ATOWER || *this == STRUCT_OBELISK) {
-                            coord = Map[coord].Adjacent_Cell(FACING_S)->Cell_Coord();
+                            coord = Map[Coord_Cell(coord)].Adjacent_Cell(FACING_S)->Cell_Coord();
                         }
                         coord = Map[Coord_Cell(coord)].Closest_Free_Spot(coord, false);
 

--- a/tiberiandawn/building.cpp
+++ b/tiberiandawn/building.cpp
@@ -1171,7 +1171,12 @@ void BuildingClass::AI(void)
             if (House->Available_Money() >= REPAIR_THRESHHOLD) {
                 Repair(1);
             } else {
-                if (IsTickedOff && (int)Scen.Scenario > 2 && Random_Pick(0, 50) < (int)Scen.Scenario && !Trigger) {
+
+                // GB 2022 improvement by TobiasKarnat, This on top would improve
+                // skirmish by randomizing building choice, prioritizing power and
+                // sell off later [TD].
+                if (IsTickedOff && (int)Scen.Scenario > 2 && Random_Pick(0, 50) < (int)Scen.Scenario && !Trigger
+                    && *this != STRUCT_CONST && Health_Ratio() < (unsigned)(0x0040)) {
                     if (GameToPlay != GAME_NORMAL || Scen.Scenario != 15 || PlayerPtr->ActLike != HOUSE_GOOD
                         || *this != STRUCT_TEMPLE) {
                         Sell_Back(1);

--- a/tiberiandawn/nulldlg.cpp
+++ b/tiberiandawn/nulldlg.cpp
@@ -354,11 +354,14 @@ int Com_Scenario_Dialog(void)
     Init scenario values, only the first time through
     ........................................................................*/
     if (first_time) {
-        MPlayerCredits = 3000; // init credits & credit buffer
-        MPlayerBases = 1;      // init scenario parameters
-        MPlayerTiberium = 0;
+        // GB 2022 set defaults for skirmish also:
+        BuildLevel = 7;
+
+        MPlayerCredits = 10000; // init credits & credit buffer
+        MPlayerBases = 1;       // init scenario parameters
+        MPlayerTiberium = 1;
         MPlayerGoodies = 0;
-        MPlayerGhosts = 0;
+        MPlayerGhosts = 1;
         Special.IsCaptureTheFlag = 0;
         MPlayerUnitCount = (MPlayerCountMax[MPlayerBases] + MPlayerCountMin[MPlayerBases]) / 2;
         first_time = false;

--- a/tiberiandawn/rules.cpp
+++ b/tiberiandawn/rules.cpp
@@ -89,22 +89,20 @@ RulesClass::RulesClass(void)
     : AttackInterval(3)
     , AttackDelay(5)
     , PowerEmergencyFraction(3, 4)
-    , AirstripRatio(".12")
-    , AirstripLimit(5)
     , HelipadRatio(".12")
-    , HelipadLimit(5)
-    , TeslaRatio(".16")
-    , TeslaLimit(10)
+    , HelipadLimit(6)
+    , TeslaRatio(".8")
+    , TeslaLimit(5)
     , AARatio(".14")
     , AALimit(10)
     , DefenseRatio(".5")
-    , DefenseLimit(40)
+    , DefenseLimit(25)
     , WarRatio(".1")
-    , WarLimit(2)
+    , WarLimit(3)
     , BarracksRatio(".16")
     , BarracksLimit(2)
-    , RefineryLimit(4)
-    , RefineryRatio(".16")
+    , RefineryLimit(7)
+    , RefineryRatio(".18")
     , BaseSizeAdd(3)
     , PowerSurplus(50)
     , MaxIQ(5)
@@ -126,15 +124,20 @@ RulesClass::RulesClass(void)
     , AllowSuperWeapons(true)
 {
 #ifndef REMASTER_BUILD
-    Diff[DIFF_EASY].FirepowerBias = "1.2";
-    Diff[DIFF_EASY].GroundspeedBias = "1.2";
-    Diff[DIFF_EASY].AirspeedBias = "1.2";
-    Diff[DIFF_EASY].ArmorBias = "0.3";
+
+    /* giulianob: Bump FirepowerBias just a little, else the enemy do too much damage. */
+    Diff[DIFF_EASY].FirepowerBias = "1.1";
+    /* giulianob: Same thing with speed. */
+    Diff[DIFF_EASY].GroundspeedBias = "1.1";
+    Diff[DIFF_EASY].AirspeedBias = "1.1";
+    /* giulianob: Don't bump the ArmorBias, else enemy units on hard becomes
+       undestroyable.  */
+    Diff[DIFF_EASY].ArmorBias = 1;
     Diff[DIFF_EASY].ROFBias = "0.8";
     Diff[DIFF_EASY].CostBias = "0.8";
     Diff[DIFF_EASY].BuildSpeedBias = "0.6";
     Diff[DIFF_EASY].RepairDelay = "0.001";
-    Diff[DIFF_EASY].BuildDelay = "0.001";
+    Diff[DIFF_EASY].BuildDelay = "0.002";
     Diff[DIFF_EASY].IsBuildSlowdown = false;
     Diff[DIFF_EASY].IsWallDestroyer = true;
     Diff[DIFF_EASY].IsContentScan = true;
@@ -322,8 +325,6 @@ bool RulesClass::AI(CCINIClass& ini)
         TeslaLimit = ini.Get_Int(AI, "ObeliskLimit", TeslaLimit);
         HelipadRatio = ini.Get_Fixed(AI, "HelipadRatio", HelipadRatio);
         HelipadLimit = ini.Get_Int(AI, "HelipadLimit", HelipadLimit);
-        AirstripRatio = ini.Get_Fixed(AI, "AirstripRatio", AirstripRatio);
-        AirstripLimit = ini.Get_Int(AI, "AirstripLimit", AirstripLimit);
         IsCompEasyBonus = ini.Get_Bool(AI, "CompEasyBonus", IsCompEasyBonus);
         IsComputerParanoid = ini.Get_Bool(AI, "Paranoid", IsComputerParanoid);
         PowerEmergencyFraction = ini.Get_Fixed(AI, "PowerEmergency", PowerEmergencyFraction);
@@ -370,8 +371,6 @@ bool RulesClass::Export_AI(CCINIClass& ini)
     ini.Put_Int(AI, "ObeliskLimit", TeslaLimit);
     ini.Put_Fixed(AI, "HelipadRatio", HelipadRatio);
     ini.Put_Int(AI, "HelipadLimit", HelipadLimit);
-    ini.Put_Fixed(AI, "AirstripRatio", AirstripRatio);
-    ini.Put_Int(AI, "AirstripLimit", AirstripLimit);
     ini.Put_Bool(AI, "CompEasyBonus", IsCompEasyBonus);
     ini.Put_Bool(AI, "Paranoid", IsComputerParanoid);
     ini.Put_Fixed(AI, "PowerEmergency", PowerEmergencyFraction);

--- a/tiberiandawn/rules.h
+++ b/tiberiandawn/rules.h
@@ -95,17 +95,6 @@ public:
 
     /*
     **	This specifies the percentage of the base (by building quantity) that should
-    **	be composed of airstrips.
-    */
-    fixed AirstripRatio;
-
-    /*
-    **	Limit the number of airstrips to this amount.
-    */
-    int AirstripLimit;
-
-    /*
-    **	This specifies the percentage of the base (by building quantity) that should
     **	be composed of helipads.
     */
     fixed HelipadRatio;

--- a/tiberiandawn/unit.cpp
+++ b/tiberiandawn/unit.cpp
@@ -1331,9 +1331,14 @@ void UnitClass::Enter_Idle_Mode(bool initial)
                     }
 
 #endif
-                    //} else {
-                    //	order = MISSION_HUNT;
-                    //}
+
+                    // GB 2022 improvement by TobiasKarnat
+                    // This shuffles build units around the base which gives AI
+                    // more space for buildings and reduces risk that unit blocks
+                    // refinery, by screaming_chicken (more simplified).
+                    if (initial && Frame > 1000) {
+                        this->ArchiveTarget = ::As_Target(House->Where_To_Go((FootClass*)this));
+                    }
                 }
             }
         }


### PR DESCRIPTION
 Tiberian Dawn AI in skirmish was backported from RA, but it do not take
    into account many pecularities from TD. This commit introduced the
    following changes:
    
    1. Sell off buildings when health is low and there is no money to repair
       them.
    2. Initial build order try to be CY -> Power -> Barracks -> Ref -> Ref
       -> Anything else
    3. Randomize one of the "best" buildings from the "best" vector.
    4. Allow Nod to build Helipads.
    5. Allow Nod to build Comm Center after airstrip for tech.
    6. Reduce the maximum amount of Obelisks so the AI don't get stuck
       with low power
    7. Allow Nod to build airstrips.
    8. Fix insane bumps on hard difficulty.
    9. Allow GDI to build Guard Towers and Adv. Guard Towers.
    10. Allow GDI to build Repair Bay only after War Factory.
    11. Allow GDI to build Comm center -> Adv. Guard Towers if it finds
        itself theaten by air units.
    12. Reorganize sell urgency if it finds itself without money.
    13. Reorganize sell urgency if it finds itself without power.
    
    Many changes where done by Gerwin2k, TobiasKarnat and myself.

This also fixes the bug reported in #837 . 