### PR TITLE
TD: Handle save games made with different resolutions

### DIFF
--- a/tiberiandawn/credits.cpp
+++ b/tiberiandawn/credits.cpp
@@ -79,7 +79,6 @@ CreditClass::CreditClass(void)
  * HISTORY:                                                                                    *
  *   03/13/1995 JLB : Created.                                                                 *
  *=============================================================================================*/
-#define XX (320 - 120)
 #define WW 50
 void CreditClass::Graphic_Logic(bool forced)
 {

--- a/tiberiandawn/power.cpp
+++ b/tiberiandawn/power.cpp
@@ -110,6 +110,26 @@ void PowerClass::Init_Clear(void)
     PowerDir = 0;
 }
 
+void PowerClass::Recalculate_Offsets(void)
+{
+    int factor = Get_Resolution_Factor();
+    PowX = SeenBuff.Get_Width() - Map.RadWidth;
+    if (factor) {
+        PowY = Map.RadY + Map.RadHeight + (13 << factor) - 4;
+    } else {
+        PowY = Map.RadY + Map.RadHeight + (13 << factor);
+    }
+    PowWidth = 8 << factor;
+    PowHeight = SeenBuff.Get_Height() - PowY;
+    PowLineSpace = 5 << factor;
+    PowLineWidth = PowWidth - 4;
+
+    PowerButton.X = PowX;
+    PowerButton.Y = PowY;
+    PowerButton.Width = PowWidth - 1;
+    PowerButton.Height = PowHeight;
+}
+
 /***********************************************************************************************
  * PowerClass::One_Time -- One time processing for the power bar.                              *
  *                                                                                             *
@@ -127,24 +147,9 @@ void PowerClass::Init_Clear(void)
 void PowerClass::One_Time(void)
 {
     RadarClass::One_Time();
+    Recalculate_Offsets();
 
     int factor = Get_Resolution_Factor();
-    PowX = SeenBuff.Get_Width() - Map.RadWidth;
-    if (factor) {
-        PowY = Map.RadY + Map.RadHeight + (13 << factor) - 4;
-    } else {
-        PowY = Map.RadY + Map.RadHeight + (13 << factor);
-    }
-    PowWidth = 8 << factor;
-    PowHeight = SeenBuff.Get_Height() - PowY;
-    PowLineSpace = 5 << factor;
-    PowLineWidth = PowWidth - 4;
-
-    PowerButton.X = PowX;
-    PowerButton.Y = PowY;
-    PowerButton.Width = PowWidth - 1;
-    PowerButton.Height = PowHeight;
-
     PowerShape = MFCD::Retrieve((factor) ? "HPOWER.SHP" : "POWER.SHP");
     PowerBarShape = Hires_Retrieve("PWRBAR.SHP");
 }
@@ -172,6 +177,7 @@ void PowerClass::Draw_It(bool complete)
     int factor = Get_Resolution_Factor();
 
     if (complete || IsToRedraw) {
+        Recalculate_Offsets();
         //		PowX = TacPixelX + TacWidth*ICON_PIXEL_W;	// X position of upper left corner of power bar.
 
         if (LogicPage->Lock()) {

--- a/tiberiandawn/power.h
+++ b/tiberiandawn/power.h
@@ -103,6 +103,7 @@ protected:
     };
 
 private:
+    void Recalculate_Offsets(void);
     int Power_Height(int value);
 
     unsigned IsActive : 1;

--- a/tiberiandawn/radar.cpp
+++ b/tiberiandawn/radar.cpp
@@ -105,24 +105,7 @@ RadarClass::RadarClass(void)
     IsPlayerNames = false;
 }
 
-/***********************************************************************************************
- * RadarClass::One_Time -- Handles one time processing for the radar map.                      *
- *                                                                                             *
- *    This routine handles any one time processing required in order for the radar map to      *
- *    function. This actually only requires an allocation of the radar staging buffer. This    *
- *    buffer is needed for those cases where the radar area of the page is being destroyed     *
- *    and it needs to be destroyed.                                                            *
- *                                                                                             *
- * INPUT:   none                                                                               *
- *                                                                                             *
- * OUTPUT:  none                                                                               *
- *                                                                                             *
- * WARNINGS:   Be sure to call this routine only ONCE.                                         *
- *                                                                                             *
- * HISTORY:                                                                                    *
- *   12/22/1994 JLB : Created.                                                                 *
- *=============================================================================================*/
-void RadarClass::One_Time(void)
+void RadarClass::Recalculate_Offsets(void)
 {
     int factor = Get_Resolution_Factor();
     RadWidth = 80 << factor;
@@ -144,11 +127,33 @@ void RadarClass::One_Time(void)
         RadIHeight = 69 << factor;
     }
 
-    DisplayClass::One_Time();
     RadarButton.X = RadX + RadOffX;
     RadarButton.Y = RadY + RadOffY;
     RadarButton.Width = RadIWidth;
     RadarButton.Height = RadIHeight;
+}
+
+/***********************************************************************************************
+ * RadarClass::One_Time -- Handles one time processing for the radar map.                      *
+ *                                                                                             *
+ *    This routine handles any one time processing required in order for the radar map to      *
+ *    function. This actually only requires an allocation of the radar staging buffer. This    *
+ *    buffer is needed for those cases where the radar area of the page is being destroyed     *
+ *    and it needs to be destroyed.                                                            *
+ *                                                                                             *
+ * INPUT:   none                                                                               *
+ *                                                                                             *
+ * OUTPUT:  none                                                                               *
+ *                                                                                             *
+ * WARNINGS:   Be sure to call this routine only ONCE.                                         *
+ *                                                                                             *
+ * HISTORY:                                                                                    *
+ *   12/22/1994 JLB : Created.                                                                 *
+ *=============================================================================================*/
+void RadarClass::One_Time(void)
+{
+    Recalculate_Offsets();
+    DisplayClass::One_Time();
 }
 
 /***********************************************************************************************
@@ -337,6 +342,8 @@ void RadarClass::Draw_It(bool forced)
     */
     if (!forced && !IsToRedraw && !FullRedraw)
         return;
+
+    Recalculate_Offsets();
 
     static HousesType _house = HOUSE_NONE;
     if (PlayerPtr->ActLike != _house) {

--- a/tiberiandawn/radar.h
+++ b/tiberiandawn/radar.h
@@ -186,6 +186,8 @@ protected:
     static TacticalClass RadarButton;
 
 private:
+    void Recalculate_Offsets(void);
+
     /*
     **	The current radar position as the upper left corner cell for the
     **	radar map display. The width and height is controlled by the

--- a/tiberiandawn/sidebar.h
+++ b/tiberiandawn/sidebar.h
@@ -367,6 +367,9 @@ public:
         */
         static char ClockTranslucentTable[(1 + 1) * 256];
 
+    private:
+        void Recalculate_Offsets(void);
+
     } Column[COLUMNS];
 
     /*
@@ -408,6 +411,7 @@ public:
     static void const* SidebarShape2;
 
 private:
+    void Recalculate_Offsets(void);
     bool Activate_Repair(int control);
     bool Activate_Upgrade(int control);
     bool Activate_Demolish(int control);

--- a/tiberiandawn/tab.cpp
+++ b/tiberiandawn/tab.cpp
@@ -127,7 +127,7 @@ void TabClass::Draw_It(bool complete)
 
 void TabClass::Draw_Credits_Tab(void)
 {
-    unsigned x = Get_Resolution_Factor() ? 320 : 160;
+    unsigned x = SeenBuff.Get_Width() - (Get_Resolution_Factor() ? 320 : 160);
     CC_Draw_Shape(TabShape, 0, x, 0, WINDOW_MAIN, SHAPE_NORMAL);
 }
 


### PR DESCRIPTION
This commit makes the sidebar account for changes in screen width, such as those caused by loading a saved game made at a different resolution. Additionally, placement logic was changed for certain elements to be right-aligned rather than left-aligned, allowing different horizontal widths greater than 640 to appear correct.