### PR TITLE
Renamed the 'List' and 'Node' classes to 'VanillaList' and 'VanillaNo…

### DIFF
--- a/common/ini.h
+++ b/common/ini.h
@@ -133,7 +133,7 @@ protected:
     **	The value entries for the INI file are stored as objects of this type.
     **	The entry identifier and value string are combined into this object.
     */
-    struct INIEntry : Node<INIEntry>
+    struct INIEntry : VanillaNode<INIEntry>
     {
         INIEntry(char* entry = 0, char* value = 0)
             : Entry(entry)
@@ -160,7 +160,7 @@ protected:
     **	Each section (bracketed) is represented by an object of this type. All entries
     **	subordinate to this section are attached.
     */
-    struct INISection : Node<INISection>
+    struct INISection : VanillaNode<INISection>
     {
         INISection(char* section)
             : Section(section)
@@ -179,7 +179,7 @@ protected:
         };
 
         char* Section;
-        List<INIEntry> EntryList;
+        VanillaList<INIEntry> EntryList;
         IndexClass<INIEntry*> EntryIndex;
     };
 
@@ -194,7 +194,7 @@ protected:
     /*
     **	This is the list of all sections within this INI file.
     */
-    List<INISection> SectionList;
+    VanillaList<INISection> SectionList;
 
     IndexClass<INISection*> SectionIndex;
 
@@ -203,7 +203,7 @@ public:
     {
         MAX_LINE_LENGTH = 128
     };
-    const List<INISection>& Section_List() const
+    const VanillaList<INISection>& Section_List() const
     {
         return SectionList;
     }

--- a/common/listnode.h
+++ b/common/listnode.h
@@ -174,13 +174,13 @@ private:
 **	interface class will work. You can usually ensure this by deriving the
 **	class T object from this node.
 */
-template <class T> class List;
-template <class T> class Node : public GenericNode
+template <class T> class VanillaList;
+template <class T> class VanillaNode : public GenericNode
 {
 public:
-    List<T>* Main_List(void) const
+    VanillaList<T>* Main_List(void) const
     {
-        return ((List<T>*)GenericNode::Main_List());
+        return ((VanillaList<T>*)GenericNode::Main_List());
     }
     T* Next(void) const
     {
@@ -200,7 +200,7 @@ public:
 **	This is an "interface class" for a list of nodes. The rules for the class T object
 **	are the same as the requirements required of the node class.
 */
-template <class T> class List : public GenericList
+template <class T> class VanillaList : public GenericList
 {
 public:
     T* First(void) const

--- a/common/mixfile.cpp
+++ b/common/mixfile.cpp
@@ -52,4 +52,4 @@ template class MixFileClass<CCFileClass>;
 **	This is the pointer to the first mixfile in the list of mixfiles registered
 **	with the mixfile system.
 */
-template <class T, class TCRC> List<MixFileClass<T, TCRC>> MixFileClass<T, TCRC>::MixList;
+template <class T, class TCRC> VanillaList<MixFileClass<T, TCRC>> MixFileClass<T, TCRC>::MixList;

--- a/common/mixfile.h
+++ b/common/mixfile.h
@@ -44,7 +44,7 @@ void Emergency_Exit(int);
 extern int RequiredCD;
 extern bool RunningAsDLL;
 
-template <class T, class TCRC = CRCEngine> class MixFileClass : public Node<MixFileClass<T>>
+template <class T, class TCRC = CRCEngine> class MixFileClass : public VanillaNode<MixFileClass<T>>
 {
 public:
     char const* Filename; // Filename of mixfile.
@@ -158,7 +158,7 @@ private:
     */
     void* Data; // Pointer to raw data.
 
-    static List<MixFileClass<T, TCRC>> MixList;
+    static VanillaList<MixFileClass<T, TCRC>> MixList;
 };
 
 /***********************************************************************************************

--- a/tools/mixtool/fastini.h
+++ b/tools/mixtool/fastini.h
@@ -43,7 +43,7 @@ enum INILoadType
 
 class FastINIClass
 {
-    class FastINIEntry : public Node<FastINIEntry>
+    class FastINIEntry : public VanillaNode<FastINIEntry>
     {
     public:
         // Class constructor and deconstructor.
@@ -78,7 +78,7 @@ class FastINIClass
         char* Value;
     };
 
-    class FastINISection : public Node<FastINISection>
+    class FastINISection : public VanillaNode<FastINISection>
     {
     public:
         FastINISection(const char* name)
@@ -109,7 +109,7 @@ class FastINIClass
 
     public:
         char* SectionName;
-        List<FastINIEntry> EntryList;
+        VanillaList<FastINIEntry> EntryList;
         IndexClass<FastINIEntry*> EntryIndex;
     };
 
@@ -139,7 +139,7 @@ public:
     int Load(FileClass& file);
     virtual int Load(Straw& straw);
 
-    const List<FastINISection>& Section_List() const
+    const VanillaList<FastINISection>& Section_List() const
     {
         return SectionList;
     }
@@ -189,7 +189,7 @@ protected:
     static int32_t const CRC(const char* string);
 
 protected:
-    List<FastINISection> SectionList;
+    VanillaList<FastINISection> SectionList;
     IndexClass<FastINISection*> SectionIndex;
 };
 

--- a/tools/mixtool/makemix.cpp
+++ b/tools/mixtool/makemix.cpp
@@ -43,7 +43,7 @@
 **	This is the pointer to the first mixfile in the list of mixfiles registered
 **	with the mixfile system.
 */
-template <class T, class TCRC> List<MixFileClass<T, TCRC>> MixFileClass<T, TCRC>::MixList;
+template <class T, class TCRC> VanillaList<MixFileClass<T, TCRC>> MixFileClass<T, TCRC>::MixList;
 
 void Print_Help()
 {

--- a/tools/mixtool/mixcreate.h
+++ b/tools/mixtool/mixcreate.h
@@ -76,11 +76,11 @@ template <typename TFC, typename TCRC> class MixFileCreatorClass
     };
 
 private:
-    class FileDataNode : public Node<FileDataNode>
+    class FileDataNode : public VanillaNode<FileDataNode>
     {
     public:
         FileDataNode()
-            : Node<FileDataNode>()
+            : VanillaNode<FileDataNode>()
             , Entry()
             , FilePath(nullptr)
             , InMix(false)
@@ -157,7 +157,7 @@ private:
     static char TempFilename[];
 
 protected:
-    List<FileDataNode> FileList;
+    VanillaList<FileDataNode> FileList;
     IndexClass<FileDataNode*> FileIndex;
     TFC* NewMixHandle;
     MixNameDatabase* NameDatabase;


### PR DESCRIPTION
…de' to avoid conflicts with system types.