### PR TITLE
Avoid redefinition of __USE_POSIX199309/_POSIX_C_SOURCE

### DIFF
--- a/common/mssleep.h
+++ b/common/mssleep.h
@@ -11,8 +11,12 @@
 #elif defined(_WIN32)
 #include <synchapi.h>
 #else /* Assuming recent posix*/
-#define __USE_POSIX199309
+#ifndef __USE_POSIX199309
+#define __USE_POSIX199309 1
+#endif
+#ifndef _POSIX_C_SOURCE
 #define _POSIX_C_SOURCE 199309L
+#endif
 #include <time.h>
 #endif
 


### PR DESCRIPTION
On glibc systems, they are already defined in <features.h> which is pulled in by any system header. Defining such macros in header files is too late.