### PR TITLE
Call Sound_End() during the normal exit procedure to ensure that the …

### DIFF
--- a/redalert/startup.cpp
+++ b/redalert/startup.cpp
@@ -491,6 +491,8 @@ int main(int argc, char* argv[])
         Reset_Video_Mode();
 #endif
 
+        Sound_End();
+
         /*
         ** Flag that this is a clean shutdown (not killed with Ctrl-Alt-Del)
         */

--- a/tiberiandawn/startup.cpp
+++ b/tiberiandawn/startup.cpp
@@ -471,7 +471,11 @@ int main(int argc, char** argv)
 
 #if defined(SDL_BUILD)
         Reset_Video_Mode();
-#elif defined(_WIN32)
+#endif
+
+        Sound_End();
+
+#if defined(_WIN32)
         PostMessageA(MainWindow, WM_DESTROY, 0, 0);
         do {
             Keyboard->Check();


### PR DESCRIPTION
…sound system is properly shut down before quitting the game.