### PR TITLE
Big endian fixes for the Tiberian Dawn coordinate functions.

### DIFF
--- a/tiberiandawn/defines.h
+++ b/tiberiandawn/defines.h
@@ -1677,10 +1677,6 @@ typedef union
 } COORD_COMPOSITE;
 
 typedef signed short CELL;
-#ifdef __BIG_ENDIAN__
-#warning "FIXME"
-//#define SLUFF_BITS (sizeof(CELL) * CHAR_BIT) - (14)
-#endif
 
 typedef union
 {
@@ -1688,18 +1684,16 @@ typedef union
     struct
     {
 #ifdef __BIG_ENDIAN__
-#if SLUFF_BITS
         /*
         **	Unused upper bits will cause problems on a big-endian machine unless they
         **	are deliberately accounted for.
         */
-        unsigned sluff : SLUF_BITS;
-#endif
-        unsigned Y : MAP_CELL_MAX_Y_BITS;
-        unsigned X : MAP_CELL_MAX_X_BITS;
+        unsigned short sluff : 16 - (MAP_CELL_MAX_X_BITS + MAP_CELL_MAX_Y_BITS);
+        unsigned short Y : MAP_CELL_MAX_Y_BITS;
+        unsigned short X : MAP_CELL_MAX_X_BITS;
 #else
-        unsigned X : MAP_CELL_MAX_X_BITS;
-        unsigned Y : MAP_CELL_MAX_Y_BITS;
+        unsigned short X : MAP_CELL_MAX_X_BITS;
+        unsigned short Y : MAP_CELL_MAX_Y_BITS;
 #endif
     } Sub;
 } CELL_COMPOSITE;


### PR DESCRIPTION
Commit 53483a3530082d2f0d05bfc3ca18d0b4938ee3d7 copied over endian bugs from Red Alert to Tiberian Dawn that have been fixed in a not yet merged pull request. This pull request applies similar fixes to Tiberian Dawn's new code.