### PR TITLE
Optimize ADPCM (sosCODEC) decompression

### DIFF
--- a/common/soscomp.h
+++ b/common/soscomp.h
@@ -43,21 +43,16 @@ typedef struct _tagCOMPRESS_INFO
     char* lpDest;
     unsigned int dwCompSize;
     unsigned int dwUnCompSize;
-    unsigned int dwSampleIndex;
-    int dwPredicted;
-    int dwDifference;
-    short wCodeBuf;
-    short wCode;
-    short wStep;
-    short wIndex;
-
-    unsigned int dwSampleIndex2; // added BP for channel 2
-    int dwPredicted2;            // added BP for channel 2
-    int dwDifference2;           // added BP for channel 2
-    short wCodeBuf2;             // added BP for channel 2
-    short wCode2;                // added BP for channel 2
-    short wStep2;                // added BP for channel 2
-    short wIndex2;               // added BP for channel 2
+    struct
+    {
+        unsigned int dwSampleIndex;
+        int dwPredicted;
+        int dwDifference;
+        short wCodeBuf;
+        short wCode;
+        short wStep;
+        short wIndex;
+    } Channels[2];
     short wBitSize;
     short wChannels; // added BP for # of channels
 } _SOS_COMPRESS_INFO;


### PR DESCRIPTION
This commit optimizes ADPCM decompression in game by:

* Removing any unsupported modes that the game do not use.
* Using a table of possible values instead of computing them on each iteration.

This new table is built by employing a dynamic programming techinque. The possible values are bound and the product of the dimensions are small, hence this techinque is quite effective in optimizing things by precomputing the values.

Signed-off-by: Giuliano Belinassi <gbelinassi@suse.de>