### PR TITLE
Moved platform-specific WWKeyboardClass code into their own classes and files.

### DIFF
--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -112,6 +112,7 @@ set(COMMONR_SRC
     soundio_null.cpp
     video_null.cpp
     wwkeyboard.cpp
+    wwkeyboard_win32.cpp
     wwmouse.cpp
 )
 
@@ -140,12 +141,12 @@ else()
 endif()
 
 if(DDRAW)
-    list(APPEND COMMONV_SRC video_ddraw.cpp)
+    list(APPEND COMMONV_SRC video_ddraw.cpp wwkeyboard_win32.cpp)
     list(APPEND VANILLA_LIBS ddraw)
 elseif(SDL2)
-    list(APPEND COMMONV_SRC video_sdl2.cpp)
+    list(APPEND COMMONV_SRC video_sdl2.cpp wwkeyboard_sdl2.cpp)
 elseif(SDL1)
-    list(APPEND COMMONV_SRC video_sdl1.cpp)
+    list(APPEND COMMONV_SRC video_sdl1.cpp wwkeyboard_sdl1.cpp)
 else()
     list(APPEND COMMONV_SRC video_null.cpp)
 endif()

--- a/common/wwkeyboard.cpp
+++ b/common/wwkeyboard.cpp
@@ -55,12 +55,7 @@
 #include "video.h"
 #include "miscasm.h"
 #include <string.h>
-#include <cmath>
 #include <cstdlib>
-#ifdef SDL_BUILD
-#include <SDL.h>
-#include "sdl_keymap.h"
-#endif
 #include "settings.h"
 
 #define ARRAY_SIZE(x) int(sizeof(x) / sizeof(x[0]))
@@ -88,11 +83,11 @@ WWKeyboardClass::WWKeyboardClass(void)
     , Tail(0)
     , DownSkip(0)
 {
-#if defined(_WIN32)
-    memset(KeyState, '\0', sizeof(KeyState));
-#endif
-
     memset(DownState, '\0', sizeof(DownState));
+}
+
+WWKeyboardClass::~WWKeyboardClass()
+{
 }
 
 /***********************************************************************************************
@@ -276,92 +271,6 @@ bool WWKeyboardClass::Put_Mouse_Message(unsigned short vk_key, int x, int y, boo
 }
 
 /***********************************************************************************************
- * WWKeyboardClass::To_ASCII -- Convert the key value into an ASCII representation.            *
- *                                                                                             *
- *    This routine will convert the key code specified into an ASCII value. This takes into    *
- *    consideration the language and keyboard mapping of the host Windows system.              *
- *                                                                                             *
- * INPUT:   key   -- The key code to convert into ASCII.                                       *
- *                                                                                             *
- * OUTPUT:  Returns with the key converted into ASCII. If the key has no ASCII equivalent,     *
- *          then '\0' is returned.                                                             *
- *                                                                                             *
- * WARNINGS:   none                                                                            *
- *                                                                                             *
- * HISTORY:                                                                                    *
- *   09/30/1996 JLB : Created.                                                                 *
- *=============================================================================================*/
-KeyASCIIType WWKeyboardClass::To_ASCII(unsigned short key)
-{
-    /*
-    **	Released keys never translate into an ASCII value.
-    */
-    if (key & WWKEY_RLS_BIT) {
-        return KA_NONE;
-    }
-
-    /*
-    **	Ask windows to translate the key into an ASCII equivalent.
-    */
-    char buffer[10];
-    int result = 1;
-    int scancode = 0;
-
-#if defined(SDL_BUILD)
-    key &= 0xFF; // drop all mods
-
-    if (key > ARRAY_SIZE(sdl_keymap) / 2 - 1) {
-        return KA_NONE;
-    }
-
-    if (SDL_GetModState() & KMOD_SHIFT) {
-        return sdl_keymap[key + ARRAY_SIZE(sdl_keymap) / 2];
-    } else {
-        return sdl_keymap[key];
-    }
-#elif defined(_WIN32)
-    /*
-    **	Set the KeyState buffer to reflect the shift bits stored in the key value.
-    */
-    if (key & WWKEY_SHIFT_BIT) {
-        KeyState[VK_SHIFT] = 0x80;
-    }
-    if (key & WWKEY_CTRL_BIT) {
-        KeyState[VK_CONTROL] = 0x80;
-    }
-    if (key & WWKEY_ALT_BIT) {
-        KeyState[VK_MENU] = 0x80;
-    }
-
-    scancode = MapVirtualKeyA(key & 0xFF, 0);
-    result = ToAscii((UINT)(key & 0xFF), (UINT)scancode, (PBYTE)KeyState, (LPWORD)buffer, (UINT)0);
-
-    /*
-    **	Restore the KeyState buffer back to pristine condition.
-    */
-    if (key & WWKEY_SHIFT_BIT) {
-        KeyState[VK_SHIFT] = 0;
-    }
-    if (key & WWKEY_CTRL_BIT) {
-        KeyState[VK_CONTROL] = 0;
-    }
-    if (key & WWKEY_ALT_BIT) {
-        KeyState[VK_MENU] = 0;
-    }
-#endif
-
-    /*
-    **	If Windows could not perform the translation as expected, then
-    **	return with a null ASCII value.
-    */
-    if (result != 1) {
-        return KA_NONE;
-    }
-
-    return (KeyASCIIType)(buffer[0]);
-}
-
-/***********************************************************************************************
  * WWKeyboardClass::Down -- Checks to see if the specified key is being held down.             *
  *                                                                                             *
  *    This routine will examine the key specified to see if it is currently being held down.   *
@@ -534,326 +443,28 @@ bool WWKeyboardClass::Is_Buffer_Empty(void) const
  * HISTORY:                                                                                    *
  *   09/30/1996 JLB : Created.                                                                 *
  *=============================================================================================*/
-void Process_Network();
-
-void WWKeyboardClass::Fill_Buffer_From_System(void)
-{
-#ifdef SDL_BUILD
-#ifdef NETWORKING
-    Process_Network();
-#endif
-    SDL_Event event;
-
-    while (!Is_Buffer_Full() && SDL_PollEvent(&event)) {
-        unsigned short key;
-        switch (event.type) {
-        case SDL_QUIT:
-            exit(0);
-            break;
-        case SDL_KEYDOWN:
-#ifdef SDL2_BUILD
-            Put_Key_Message(event.key.keysym.scancode, false);
-#else
-            Put_Key_Message(event.key.keysym.sym, false);
-#endif
-            break;
-        case SDL_KEYUP:
-#ifdef SDL2_BUILD
-            if (event.key.keysym.scancode == SDL_SCANCODE_RETURN && Down(VK_MENU)) {
-                Toggle_Video_Fullscreen();
-            } else {
-                Put_Key_Message(event.key.keysym.scancode, true);
-            }
-#else
-            Put_Key_Message(event.key.keysym.sym, true);
-#endif
-            break;
-        case SDL_MOUSEMOTION:
-            Move_Video_Mouse(static_cast<float>(event.motion.xrel), static_cast<float>(event.motion.yrel));
-            break;
-        case SDL_MOUSEBUTTONDOWN:
-        case SDL_MOUSEBUTTONUP: {
-            int x, y;
-
-            switch (event.button.button) {
-            case SDL_BUTTON_LEFT:
-            default:
-                key = VK_LBUTTON;
-                break;
-            case SDL_BUTTON_RIGHT:
-                key = VK_RBUTTON;
-                break;
-            case SDL_BUTTON_MIDDLE:
-                key = VK_MBUTTON;
-                break;
-#ifdef SDL1_BUILD
-            case SDL_BUTTON_WHEELUP:
-                key = VK_MOUSEWHEEL_UP;
-                break;
-            case SDL_BUTTON_WHEELDOWN:
-                key = VK_MOUSEWHEEL_DOWN;
-                break;
-#endif
-            }
-
-            if (Settings.Mouse.RawInput || Is_Gamepad_Active()) {
-                Get_Video_Mouse(x, y);
-            } else {
-                float scale_x = 1.0f, scale_y = 1.0f;
-                Get_Video_Scale(scale_x, scale_y);
-                x = event.button.x / scale_x;
-                y = event.button.y / scale_y;
-            }
-
-            Put_Mouse_Message(key, x, y, event.type == SDL_MOUSEBUTTONDOWN ? false : true);
-        } break;
-#ifdef SDL2_BUILD
-        case SDL_WINDOWEVENT:
-            switch (event.window.event) {
-            case SDL_WINDOWEVENT_EXPOSED:
-            case SDL_WINDOWEVENT_RESTORED:
-            case SDL_WINDOWEVENT_FOCUS_GAINED:
-                Focus_Restore();
-                break;
-            case SDL_WINDOWEVENT_HIDDEN:
-            case SDL_WINDOWEVENT_MINIMIZED:
-            case SDL_WINDOWEVENT_FOCUS_LOST:
-                Focus_Loss();
-                break;
-            }
-            break;
-        case SDL_MOUSEWHEEL:
-            if (event.wheel.y > 0) { // scroll up
-                Put_Key_Message(VK_MOUSEWHEEL_UP, false);
-            } else if (event.wheel.y < 0) { // scroll down
-                Put_Key_Message(VK_MOUSEWHEEL_DOWN, false);
-            }
-            break;
-        case SDL_CONTROLLERDEVICEREMOVED:
-            if (GameController != nullptr) {
-                const SDL_GameController* removedController = SDL_GameControllerFromInstanceID(event.jdevice.which);
-                if (removedController == GameController) {
-                    SDL_GameControllerClose(GameController);
-                    GameController = nullptr;
-                }
-            }
-            break;
-        case SDL_CONTROLLERDEVICEADDED:
-            if (GameController == nullptr) {
-                GameController = SDL_GameControllerOpen(event.jdevice.which);
-            }
-            break;
-        case SDL_CONTROLLERAXISMOTION:
-            Handle_Controller_Axis_Event(event.caxis);
-            break;
-        case SDL_CONTROLLERBUTTONDOWN:
-        case SDL_CONTROLLERBUTTONUP:
-            Handle_Controller_Button_Event(event.cbutton);
-            break;
-#endif
-        }
-    }
-#ifdef SDL2_BUILD
-    if (Is_Gamepad_Active()) {
-        Process_Controller_Axis_Motion();
-    }
-#endif
-#elif defined(_WIN32)
-    if (!Is_Buffer_Full()) {
-        MSG msg;
-        while (PeekMessageA(&msg, NULL, 0, 0, PM_NOREMOVE)) {
-            if (!GetMessageA(&msg, NULL, 0, 0)) {
-                return;
-            }
-            TranslateMessage(&msg);
-            DispatchMessageA(&msg);
-        }
-    }
-#endif
-}
-
-#ifdef SDL2_BUILD
 bool WWKeyboardClass::Is_Gamepad_Active()
 {
-    return GameController != nullptr;
+    return false;
 }
 
 void WWKeyboardClass::Open_Controller()
 {
-    for (int i = 0; i < SDL_NumJoysticks(); ++i) {
-        if (SDL_IsGameController(i)) {
-            GameController = SDL_GameControllerOpen(i);
-        }
-    }
 }
 
 void WWKeyboardClass::Close_Controller()
 {
-    if (SDL_GameControllerGetAttached(GameController)) {
-        SDL_GameControllerClose(GameController);
-        GameController = nullptr;
-    }
-}
-
-void WWKeyboardClass::Process_Controller_Axis_Motion()
-{
-    const uint32_t currentTime = SDL_GetTicks();
-    const float deltaTime = currentTime - LastControllerTime;
-    LastControllerTime = currentTime;
-
-    if (ControllerLeftXAxis != 0 || ControllerLeftYAxis != 0) {
-        const int16_t xSign = (ControllerLeftXAxis > 0) - (ControllerLeftXAxis < 0);
-        const int16_t ySign = (ControllerLeftYAxis > 0) - (ControllerLeftYAxis < 0);
-
-        float movX = std::pow(std::abs(ControllerLeftXAxis), CONTROLLER_AXIS_SPEEDUP) * xSign * deltaTime
-                     * Settings.Mouse.ControllerPointerSpeed / CONTROLLER_SPEED_MOD * ControllerSpeedBoost;
-        float movY = std::pow(std::abs(ControllerLeftYAxis), CONTROLLER_AXIS_SPEEDUP) * ySign * deltaTime
-                     * Settings.Mouse.ControllerPointerSpeed / CONTROLLER_SPEED_MOD * ControllerSpeedBoost;
-
-        Move_Video_Mouse(movX, movY);
-    }
-}
-
-void WWKeyboardClass::Handle_Controller_Axis_Event(const SDL_ControllerAxisEvent& motion)
-{
-    AnalogScrollActive = false;
-    ScrollDirType directionX = SDIR_NONE;
-    ScrollDirType directionY = SDIR_NONE;
-
-    if (motion.axis == SDL_CONTROLLER_AXIS_LEFTX) {
-        if (std::abs(motion.value) > CONTROLLER_L_DEADZONE)
-            ControllerLeftXAxis = motion.value;
-        else
-            ControllerLeftXAxis = 0;
-    } else if (motion.axis == SDL_CONTROLLER_AXIS_LEFTY) {
-        if (std::abs(motion.value) > CONTROLLER_L_DEADZONE)
-            ControllerLeftYAxis = motion.value;
-        else
-            ControllerLeftYAxis = 0;
-    } else if (motion.axis == SDL_CONTROLLER_AXIS_RIGHTX) {
-        if (std::abs(motion.value) > CONTROLLER_R_DEADZONE)
-            ControllerRightXAxis = motion.value;
-        else
-            ControllerRightXAxis = 0;
-    } else if (motion.axis == SDL_CONTROLLER_AXIS_RIGHTY) {
-        if (std::abs(motion.value) > CONTROLLER_R_DEADZONE)
-            ControllerRightYAxis = motion.value;
-        else
-            ControllerRightYAxis = 0;
-    } else if (motion.axis == SDL_CONTROLLER_AXIS_TRIGGERRIGHT) {
-        if (std::abs(motion.value) > CONTROLLER_TRIGGER_R_DEADZONE)
-            ControllerSpeedBoost = 1 + (static_cast<float>(motion.value) / 32767) * CONTROLLER_TRIGGER_SPEEDUP;
-        else
-            ControllerSpeedBoost = 1;
-    }
-
-    if (ControllerRightXAxis != 0) {
-        AnalogScrollActive = true;
-        directionX = ControllerRightXAxis > 0 ? SDIR_E : SDIR_W;
-    }
-    if (ControllerRightYAxis != 0) {
-        AnalogScrollActive = true;
-        directionY = ControllerRightYAxis > 0 ? SDIR_S : SDIR_N;
-    }
-
-    if (directionX == SDIR_E && directionY == SDIR_N) {
-        ScrollDirection = SDIR_NE;
-    } else if (directionX == SDIR_E && directionY == SDIR_S) {
-        ScrollDirection = SDIR_SE;
-    } else if (directionX == SDIR_W && directionY == SDIR_N) {
-        ScrollDirection = SDIR_NW;
-    } else if (directionX == SDIR_W && directionY == SDIR_S) {
-        ScrollDirection = SDIR_SW;
-    } else if (directionX == SDIR_E) {
-        ScrollDirection = SDIR_E;
-    } else if (directionX == SDIR_W) {
-        ScrollDirection = SDIR_W;
-    } else if (directionY == SDIR_S) {
-        ScrollDirection = SDIR_S;
-    } else if (directionY == SDIR_N) {
-        ScrollDirection = SDIR_N;
-    }
-}
-
-void WWKeyboardClass::Handle_Controller_Button_Event(const SDL_ControllerButtonEvent& button)
-{
-    bool keyboardPress = false;
-    bool mousePress = false;
-    unsigned short key;
-    SDL_Scancode scancode;
-
-    switch (button.button) {
-    case SDL_CONTROLLER_BUTTON_A:
-        mousePress = true;
-        key = VK_LBUTTON;
-        break;
-    case SDL_CONTROLLER_BUTTON_B:
-        mousePress = true;
-        key = VK_RBUTTON;
-        break;
-    case SDL_CONTROLLER_BUTTON_X:
-        keyboardPress = true;
-        scancode = SDL_SCANCODE_G;
-        break;
-    case SDL_CONTROLLER_BUTTON_Y:
-        keyboardPress = true;
-        scancode = SDL_SCANCODE_F;
-        break;
-    case SDL_CONTROLLER_BUTTON_BACK:
-        keyboardPress = true;
-        scancode = SDL_SCANCODE_ESCAPE;
-        break;
-    case SDL_CONTROLLER_BUTTON_START:
-        keyboardPress = true;
-        scancode = SDL_SCANCODE_RETURN;
-        break;
-    case SDL_CONTROLLER_BUTTON_LEFTSHOULDER:
-        keyboardPress = true;
-        scancode = SDL_SCANCODE_LCTRL;
-        break;
-    case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER:
-        keyboardPress = true;
-        scancode = SDL_SCANCODE_LALT;
-        break;
-    case SDL_CONTROLLER_BUTTON_DPAD_UP:
-        keyboardPress = true;
-        scancode = SDL_SCANCODE_1;
-        break;
-    case SDL_CONTROLLER_BUTTON_DPAD_RIGHT:
-        keyboardPress = true;
-        scancode = SDL_SCANCODE_2;
-        break;
-    case SDL_CONTROLLER_BUTTON_DPAD_DOWN:
-        keyboardPress = true;
-        scancode = SDL_SCANCODE_3;
-        break;
-    case SDL_CONTROLLER_BUTTON_DPAD_LEFT:
-        keyboardPress = true;
-        scancode = SDL_SCANCODE_4;
-        break;
-    default:
-        break;
-    }
-
-    if (keyboardPress) {
-        Put_Key_Message(scancode, button.state == SDL_RELEASED);
-    } else if (mousePress) {
-        int x, y;
-        Get_Video_Mouse(x, y);
-        Put_Mouse_Message(key, x, y, button.state == SDL_RELEASED);
-    }
 }
 
 bool WWKeyboardClass::Is_Analog_Scroll_Active()
 {
-    return AnalogScrollActive;
+    return false;
 }
 
 unsigned char WWKeyboardClass::Get_Scroll_Direction()
 {
-    return ScrollDirection;
+    return SDIR_NONE;
 }
-#endif
 
 /***********************************************************************************************
  * WWKeyboardClass::Clear -- Clears the keyboard buffer.                                       *

--- a/common/wwkeyboard_sdl1.cpp
+++ b/common/wwkeyboard_sdl1.cpp
@@ -1,0 +1,113 @@
+//
+// Copyright 2020 Electronic Arts Inc.
+//
+// TiberianDawn.DLL and RedAlert.dll and corresponding source code is free
+// software: you can redistribute it and/or modify it under the terms of
+// the GNU General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+
+// TiberianDawn.DLL and RedAlert.dll and corresponding source code is distributed
+// in the hope that it will be useful, but with permitted additional restrictions
+// under Section 7 of the GPL. See the GNU General Public License in LICENSE.TXT
+// distributed with this program. You should have received a copy of the
+// GNU General Public License along with permitted additional restrictions
+// with this program. If not, see https://github.com/electronicarts/CnC_Remastered_Collection
+
+#include "macros.h"
+#include "wwkeyboard_sdl1.h"
+#include "video.h"
+#include "sdl_keymap.h"
+#include "settings.h"
+#include <SDL.h>
+
+void Focus_Loss();
+void Focus_Restore();
+void Process_Network();
+
+WWKeyboardClassSDL1::~WWKeyboardClassSDL1()
+{
+}
+
+void WWKeyboardClassSDL1::Fill_Buffer_From_System(void)
+{
+#ifdef NETWORKING
+    Process_Network();
+#endif
+    SDL_Event event;
+
+    while (!Is_Buffer_Full() && SDL_PollEvent(&event)) {
+        unsigned short key;
+        switch (event.type) {
+        case SDL_QUIT:
+            exit(0);
+            break;
+        case SDL_KEYDOWN:
+            Put_Key_Message(event.key.keysym.sym, false);
+            break;
+        case SDL_KEYUP:
+            Put_Key_Message(event.key.keysym.sym, true);
+            break;
+        case SDL_MOUSEMOTION:
+            Move_Video_Mouse(static_cast<float>(event.motion.xrel), static_cast<float>(event.motion.yrel));
+            break;
+        case SDL_MOUSEBUTTONDOWN:
+        case SDL_MOUSEBUTTONUP: {
+            int x, y;
+
+            switch (event.button.button) {
+            case SDL_BUTTON_LEFT:
+            default:
+                key = VK_LBUTTON;
+                break;
+            case SDL_BUTTON_RIGHT:
+                key = VK_RBUTTON;
+                break;
+            case SDL_BUTTON_MIDDLE:
+                key = VK_MBUTTON;
+                break;
+            case SDL_BUTTON_WHEELUP:
+                key = VK_MOUSEWHEEL_UP;
+                break;
+            case SDL_BUTTON_WHEELDOWN:
+                key = VK_MOUSEWHEEL_DOWN;
+                break;
+            }
+
+            if (Settings.Mouse.RawInput || Is_Gamepad_Active()) {
+                Get_Video_Mouse(x, y);
+            } else {
+                float scale_x = 1.0f, scale_y = 1.0f;
+                Get_Video_Scale(scale_x, scale_y);
+                x = event.button.x / scale_x;
+                y = event.button.y / scale_y;
+            }
+
+            Put_Mouse_Message(key, x, y, event.type == SDL_MOUSEBUTTONDOWN ? false : true);
+        } break;
+        }
+    }
+}
+
+KeyASCIIType WWKeyboardClassSDL1::To_ASCII(unsigned short key)
+{
+    if (key & WWKEY_RLS_BIT) {
+        return KA_NONE;
+    }
+
+    key &= 0xFF; // drop all mods
+
+    if (key > ARRAY_SIZE(sdl_keymap) / 2 - 1) {
+        return KA_NONE;
+    }
+
+    if (SDL_GetModState() & KMOD_SHIFT) {
+        return sdl_keymap[key + ARRAY_SIZE(sdl_keymap) / 2];
+    } else {
+        return sdl_keymap[key];
+    }
+}
+
+WWKeyboardClass* CreateWWKeyboardClass(void)
+{
+    return new WWKeyboardClassSDL1;
+}

--- a/common/wwkeyboard_sdl1.h
+++ b/common/wwkeyboard_sdl1.h
@@ -1,0 +1,10 @@
+#include "wwkeyboard.h"
+
+class WWKeyboardClassSDL1 : public WWKeyboardClass
+{
+public:
+    virtual ~WWKeyboardClassSDL1();
+
+    virtual void Fill_Buffer_From_System(void);
+    virtual KeyASCIIType To_ASCII(unsigned short key);
+};

--- a/common/wwkeyboard_sdl2.cpp
+++ b/common/wwkeyboard_sdl2.cpp
@@ -1,0 +1,338 @@
+//
+// Copyright 2020 Electronic Arts Inc.
+//
+// TiberianDawn.DLL and RedAlert.dll and corresponding source code is free
+// software: you can redistribute it and/or modify it under the terms of
+// the GNU General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+
+// TiberianDawn.DLL and RedAlert.dll and corresponding source code is distributed
+// in the hope that it will be useful, but with permitted additional restrictions
+// under Section 7 of the GPL. See the GNU General Public License in LICENSE.TXT
+// distributed with this program. You should have received a copy of the
+// GNU General Public License along with permitted additional restrictions
+// with this program. If not, see https://github.com/electronicarts/CnC_Remastered_Collection
+
+#include "macros.h"
+#include "wwkeyboard_sdl2.h"
+#include "video.h"
+#include "sdl_keymap.h"
+#include "settings.h"
+#include <cmath>
+#include <SDL.h>
+
+void Focus_Loss();
+void Focus_Restore();
+void Process_Network();
+
+WWKeyboardClassSDL2::~WWKeyboardClassSDL2()
+{
+}
+
+void WWKeyboardClassSDL2::Fill_Buffer_From_System(void)
+{
+#ifdef NETWORKING
+    Process_Network();
+#endif
+    SDL_Event event;
+
+    while (!Is_Buffer_Full() && SDL_PollEvent(&event)) {
+        unsigned short key;
+        switch (event.type) {
+        case SDL_QUIT:
+            exit(0);
+            break;
+        case SDL_KEYDOWN:
+            Put_Key_Message(event.key.keysym.scancode, false);
+            break;
+        case SDL_KEYUP:
+            if (event.key.keysym.scancode == SDL_SCANCODE_RETURN && Down(VK_MENU)) {
+                Toggle_Video_Fullscreen();
+            } else {
+                Put_Key_Message(event.key.keysym.scancode, true);
+            }
+            break;
+        case SDL_MOUSEMOTION:
+            Move_Video_Mouse(static_cast<float>(event.motion.xrel), static_cast<float>(event.motion.yrel));
+            break;
+        case SDL_MOUSEBUTTONDOWN:
+        case SDL_MOUSEBUTTONUP: {
+            int x, y;
+
+            switch (event.button.button) {
+            case SDL_BUTTON_LEFT:
+            default:
+                key = VK_LBUTTON;
+                break;
+            case SDL_BUTTON_RIGHT:
+                key = VK_RBUTTON;
+                break;
+            case SDL_BUTTON_MIDDLE:
+                key = VK_MBUTTON;
+                break;
+            }
+
+            if (Settings.Mouse.RawInput || Is_Gamepad_Active()) {
+                Get_Video_Mouse(x, y);
+            } else {
+                float scale_x = 1.0f, scale_y = 1.0f;
+                Get_Video_Scale(scale_x, scale_y);
+                x = event.button.x / scale_x;
+                y = event.button.y / scale_y;
+            }
+
+            Put_Mouse_Message(key, x, y, event.type == SDL_MOUSEBUTTONDOWN ? false : true);
+        } break;
+        case SDL_WINDOWEVENT:
+            switch (event.window.event) {
+            case SDL_WINDOWEVENT_EXPOSED:
+            case SDL_WINDOWEVENT_RESTORED:
+            case SDL_WINDOWEVENT_FOCUS_GAINED:
+                Focus_Restore();
+                break;
+            case SDL_WINDOWEVENT_HIDDEN:
+            case SDL_WINDOWEVENT_MINIMIZED:
+            case SDL_WINDOWEVENT_FOCUS_LOST:
+                Focus_Loss();
+                break;
+            }
+            break;
+        case SDL_MOUSEWHEEL:
+            if (event.wheel.y > 0) { // scroll up
+                Put_Key_Message(VK_MOUSEWHEEL_UP, false);
+            } else if (event.wheel.y < 0) { // scroll down
+                Put_Key_Message(VK_MOUSEWHEEL_DOWN, false);
+            }
+            break;
+        case SDL_CONTROLLERDEVICEREMOVED:
+            if (GameController != nullptr) {
+                const SDL_GameController* removedController = SDL_GameControllerFromInstanceID(event.jdevice.which);
+                if (removedController == GameController) {
+                    SDL_GameControllerClose(GameController);
+                    GameController = nullptr;
+                }
+            }
+            break;
+        case SDL_CONTROLLERDEVICEADDED:
+            if (GameController == nullptr) {
+                GameController = SDL_GameControllerOpen(event.jdevice.which);
+            }
+            break;
+        case SDL_CONTROLLERAXISMOTION:
+            Handle_Controller_Axis_Event(event.caxis);
+            break;
+        case SDL_CONTROLLERBUTTONDOWN:
+        case SDL_CONTROLLERBUTTONUP:
+            Handle_Controller_Button_Event(event.cbutton);
+            break;
+        }
+    }
+    if (Is_Gamepad_Active()) {
+        Process_Controller_Axis_Motion();
+    }
+}
+
+bool WWKeyboardClassSDL2::Is_Gamepad_Active()
+{
+    return GameController != nullptr;
+}
+
+void WWKeyboardClassSDL2::Open_Controller()
+{
+    for (int i = 0; i < SDL_NumJoysticks(); ++i) {
+        if (SDL_IsGameController(i)) {
+            GameController = SDL_GameControllerOpen(i);
+        }
+    }
+}
+
+void WWKeyboardClassSDL2::Close_Controller()
+{
+    if (SDL_GameControllerGetAttached(GameController)) {
+        SDL_GameControllerClose(GameController);
+        GameController = nullptr;
+    }
+}
+
+void WWKeyboardClassSDL2::Process_Controller_Axis_Motion()
+{
+    const uint32_t currentTime = SDL_GetTicks();
+    const float deltaTime = currentTime - LastControllerTime;
+    LastControllerTime = currentTime;
+
+    if (ControllerLeftXAxis != 0 || ControllerLeftYAxis != 0) {
+        const int16_t xSign = (ControllerLeftXAxis > 0) - (ControllerLeftXAxis < 0);
+        const int16_t ySign = (ControllerLeftYAxis > 0) - (ControllerLeftYAxis < 0);
+
+        float movX = std::pow(std::abs(ControllerLeftXAxis), CONTROLLER_AXIS_SPEEDUP) * xSign * deltaTime
+                     * Settings.Mouse.ControllerPointerSpeed / CONTROLLER_SPEED_MOD * ControllerSpeedBoost;
+        float movY = std::pow(std::abs(ControllerLeftYAxis), CONTROLLER_AXIS_SPEEDUP) * ySign * deltaTime
+                     * Settings.Mouse.ControllerPointerSpeed / CONTROLLER_SPEED_MOD * ControllerSpeedBoost;
+
+        Move_Video_Mouse(movX, movY);
+    }
+}
+
+void WWKeyboardClassSDL2::Handle_Controller_Axis_Event(const SDL_ControllerAxisEvent& motion)
+{
+    AnalogScrollActive = false;
+    ScrollDirType directionX = SDIR_NONE;
+    ScrollDirType directionY = SDIR_NONE;
+
+    if (motion.axis == SDL_CONTROLLER_AXIS_LEFTX) {
+        if (std::abs(motion.value) > CONTROLLER_L_DEADZONE)
+            ControllerLeftXAxis = motion.value;
+        else
+            ControllerLeftXAxis = 0;
+    } else if (motion.axis == SDL_CONTROLLER_AXIS_LEFTY) {
+        if (std::abs(motion.value) > CONTROLLER_L_DEADZONE)
+            ControllerLeftYAxis = motion.value;
+        else
+            ControllerLeftYAxis = 0;
+    } else if (motion.axis == SDL_CONTROLLER_AXIS_RIGHTX) {
+        if (std::abs(motion.value) > CONTROLLER_R_DEADZONE)
+            ControllerRightXAxis = motion.value;
+        else
+            ControllerRightXAxis = 0;
+    } else if (motion.axis == SDL_CONTROLLER_AXIS_RIGHTY) {
+        if (std::abs(motion.value) > CONTROLLER_R_DEADZONE)
+            ControllerRightYAxis = motion.value;
+        else
+            ControllerRightYAxis = 0;
+    } else if (motion.axis == SDL_CONTROLLER_AXIS_TRIGGERRIGHT) {
+        if (std::abs(motion.value) > CONTROLLER_TRIGGER_R_DEADZONE)
+            ControllerSpeedBoost = 1 + (static_cast<float>(motion.value) / 32767) * CONTROLLER_TRIGGER_SPEEDUP;
+        else
+            ControllerSpeedBoost = 1;
+    }
+
+    if (ControllerRightXAxis != 0) {
+        AnalogScrollActive = true;
+        directionX = ControllerRightXAxis > 0 ? SDIR_E : SDIR_W;
+    }
+    if (ControllerRightYAxis != 0) {
+        AnalogScrollActive = true;
+        directionY = ControllerRightYAxis > 0 ? SDIR_S : SDIR_N;
+    }
+
+    if (directionX == SDIR_E && directionY == SDIR_N) {
+        ScrollDirection = SDIR_NE;
+    } else if (directionX == SDIR_E && directionY == SDIR_S) {
+        ScrollDirection = SDIR_SE;
+    } else if (directionX == SDIR_W && directionY == SDIR_N) {
+        ScrollDirection = SDIR_NW;
+    } else if (directionX == SDIR_W && directionY == SDIR_S) {
+        ScrollDirection = SDIR_SW;
+    } else if (directionX == SDIR_E) {
+        ScrollDirection = SDIR_E;
+    } else if (directionX == SDIR_W) {
+        ScrollDirection = SDIR_W;
+    } else if (directionY == SDIR_S) {
+        ScrollDirection = SDIR_S;
+    } else if (directionY == SDIR_N) {
+        ScrollDirection = SDIR_N;
+    }
+}
+
+void WWKeyboardClassSDL2::Handle_Controller_Button_Event(const SDL_ControllerButtonEvent& button)
+{
+    bool keyboardPress = false;
+    bool mousePress = false;
+    unsigned short key;
+    SDL_Scancode scancode;
+
+    switch (button.button) {
+    case SDL_CONTROLLER_BUTTON_A:
+        mousePress = true;
+        key = VK_LBUTTON;
+        break;
+    case SDL_CONTROLLER_BUTTON_B:
+        mousePress = true;
+        key = VK_RBUTTON;
+        break;
+    case SDL_CONTROLLER_BUTTON_X:
+        keyboardPress = true;
+        scancode = SDL_SCANCODE_G;
+        break;
+    case SDL_CONTROLLER_BUTTON_Y:
+        keyboardPress = true;
+        scancode = SDL_SCANCODE_F;
+        break;
+    case SDL_CONTROLLER_BUTTON_BACK:
+        keyboardPress = true;
+        scancode = SDL_SCANCODE_ESCAPE;
+        break;
+    case SDL_CONTROLLER_BUTTON_START:
+        keyboardPress = true;
+        scancode = SDL_SCANCODE_RETURN;
+        break;
+    case SDL_CONTROLLER_BUTTON_LEFTSHOULDER:
+        keyboardPress = true;
+        scancode = SDL_SCANCODE_LCTRL;
+        break;
+    case SDL_CONTROLLER_BUTTON_RIGHTSHOULDER:
+        keyboardPress = true;
+        scancode = SDL_SCANCODE_LALT;
+        break;
+    case SDL_CONTROLLER_BUTTON_DPAD_UP:
+        keyboardPress = true;
+        scancode = SDL_SCANCODE_1;
+        break;
+    case SDL_CONTROLLER_BUTTON_DPAD_RIGHT:
+        keyboardPress = true;
+        scancode = SDL_SCANCODE_2;
+        break;
+    case SDL_CONTROLLER_BUTTON_DPAD_DOWN:
+        keyboardPress = true;
+        scancode = SDL_SCANCODE_3;
+        break;
+    case SDL_CONTROLLER_BUTTON_DPAD_LEFT:
+        keyboardPress = true;
+        scancode = SDL_SCANCODE_4;
+        break;
+    default:
+        break;
+    }
+
+    if (keyboardPress) {
+        Put_Key_Message(scancode, button.state == SDL_RELEASED);
+    } else if (mousePress) {
+        int x, y;
+        Get_Video_Mouse(x, y);
+        Put_Mouse_Message(key, x, y, button.state == SDL_RELEASED);
+    }
+}
+
+bool WWKeyboardClassSDL2::Is_Analog_Scroll_Active()
+{
+    return AnalogScrollActive;
+}
+
+unsigned char WWKeyboardClassSDL2::Get_Scroll_Direction()
+{
+    return ScrollDirection;
+}
+
+KeyASCIIType WWKeyboardClassSDL2::To_ASCII(unsigned short key)
+{
+    if (key & WWKEY_RLS_BIT) {
+        return KA_NONE;
+    }
+
+    key &= 0xFF; // drop all mods
+
+    if (key > ARRAY_SIZE(sdl_keymap) / 2 - 1) {
+        return KA_NONE;
+    }
+
+    if (SDL_GetModState() & KMOD_SHIFT) {
+        return sdl_keymap[key + ARRAY_SIZE(sdl_keymap) / 2];
+    } else {
+        return sdl_keymap[key];
+    }
+}
+
+WWKeyboardClass* CreateWWKeyboardClass(void)
+{
+    return new WWKeyboardClassSDL2;
+}

--- a/common/wwkeyboard_sdl2.h
+++ b/common/wwkeyboard_sdl2.h
@@ -1,0 +1,44 @@
+#include "wwkeyboard.h"
+
+class WWKeyboardClassSDL2 : public WWKeyboardClass
+{
+public:
+    virtual ~WWKeyboardClassSDL2();
+
+    virtual void Fill_Buffer_From_System(void);
+    virtual bool Is_Gamepad_Active();
+    virtual void Open_Controller();
+    virtual void Close_Controller();
+    virtual bool Is_Analog_Scroll_Active();
+    virtual unsigned char Get_Scroll_Direction();
+    virtual KeyASCIIType To_ASCII(unsigned short key);
+
+private:
+    void Handle_Controller_Axis_Event(const SDL_ControllerAxisEvent& motion);
+    void Handle_Controller_Button_Event(const SDL_ControllerButtonEvent& button);
+    void Process_Controller_Axis_Motion();
+
+    // used to convert user-friendly pointer speed values into more useable ones
+    static constexpr float CONTROLLER_SPEED_MOD = 2000000.0f;
+    // bigger value correndsponds to faster pointer movement speed with bigger stick axis values
+    static constexpr float CONTROLLER_AXIS_SPEEDUP = 1.03f;
+    // speedup value while the trigger is pressed
+    static constexpr int CONTROLLER_TRIGGER_SPEEDUP = 2;
+
+    enum
+    {
+        CONTROLLER_L_DEADZONE = 4000,
+        CONTROLLER_R_DEADZONE = 6000,
+        CONTROLLER_TRIGGER_R_DEADZONE = 3000
+    };
+
+    SDL_GameController* GameController = nullptr;
+    int16_t ControllerLeftXAxis = 0;
+    int16_t ControllerLeftYAxis = 0;
+    int16_t ControllerRightXAxis = 0;
+    int16_t ControllerRightYAxis = 0;
+    uint32_t LastControllerTime = 0;
+    float ControllerSpeedBoost = 1;
+    bool AnalogScrollActive = false;
+    ScrollDirType ScrollDirection = SDIR_NONE;
+};

--- a/common/wwkeyboard_sdl32.cpp
+++ b/common/wwkeyboard_sdl32.cpp
@@ -1,0 +1,46 @@
+//
+// Copyright 2020 Electronic Arts Inc.
+//
+// TiberianDawn.DLL and RedAlert.dll and corresponding source code is free
+// software: you can redistribute it and/or modify it under the terms of
+// the GNU General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+
+// TiberianDawn.DLL and RedAlert.dll and corresponding source code is distributed
+// in the hope that it will be useful, but with permitted additional restrictions
+// under Section 7 of the GPL. See the GNU General Public License in LICENSE.TXT
+// distributed with this program. You should have received a copy of the
+// GNU General Public License along with permitted additional restrictions
+// with this program. If not, see https://github.com/electronicarts/CnC_Remastered_Collection
+
+#include "wwkeyboard_sdl1.h"
+#include "video.h"
+#include "settings.h"
+#include <SDL.h>
+
+void Focus_Loss();
+void Focus_Restore();
+void Process_Network();
+
+WWKeyboardClassWin32::~WWKeyboardClassWin32()
+{
+}
+
+void WWKeyboardClassWin32::Fill_Buffer_From_System(void)
+{
+    if (!Is_Buffer_Full()) {
+        MSG msg;
+        while (PeekMessageA(&msg, NULL, 0, 0, PM_NOREMOVE)) {
+            if (!GetMessageA(&msg, NULL, 0, 0)) {
+                return;
+            }
+            TranslateMessage(&msg);
+            DispatchMessageA(&msg);
+        }
+    }
+}
+
+WWKeyboardClass* CreateWWKeyboardClass(void)
+{
+    return new WWKeyboardClassWin32;
+}

--- a/common/wwkeyboard_win32.cpp
+++ b/common/wwkeyboard_win32.cpp
@@ -1,0 +1,118 @@
+//
+// Copyright 2020 Electronic Arts Inc.
+//
+// TiberianDawn.DLL and RedAlert.dll and corresponding source code is free
+// software: you can redistribute it and/or modify it under the terms of
+// the GNU General Public License as published by the Free Software Foundation,
+// either version 3 of the License, or (at your option) any later version.
+
+// TiberianDawn.DLL and RedAlert.dll and corresponding source code is distributed
+// in the hope that it will be useful, but with permitted additional restrictions
+// under Section 7 of the GPL. See the GNU General Public License in LICENSE.TXT
+// distributed with this program. You should have received a copy of the
+// GNU General Public License along with permitted additional restrictions
+// with this program. If not, see https://github.com/electronicarts/CnC_Remastered_Collection
+
+#include "wwkeyboard_win32.h"
+#include "video.h"
+#include "settings.h"
+
+void Focus_Loss();
+void Focus_Restore();
+void Process_Network();
+
+WWKeyboardClassWin32::~WWKeyboardClassWin32()
+{
+    memset(KeyState, '\0', sizeof(KeyState));
+}
+
+void WWKeyboardClassWin32::Fill_Buffer_From_System(void)
+{
+    if (!Is_Buffer_Full()) {
+        MSG msg;
+        while (PeekMessageA(&msg, NULL, 0, 0, PM_NOREMOVE)) {
+            if (!GetMessageA(&msg, NULL, 0, 0)) {
+                return;
+            }
+            TranslateMessage(&msg);
+            DispatchMessageA(&msg);
+        }
+    }
+}
+
+/***********************************************************************************************
+ * WWKeyboardClassWin32::To_ASCII -- Convert the key value into an ASCII representation.       *
+ *                                                                                             *
+ *    This routine will convert the key code specified into an ASCII value. This takes into    *
+ *    consideration the language and keyboard mapping of the host Windows system.              *
+ *                                                                                             *
+ * INPUT:   key   -- The key code to convert into ASCII.                                       *
+ *                                                                                             *
+ * OUTPUT:  Returns with the key converted into ASCII. If the key has no ASCII equivalent,     *
+ *          then '\0' is returned.                                                             *
+ *                                                                                             *
+ * WARNINGS:   none                                                                            *
+ *                                                                                             *
+ * HISTORY:                                                                                    *
+ *   09/30/1996 JLB : Created.                                                                 *
+ *=============================================================================================*/
+KeyASCIIType WWKeyboardClassWin32::To_ASCII(unsigned short key)
+{
+    /*
+    **	Released keys never translate into an ASCII value.
+    */
+    if (key & WWKEY_RLS_BIT) {
+        return KA_NONE;
+    }
+
+    /*
+    **	Ask windows to translate the key into an ASCII equivalent.
+    */
+    char buffer[10];
+    int result = 1;
+    int scancode = 0;
+
+    /*
+    **	Set the KeyState buffer to reflect the shift bits stored in the key value.
+    */
+    if (key & WWKEY_SHIFT_BIT) {
+        KeyState[VK_SHIFT] = 0x80;
+    }
+    if (key & WWKEY_CTRL_BIT) {
+        KeyState[VK_CONTROL] = 0x80;
+    }
+    if (key & WWKEY_ALT_BIT) {
+        KeyState[VK_MENU] = 0x80;
+    }
+
+    scancode = MapVirtualKeyA(key & 0xFF, 0);
+    result = ToAscii((UINT)(key & 0xFF), (UINT)scancode, (PBYTE)KeyState, (LPWORD)buffer, (UINT)0);
+
+    /*
+    **	Restore the KeyState buffer back to pristine condition.
+    */
+    if (key & WWKEY_SHIFT_BIT) {
+        KeyState[VK_SHIFT] = 0;
+    }
+    if (key & WWKEY_CTRL_BIT) {
+        KeyState[VK_CONTROL] = 0;
+    }
+    if (key & WWKEY_ALT_BIT) {
+        KeyState[VK_MENU] = 0;
+    }
+
+    /*
+    **	If Windows could not perform the translation as expected, then
+    **	return with a null ASCII value.
+    */
+    if (result != 1) {
+        return KA_NONE;
+    }
+
+    return (KeyASCIIType)(buffer[0]);
+}
+
+WWKeyboardClass* CreateWWKeyboardClass(void)
+{
+    return new WWKeyboardClassWin32;
+}

--- a/common/wwkeyboard_win32.h
+++ b/common/wwkeyboard_win32.h
@@ -1,0 +1,17 @@
+#include "wwkeyboard.h"
+
+class WWKeyboardClassWin32 : public WWKeyboardClass
+{
+public:
+    virtual ~WWKeyboardClassWin32();
+
+    virtual void Fill_Buffer_From_System(void);
+    virtual KeyASCIIType To_ASCII(unsigned short key);
+
+private:
+    /*
+    **	This is a keyboard state array that is used to aid in translating
+    **	KN_ keys into KA_ keys.
+    */
+    unsigned char KeyState[256];
+};

--- a/redalert/startup.cpp
+++ b/redalert/startup.cpp
@@ -298,7 +298,7 @@ int main(int argc, char* argv[])
 
         CCFileClass cfile(CONFIG_FILE_NAME);
 
-        Keyboard = new WWKeyboardClass();
+        Keyboard = CreateWWKeyboardClass();
 
         /*
         ** If there is loads of memory then use uncompressed shapes

--- a/tiberiandawn/startup.cpp
+++ b/tiberiandawn/startup.cpp
@@ -232,7 +232,7 @@ int main(int argc, char** argv)
 
         CCFileClass cfile("CONQUER.INI");
 
-        Keyboard = new WWKeyboardClass();
+        Keyboard = CreateWWKeyboardClass();
 
 #ifdef JAPANESE
         //////////////////////////////////////if(!ForceEnglish) KBLanguage = 1;


### PR DESCRIPTION
No new functionality is introduced with this pull request. It simply abstracts the WWKeyboardClass interface and moves existing code into platform-specific files, to avoid hard-to-maintain #ifdef blocks in the main file.

Please note that this commit is more than a year old at this point. I did test these changes back then for all platforms, and I briefly retested them just now with SDL2 and SDL1 on Linux. I'd appreciate it if someone who uses Vanilla Conquer on Windows could test this and confirm that it also still works there.