### PR TITLE
Fixes a segfault under linux when opening the load screen.

### DIFF
--- a/redalert/loaddlg.cpp
+++ b/redalert/loaddlg.cpp
@@ -771,9 +771,9 @@ void LoadOptionsClass::Fill_List(ListClass* list)
  *=============================================================================================*/
 int LoadOptionsClass::Num_From_Ext(const char* fname)
 {
-    char ext[_MAX_EXT];
+    const char* ext;
 
-    _splitpath(fname, NULL, NULL, NULL, ext);
+    ext = strrchr(fname, '.');
     int num = atoi(ext + 1); // skip the '.'
     return (num);
 }

--- a/tiberiandawn/loaddlg.cpp
+++ b/tiberiandawn/loaddlg.cpp
@@ -714,9 +714,9 @@ void LoadOptionsClass::Fill_List(ListClass* list)
  *=============================================================================================*/
 int LoadOptionsClass::Num_From_Ext(const char* fname)
 {
-    char ext[_MAX_EXT];
+    const char* ext;
 
-    _splitpath(fname, NULL, NULL, NULL, ext);
+    ext = strrchr(fname, '.');
     int num = atoi(ext + 1); // skip the '.'
     return (num);
 }


### PR DESCRIPTION
Removes uses of nonstandard _splitpath function to use strrchr to find extension instead.