### PR TITLE
Some general sound code cleanup: Removed unused functions and variabl…

### DIFF
--- a/common/audio.h
+++ b/common/audio.h
@@ -118,13 +118,9 @@ typedef enum
 /*=========================================================================*/
 /* The following prototypes are for the file: SOUNDIO.CPP						*/
 /*=========================================================================*/
-int File_Stream_Sample(char const* filename, bool real_time_start = false);
 int File_Stream_Sample_Vol(char const* filename, int volume, bool real_time_start = false);
 void Sound_Callback(void);
-void maintenance_callback(void);
 void* Load_Sample(char const* filename);
-int Load_Sample_Into_Buffer(char const* filename, void* buffer, int size);
-int Sample_Read(int fh, void* buffer, int size);
 void Free_Sample(void const* sample);
 bool Audio_Init(int bits_per_sample, bool stereo, int rate, bool reverse_channels);
 void Sound_End(void);
@@ -133,13 +129,9 @@ bool Sample_Status(int handle);
 bool Is_Sample_Playing(void const* sample);
 void Stop_Sample_Playing(void const* sample);
 int Play_Sample(void const* sample, int priority = 0xFF, int volume = 0xFF, signed short panloc = 0x0);
-int Play_Sample_Handle(void const* sample, int priority, int volume, signed short panloc, int id);
-int Set_Sound_Vol(int volume);
 int Set_Score_Vol(int volume);
 void Fade_Sample(int handle, int ticks);
-int Get_Free_Sample_Handle(int priority);
 int Get_Digi_Handle(void);
-int Sample_Length(void const* sample);
 void Restore_Sound_Buffers(void);
 bool Set_Primary_Buffer_Format(void);
 bool Start_Primary_Sound_Buffer(bool forced);

--- a/common/soundio_null.cpp
+++ b/common/soundio_null.cpp
@@ -6,80 +6,67 @@ bool StreamLowImpact = false;
 SFX_Type SoundType;
 Sample_Type SampleType;
 
-int File_Stream_Sample(char const* filename, bool real_time_start)
-{
-    return 1;
-};
 int File_Stream_Sample_Vol(char const* filename, int volume, bool real_time_start)
 {
     return 1;
-};
-void Sound_Callback(void){};
-void maintenance_callback(void){};
+}
+void Sound_Callback(void)
+{
+}
 void* Load_Sample(char const* filename)
 {
     return nullptr;
-};
-int Load_Sample_Into_Buffer(char const* filename, void* buffer, int size)
-{
-    return 0;
 }
-int Sample_Read(int fh, void* buffer, int size)
+void Free_Sample(void const* sample)
 {
-    return 0;
-};
-void Free_Sample(void const* sample){};
+}
 bool Audio_Init(int bits_per_sample, bool stereo, int rate, bool reverse_channels)
 {
     return 0;
-};
-void Sound_End(void){};
-void Stop_Sample(int handle){};
+}
+void Sound_End(void)
+{
+}
+void Stop_Sample(int handle)
+{
+}
 bool Sample_Status(int handle)
 {
     return 0;
-};
+}
 bool Is_Sample_Playing(void const* sample)
 {
     return 0;
-};
-void Stop_Sample_Playing(void const* sample){};
+}
+void Stop_Sample_Playing(void const* sample)
+{
+}
 int Play_Sample(void const* sample, int priority, int volume, signed short panloc)
 {
     return 1;
-};
-int Play_Sample_Handle(void const* sample, int priority, int volume, signed short panloc, int id)
-{
-    return 1;
-};
-int Set_Sound_Vol(int volume)
-{
-    return 0;
-};
+}
 int Set_Score_Vol(int volume)
 {
     return 0;
-};
-void Fade_Sample(int handle, int ticks){};
-int Get_Free_Sample_Handle(int priority)
+}
+void Fade_Sample(int handle, int ticks)
 {
-    return 1;
-};
+}
 int Get_Digi_Handle(void)
 {
     return 1;
 }
-int Sample_Length(void const* sample)
+void Restore_Sound_Buffers(void)
 {
-    return 0;
-};
-void Restore_Sound_Buffers(void){};
+}
 bool Set_Primary_Buffer_Format(void)
 {
     return 0;
-};
+}
 bool Start_Primary_Sound_Buffer(bool forced)
 {
     return 0;
-};
-void Stop_Primary_Sound_Buffer(void){};
+}
+void Stop_Primary_Sound_Buffer(void)
+{
+}


### PR DESCRIPTION
…es, marked internally-used-only functions and variables as static and removed stray semicolons after functions.