### PR TITLE
Fixed radar remap for grey

### DIFF
--- a/tiberiandawn/house.cpp
+++ b/tiberiandawn/house.cpp
@@ -4612,8 +4612,8 @@ void HouseClass::Init_Data(PlayerColorType color, HousesType house, int credits)
 
     case REMAP_LTBLUE:
         RemapTable = RemapLtBlue;
-        ((unsigned char&)Class->Color) = 135;
-        ((unsigned char&)Class->BrightColor) = 2;
+        ((unsigned char&)Class->Color) = 203;
+        ((unsigned char&)Class->BrightColor) = 201;
         break;
 
     case REMAP_ORANGE:


### PR DESCRIPTION
In VC currently it shows a green colour for grey players on the radar. 

Current VC
![vcincorrectradarcolors](https://github.com/TheAssemblyArmada/Vanilla-Conquer/assets/3741094/0e530830-aeb3-4287-a11a-8347ab102e71)

As it looks like in C&C95 (using Nyerguds' 1.06 here)
![cccolors](https://github.com/TheAssemblyArmada/Vanilla-Conquer/assets/3741094/2020946e-dcb0-478c-a2df-4b816f2fdc1c)

How it looks like with this pull request
![vcfixedradarcolors](https://github.com/TheAssemblyArmada/Vanilla-Conquer/assets/3741094/791d91f7-cb63-4b8c-8527-61d57999d5b7)
