### PR TITLE
Endian fixes for the Red Alert FootClass::SetSpeed(int) function.

### DIFF
--- a/redalert/foot.cpp
+++ b/redalert/foot.cpp
@@ -228,7 +228,7 @@ void FootClass::Set_Speed(int speed)
     assert(IsActive);
 
     speed &= 0xFF;
-    ((unsigned char&)Speed) = speed;
+    Speed = (Speed & 0xffffff00) | speed;
 }
 
 /***********************************************************************************************


### PR DESCRIPTION
Here the original code cast the variable to a pointer of a different size to manipulate just the lower bits. Converted it into less hacky code.