### PR TITLE
Fix TD house radar remap dark green edition

### DIFF
--- a/tiberiandawn/defines.h
+++ b/tiberiandawn/defines.h
@@ -697,11 +697,11 @@ typedef enum PlayerColorType : signed char
     REMAP_NONE = -1,
     REMAP_GOLD,
     REMAP_FIRST = REMAP_GOLD,
-    REMAP_LTBLUE,
+    REMAP_LTBLUE, // Ingame grey color
     REMAP_RED,
     REMAP_GREEN,
     REMAP_ORANGE,
-    REMAP_BLUE,
+    REMAP_BLUE, // Ingame dark green color
     REMAP_LAST = REMAP_BLUE,
 
     REMAP_COUNT

--- a/tiberiandawn/house.cpp
+++ b/tiberiandawn/house.cpp
@@ -4630,8 +4630,8 @@ void HouseClass::Init_Data(PlayerColorType color, HousesType house, int credits)
 
     case REMAP_BLUE:
         RemapTable = RemapBlue;
-        ((unsigned char&)Class->Color) = 203;
-        ((unsigned char&)Class->BrightColor) = 201;
+        ((unsigned char&)Class->Color) = 135;
+        ((unsigned char&)Class->BrightColor) = 2;
         break;
     }
 }


### PR DESCRIPTION
Didn't notice that the radar remap for grey and dark green were simply swapped.

Now radar shows dark green as dark green instead of grey.