### PR TITLE
Endian/alignment fixes for unions in Red Alert.

### DIFF
--- a/redalert/taction.h
+++ b/redalert/taction.h
@@ -35,6 +35,8 @@
 #ifndef ACTION_H
 #define ACTION_H
 
+#include "endianness.h"
+
 typedef enum TActionType : unsigned char
 {
     TACTION_NONE,
@@ -106,14 +108,34 @@ struct TActionClass
 
     union
     {
-        ThemeType Theme;           // Musical theme.
-        VocType Sound;             // Sound effect.
-        VoxType Speech;            // Speech identifier.
-        HousesType House;          // House to be affected.
-        SpecialWeaponType Special; // Special weapon ability.
-        QuarryType Quarry;         // Preferred target for attack.
-        VQType Movie;              // The movie to play.
-        bool Bool;                 // Boolean value.
+        struct
+        {
+#ifdef __BIG_ENDIAN__
+            unsigned char __padding_2[2];
+#endif
+            union
+            {
+                VocType Sound; // Sound effect.
+            };
+        };
+
+        struct
+        {
+#ifdef __BIG_ENDIAN__
+            unsigned char __padding_1[3];
+#endif
+            union
+            {
+                ThemeType Theme;           // Musical theme.
+                VoxType Speech;            // Speech identifier.
+                HousesType House;          // House to be affected.
+                SpecialWeaponType Special; // Special weapon ability.
+                QuarryType Quarry;         // Preferred target for attack.
+                bool Bool;                 // Boolean value.
+            };
+        };
+
+        VQType Movie; // The movie to play.
         int Value;
     } Data;
 

--- a/redalert/teamtype.h
+++ b/redalert/teamtype.h
@@ -35,6 +35,8 @@
 #ifndef TEAMTYPE_H
 #define TEAMTYPE_H
 
+#include "endianness.h"
+
 /*
 **	TeamMissionType: the various missions that a team can have.
 */
@@ -86,10 +88,21 @@ public:
     TeamMissionType Mission; // Mission type.
     union
     {
-        FormationType Formation; // Formation to use.
-        QuarryType Quarry;       // Combat quarry type.
-        MissionType Mission;     // General mission orders.
-        int Value;               // Usually a waypoint number.
+        struct
+        {
+#ifdef __BIG_ENDIAN__
+            unsigned char __padding_1[3];
+#endif
+
+            union
+            {
+                FormationType Formation; // Formation to use.
+                QuarryType Quarry;       // Combat quarry type.
+                MissionType Mission;     // General mission orders.
+            };
+        };
+
+        int Value; // Usually a waypoint number.
     } Data;
 };
 

--- a/redalert/tevent.h
+++ b/redalert/tevent.h
@@ -35,6 +35,8 @@
 #ifndef TEVENT_H
 #define TEVENT_H
 
+#include "endianness.h"
+
 /*
 **	These are the trigger events that are checked for and if qualified, they will signal
 **	a successful trigger event. This might result in the trigger action being performed.
@@ -132,12 +134,22 @@ struct TEventClass
 
     union
     {
-        StructType Structure;  // Used for structure type checking.
-        UnitType Unit;         // Used for unit type checking.
-        InfantryType Infantry; //	Used for infantry type checking.
-        AircraftType Aircraft; // Used for aircraft type checking.
-        HousesType House;      // Used for house specific events.
-        int Value;             // Used for other events that need data.
+        struct
+        {
+#ifdef __BIG_ENDIAN__
+            unsigned char __padding_1[3];
+#endif
+
+            union
+            {
+                StructType Structure;  // Used for structure type checking.
+                UnitType Unit;         // Used for unit type checking.
+                InfantryType Infantry; //	Used for infantry type checking.
+                AircraftType Aircraft; // Used for aircraft type checking.
+                HousesType House;      // Used for house specific events.
+            };
+        };
+        int Value; // Used for other events that need data.
     } Data;
 
     TEventClass(void)


### PR DESCRIPTION
Various unions in Red Alert mix variable types of different width, but expects to be able to write a value to a variable of one width, and then read the same value back from a variable of a different width. This works fine on little endian, but not on big endian, so this change adds padding on big endian before the variables with a smaller width.