### PR TITLE
Fixed two instances where the wrong constructor for EventClass was ca…

### DIFF
--- a/redalert/display.cpp
+++ b/redalert/display.cpp
@@ -3826,7 +3826,7 @@ void DisplayClass::Mouse_Left_Release(CELL cell, int x, int y, ObjectClass* obje
         **	Try to place the pending object onto the map.
         */
         if (ProximityCheck) {
-            OutList.Add(EventClass(EventClass::PLACE, PendingObjectPtr->What_Am_I(), cell + ZoneOffset));
+            OutList.Add(EventClass(EventClass::PLACE, PendingObjectPtr->What_Am_I(), (CELL)(cell + ZoneOffset)));
         } else {
             Speak(VOX_DEPLOY);
         }

--- a/tiberiandawn/display.cpp
+++ b/tiberiandawn/display.cpp
@@ -3856,7 +3856,7 @@ void DisplayClass::Mouse_Left_Release(CELL cell, int x, int y, ObjectClass* obje
         **	Try to place the pending object onto the map.
         */
         if (ProximityCheck) {
-            OutList.Add(EventClass(EventClass::PLACE, PendingObjectPtr->What_Am_I(), cell + ZoneOffset));
+            OutList.Add(EventClass(EventClass::PLACE, PendingObjectPtr->What_Am_I(), (CELL)(cell + ZoneOffset)));
         } else {
             Speak(VOX_DEPLOY);
         }


### PR DESCRIPTION
…lled, causing problems on big endian systems.

The third argument to EventClass::EventClass() was calculated by adding two variables of types CELL and short respectively, yielding a resulting type of int. This caused...

EventClass(EventType type, RTTIType object, int id);

... to be called, rather than the intended ...

EventClass(EventType type, RTTIType object, CELL cell);

... which again caused the data to be packed wrongly into the EventClass.Data union. This happened to have no side effects on little endian, as the lower bytes of EventClass.Data.General.Value lines up with the lower bytes of EventClass.Data.Place.Cell on such systems, where as they don't on big endian systems.