### PR TITLE
Turned all inline path concatenations (ie, path1 + SEP + path2) into …

### DIFF
--- a/common/cdfile.cpp
+++ b/common/cdfile.cpp
@@ -122,9 +122,7 @@ int CDFileClass::Open(int rights)
     ** Otherwise it will try and write it to the working directory, probably the binary dir.
     */
     if ((rights & WRITE) && !PathsClass::Is_Absolute(File_Name())) {
-        path = Paths.User_Path();
-        path += PathsClass::SEP;
-        path += File_Name();
+        path = Paths.Concatenate_Paths(Paths.User_Path(), File_Name());
         BufferIOFileClass::Set_Name(path.c_str());
     }
 
@@ -391,9 +389,7 @@ char const* CDFileClass::Set_Name(char const* filename)
         /*
         **	Build a pathname to search for.
         */
-        std::string path = srch->Path;
-        path += PathsClass::SEP;
-        path += filename;
+        std::string path = Paths.Concatenate_Paths(srch->Path, filename);
 
         /*
         **	Check to see if the file could be found. The low level Is_Available logic will
@@ -438,9 +434,7 @@ int CDFileClass::Is_Available(int forced)
         /*
         **	Build a pathname to search for.
         */
-        std::string path = srch->Path;
-        path += PathsClass::SEP;
-        path += filename;
+        std::string path = Paths.Concatenate_Paths(srch->Path, filename.c_str());
 
         /*
         **	Check to see if the file could be found. The low level Is_Available logic will
@@ -509,9 +503,7 @@ int CDFileClass::Open(char const* filename, int rights)
     }
 
     if ((rights & WRITE)) {
-        std::string write_path = Paths.User_Path();
-        write_path += PathsClass::SEP;
-        write_path += filename;
+        std::string write_path = Paths.Concatenate_Paths(Paths.User_Path(), filename);
         BufferIOFileClass::Set_Name(write_path.c_str());
         return (BufferIOFileClass::Open(rights));
     }

--- a/common/paths.cpp
+++ b/common/paths.cpp
@@ -55,16 +55,16 @@ void PathsClass::Init(const char* suffix, const char* ini_name, const char* data
     bool use_prog_path = false;
 
     if (ini_name != nullptr) {
-        if (!argv_path.empty() && RawFileClass((argv_path + SEP + ini_name).c_str()).Is_Available()) {
-            file.Set_Name((argv_path + SEP + ini_name).c_str());
+        if (!argv_path.empty() && RawFileClass(Concatenate_Paths(argv_path.c_str(), ini_name).c_str()).Is_Available()) {
+            file.Set_Name(Concatenate_Paths(argv_path.c_str(), ini_name).c_str());
             use_argv_path = true;
-        } else if (RawFileClass((ProgramPath + SEP + ini_name).c_str()).Is_Available()) {
-            file.Set_Name((ProgramPath + SEP + ini_name).c_str());
+        } else if (RawFileClass(Concatenate_Paths(ProgramPath.c_str(), ini_name).c_str()).Is_Available()) {
+            file.Set_Name(Concatenate_Paths(ProgramPath.c_str(), ini_name).c_str());
             use_prog_path = true;
-        } else if (RawFileClass((UserPath + SEP + ini_name).c_str()).Is_Available()) {
-            file.Set_Name((UserPath + SEP + ini_name).c_str());
-        } else if (RawFileClass((DataPath + SEP + ini_name).c_str()).Is_Available()) {
-            file.Set_Name((DataPath + SEP + ini_name).c_str());
+        } else if (RawFileClass(Concatenate_Paths(UserPath.c_str(), ini_name).c_str()).Is_Available()) {
+            file.Set_Name(Concatenate_Paths(UserPath.c_str(), ini_name).c_str());
+        } else if (RawFileClass(Concatenate_Paths(DataPath.c_str(), ini_name).c_str()).Is_Available()) {
+            file.Set_Name(Concatenate_Paths(DataPath.c_str(), ini_name).c_str());
         }
     }
 
@@ -73,9 +73,9 @@ void PathsClass::Init(const char* suffix, const char* ini_name, const char* data
     bool have_prog_data = false;
 
     if (data_name != nullptr) {
-        if (!argv_path.empty() && RawFileClass((argv_path + SEP + data_name).c_str()).Is_Available()) {
+        if (!argv_path.empty() && RawFileClass(Concatenate_Paths(argv_path.c_str(), data_name).c_str()).Is_Available()) {
             have_argv_data = true;
-        } else if (RawFileClass((ProgramPath + SEP + data_name).c_str()).Is_Available()) {
+        } else if (RawFileClass(Concatenate_Paths(ProgramPath.c_str(), data_name).c_str()).Is_Available()) {
             have_prog_data = true;
         }
     }

--- a/common/paths.cpp
+++ b/common/paths.cpp
@@ -73,7 +73,8 @@ void PathsClass::Init(const char* suffix, const char* ini_name, const char* data
     bool have_prog_data = false;
 
     if (data_name != nullptr) {
-        if (!argv_path.empty() && RawFileClass(Concatenate_Paths(argv_path.c_str(), data_name).c_str()).Is_Available()) {
+        if (!argv_path.empty()
+            && RawFileClass(Concatenate_Paths(argv_path.c_str(), data_name).c_str()).Is_Available()) {
             have_argv_data = true;
         } else if (RawFileClass(Concatenate_Paths(ProgramPath.c_str(), data_name).c_str()).Is_Available()) {
             have_prog_data = true;

--- a/common/paths.h
+++ b/common/paths.h
@@ -39,7 +39,7 @@ public:
 
     static bool Create_Directory(const char* path);
     static bool Is_Absolute(const char* path);
-    static std::string Concatenate_Paths(const char *path1, const char *path2);
+    static std::string Concatenate_Paths(const char* path1, const char* path2);
 
 #ifdef _WIN32
     constexpr static char SEP = '\\';

--- a/common/paths.h
+++ b/common/paths.h
@@ -39,6 +39,7 @@ public:
 
     static bool Create_Directory(const char* path);
     static bool Is_Absolute(const char* path);
+    static std::string Concatenate_Paths(const char *path1, const char *path2);
 
 #ifdef _WIN32
     constexpr static char SEP = '\\';

--- a/common/paths_posix.cpp
+++ b/common/paths_posix.cpp
@@ -241,7 +241,7 @@ bool PathsClass::Is_Absolute(const char* path)
     return path != nullptr && path[0] == '/';
 }
 
-std::string PathsClass::Concatenate_Paths(const char *path1, const char *path2)
+std::string PathsClass::Concatenate_Paths(const char* path1, const char* path2)
 {
     return std::string(path1) + SEP + path2;
 }

--- a/common/paths_posix.cpp
+++ b/common/paths_posix.cpp
@@ -241,6 +241,11 @@ bool PathsClass::Is_Absolute(const char* path)
     return path != nullptr && path[0] == '/';
 }
 
+std::string PathsClass::Concatenate_Paths(const char *path1, const char *path2)
+{
+    return std::string(path1) + SEP + path2;
+}
+
 std::string PathsClass::Argv_Path(const char* cmd_arg)
 {
     std::string ret(PATH_MAX, '\0');

--- a/common/paths_win.cpp
+++ b/common/paths_win.cpp
@@ -146,7 +146,7 @@ bool PathsClass::Is_Absolute(const char* path)
     return path != nullptr && (path[1] == ':' || (path[0] == '\\' && path[1] == '\\'));
 }
 
-std::string PathsClass::Concatenate_Paths(const char *path1, const char *path2)
+std::string PathsClass::Concatenate_Paths(const char* path1, const char* path2)
 {
     return std::string(path1) + SEP + path2;
 }

--- a/common/paths_win.cpp
+++ b/common/paths_win.cpp
@@ -146,6 +146,11 @@ bool PathsClass::Is_Absolute(const char* path)
     return path != nullptr && (path[1] == ':' || (path[0] == '\\' && path[1] == '\\'));
 }
 
+std::string PathsClass::Concatenate_Paths(const char *path1, const char *path2)
+{
+    return std::string(path1) + SEP + path2;
+}
+
 std::string PathsClass::Argv_Path(const char* cmd_arg)
 {
     TCHAR base_buff[MAX_PATH];

--- a/redalert/conquer.cpp
+++ b/redalert/conquer.cpp
@@ -3882,7 +3882,7 @@ static bool Change_Local_Dir(int cd)
     if (!_initialised) {
         for (int i = 0; i < CD_COUNT; ++i) {
             for (int j = 0; j < 3; ++j) {
-                std::string path = paths[j] + PathsClass::SEP + _vol_labels[i];
+                std::string path = Paths.Concatenate_Paths(paths[j].c_str(), _vol_labels[i]);
                 RawFileClass vol(path.c_str());
 
                 if (vol.Is_Directory()) {
@@ -3949,7 +3949,7 @@ static bool Change_Local_Dir(int cd)
     // If the data from the CD we want was detected, then double check it and set it as though we used the -CD command line.
     if (_detected & (1 << cd)) {
         for (int j = 0; j < 3; ++j) {
-            std::string path = paths[j] + PathsClass::SEP + _vol_labels[cd];
+            std::string path = Paths.Concatenate_Paths(paths[j].c_str(), _vol_labels[cd]);
             RawFileClass vol(path.c_str());
 
             if (vol.Is_Directory()) {

--- a/redalert/session.cpp
+++ b/redalert/session.cpp
@@ -774,9 +774,7 @@ void SessionClass::Read_Scenario_Descriptions(void)
     const char* searchPath = CDFileClass::Get_Search_Path(i);
     while (searchPath != nullptr) {
         ffd = nullptr;
-        std::string search_pattern = searchPath;
-        search_pattern += Paths.SEP;
-        search_pattern += "*.MPR";
+        std::string search_pattern = Paths.Concatenate_Paths(searchPath, "*.MPR");
         found = Find_First(search_pattern.c_str(), 0, &ffd);
         while (found) {
             CCFileClass file(ffd->GetName());
@@ -849,9 +847,7 @@ void SessionClass::Read_Scenario_Descriptions(void)
     searchPath = CDFileClass::Get_Search_Path(i);
     while (searchPath != nullptr) {
         ffd = nullptr;
-        std::string search_pattern = searchPath;
-        search_pattern += Paths.SEP;
-        search_pattern += "*.MPR";
+        std::string search_pattern = Paths.Concatenate_Paths(searchPath, "*.MPR");
         found = Find_First(search_pattern.c_str(), 0, &ffd);
         while (found) {
             char name_buffer[128];

--- a/tiberiandawn/conquer.cpp
+++ b/tiberiandawn/conquer.cpp
@@ -3512,7 +3512,7 @@ static bool Change_Local_Dir(int cd)
     if (!_initialised) {
         for (int i = 0; i < CD_COUNT; ++i) {
             for (int j = 0; j < 3; ++j) {
-                std::string path = paths[j] + PathsClass::SEP + _vol_labels[i];
+                std::string path = Paths.Concatenate_Paths(paths[j].c_str(), _vol_labels[i]);
                 RawFileClass vol(path.c_str());
 
                 if (vol.Is_Directory()) {
@@ -3569,7 +3569,7 @@ static bool Change_Local_Dir(int cd)
     // If the data from the CD we want was detected, then double check it and set it as though we used the -CD command line.
     if (_detected & (1 << cd)) {
         for (int j = 0; j < 3; ++j) {
-            std::string path = paths[j] + PathsClass::SEP + _vol_labels[cd];
+            std::string path = Paths.Concatenate_Paths(paths[j].c_str(), _vol_labels[cd]);
             RawFileClass vol(path.c_str());
 
             if (vol.Is_Directory()) {


### PR DESCRIPTION
…calls to PathsClass::Concatenate_Paths(), a newly created function.

This is done to make it easier to port the code to systems where path concatenation can't always be done with the above simple formulate. It also makes for cleaner, more readable code, in my opinion.

If this pull request is acceptable for merging, I'll submit more pull requests to eliminate the remaining inline uses for PathsClass::SEP.