### PR TITLE
Include <endianness.h> in files that need it

### DIFF
--- a/common/fixed.h
+++ b/common/fixed.h
@@ -36,6 +36,7 @@
 #define FIXED_H
 
 #include <stdint.h>
+#include "endianness.h"
 
 /*
 **	This is a very simple fixed point class that functions like a regular integral type. However

--- a/tiberiandawn/defines.h
+++ b/tiberiandawn/defines.h
@@ -35,6 +35,7 @@
 #define DEFINES_H
 
 #include "common/bitfields.h"
+#include "common/endianness.h"
 
 /**********************************************************************
 **	If defined, then the advanced balancing features will be enabled


### PR DESCRIPTION
Without this, operations on fixed values are miscompiled on big-endian machines