### PR TITLE
Fix TD skirmish vehicle building

### DIFF
--- a/tiberiandawn/scenarioini.cpp
+++ b/tiberiandawn/scenarioini.cpp
@@ -1701,7 +1701,8 @@ static void Create_Units(void)
         /*---------------------------------------------------------------------
         Set the house's max # units (this is used in the Mission_Timed_Hunt())
         ---------------------------------------------------------------------*/
-        hptr->MaxUnit = MPlayerUnitCount * scaleval;
+        // Disable this as it will force MaxUnit to 10 preventing AI from building vehicles in skirmish (Tore)
+        //hptr->MaxUnit = MPlayerUnitCount * scaleval;
 
         /*---------------------------------------------------------------------
         Create units for this house

--- a/tiberiandawn/scenarioini.cpp
+++ b/tiberiandawn/scenarioini.cpp
@@ -1698,11 +1698,12 @@ static void Create_Units(void)
             }
         }
 
+#ifndef USE_RA_AI // This prevents the AI from building vehicles when the RA AI is used in Skirmish. (Tore)
         /*---------------------------------------------------------------------
         Set the house's max # units (this is used in the Mission_Timed_Hunt())
         ---------------------------------------------------------------------*/
-        // Disable this as it will force MaxUnit to 10 preventing AI from building vehicles in skirmish (Tore)
-        //hptr->MaxUnit = MPlayerUnitCount * scaleval;
+        hptr->MaxUnit = MPlayerUnitCount * scaleval;
+#endif // USE_RA_AI
 
         /*---------------------------------------------------------------------
         Create units for this house


### PR DESCRIPTION
Currently in Vanilla Conquer TD skirmish the AI builds max 2 units. This PR should fix this. 