### PR TITLE
Add C&C Gold-style buttons (Fixes #919)

### DIFF
--- a/common/graphicsviewport.cpp
+++ b/common/graphicsviewport.cpp
@@ -981,12 +981,19 @@ void GraphicViewPortClass::Draw_Rect(int x1_pixel, int y1_pixel, int x2_pixel, i
     Unlock();
 }
 
-void GraphicViewPortClass::Texture_Fill_Rect(int xpos, int ypos, int width, int height, unsigned char* shape_pointer, int source_width, int source_height)
+void GraphicViewPortClass::Texture_Fill_Rect(int xpos,
+                                             int ypos,
+                                             int width,
+                                             int height,
+                                             unsigned char* shape_pointer,
+                                             int source_width,
+                                             int source_height)
 {
     if (Lock()) {
         for (int y = ypos; y < ypos + height; y++) {
             for (int x = xpos; x < xpos + width; x++) {
-                LogicPage->Put_Pixel(x, y, *(shape_pointer + ((y % source_height) * source_width) + (x % source_width)));
+                LogicPage->Put_Pixel(
+                    x, y, *(shape_pointer + ((y % source_height) * source_width) + (x % source_width)));
             }
         }
         Unlock();

--- a/common/graphicsviewport.cpp
+++ b/common/graphicsviewport.cpp
@@ -980,3 +980,15 @@ void GraphicViewPortClass::Draw_Rect(int x1_pixel, int y1_pixel, int x2_pixel, i
     Draw_Line(x2_pixel, y1_pixel, x2_pixel, y2_pixel, color);
     Unlock();
 }
+
+void GraphicViewPortClass::Texture_Fill_Rect(int xpos, int ypos, int width, int height, unsigned char* shape_pointer, int source_width, int source_height)
+{
+    if (Lock()) {
+        for (int y = ypos; y < ypos + height; y++) {
+            for (int x = xpos; x < xpos + width; x++) {
+                LogicPage->Put_Pixel(x, y, *(shape_pointer + ((y % source_height) * source_width) + (x % source_width)));
+            }
+        }
+        Unlock();
+    }
+}

--- a/common/graphicsviewport.h
+++ b/common/graphicsviewport.h
@@ -289,20 +289,7 @@ public:
     void Remap(int sx, int sy, int width, int height, void* remap);
     void Remap(void* remap);
     void Draw_Stamp(void const* icondata, int icon, int x_pixel, int y_pixel, void const* remap, int clip_window);
-
-    // PG_TO_FIX
-    // This seems to be missing. Might not be needed anyway since it looks like it's only used for UI drawing. ST -
-    // 12/17/2018 6:11PM
-    void Texture_Fill_Rect(int xpos,
-                           int ypos,
-                           int width,
-                           int height,
-                           void const* shape_pointer,
-                           int source_width,
-                           int source_height)
-    {
-        return;
-    }
+    void Texture_Fill_Rect(int xpos, int ypos, int width, int height, unsigned char* shape_pointer, int source_width, int source_height);
 
     // This doesnt seem to exist anywhere?? - Steve T 9/26/95 6:05PM
     //      VOID Grey_Out_Region(int x, int y, int width, int height, int color);

--- a/common/graphicsviewport.h
+++ b/common/graphicsviewport.h
@@ -289,7 +289,13 @@ public:
     void Remap(int sx, int sy, int width, int height, void* remap);
     void Remap(void* remap);
     void Draw_Stamp(void const* icondata, int icon, int x_pixel, int y_pixel, void const* remap, int clip_window);
-    void Texture_Fill_Rect(int xpos, int ypos, int width, int height, unsigned char* shape_pointer, int source_width, int source_height);
+    void Texture_Fill_Rect(int xpos,
+                           int ypos,
+                           int width,
+                           int height,
+                           unsigned char* shape_pointer,
+                           int source_width,
+                           int source_height);
 
     // This doesnt seem to exist anywhere?? - Steve T 9/26/95 6:05PM
     //      VOID Grey_Out_Region(int x, int y, int width, int height, int color);

--- a/common/settings.cpp
+++ b/common/settings.cpp
@@ -1,3 +1,4 @@
+#include "wwstd.h"
 #include "settings.h"
 #include "ini.h"
 #include "miscasm.h"
@@ -36,6 +37,8 @@ SettingsClass::SettingsClass()
 
 void SettingsClass::Load(INIClass& ini)
 {
+    char buf[128];
+
     /*
     ** Mouse settings
     */
@@ -77,6 +80,15 @@ void SettingsClass::Load(INIClass& ini)
     if (Video.Boxing || Mouse.RawInput || Mouse.ControllerEnabled) {
         Video.HardwareCursor = false;
     }
+
+    ini.Get_String("Video", "ButtonStyle", "Default", buf, sizeof(buf));
+    if (!stricmp(buf, "Gold")) {
+        Video.ButtonStyle = 1;
+    } else if (!stricmp(buf, "Classic") || !stricmp(buf, "DOS")) {
+        Video.ButtonStyle = 0;
+    } else {
+        Video.ButtonStyle = -1;
+    }
 }
 
 void SettingsClass::Save(INIClass& ini)
@@ -111,4 +123,7 @@ void SettingsClass::Save(INIClass& ini)
     ** VQA and WSA interpolation mode 0 = scanlines, 1 = vertical doubling, 2 = linear
     */
     ini.Put_Int("Video", "InterpolationMode", Video.InterpolationMode);
+
+    ini.Put_String(
+        "Video", "ButtonStyle", Video.ButtonStyle == -1 ? "Default" : (Video.ButtonStyle == 1 ? "Gold" : "Classic"));
 }

--- a/common/settings.h
+++ b/common/settings.h
@@ -33,6 +33,7 @@ public:
         int InterpolationMode;
         bool HardwareCursor;
         bool DOSMode;
+        int ButtonStyle;
         std::string Scaler;
         std::string Driver;
         std::string PixelFormat;

--- a/tiberiandawn/dialog.cpp
+++ b/tiberiandawn/dialog.cpp
@@ -44,6 +44,7 @@
  * - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - */
 
 #include "function.h"
+#include "settings.h"
 
 /***********************************************************************************************
  * Dialog_Box -- draws a dialog background box                                                 *
@@ -93,10 +94,8 @@ extern void CC_Texture_Fill(void const* shapefile, int shapenum, int xpos, int y
 
 void Draw_Box(int x, int y, int w, int h, BoxStyleEnum up, bool filled)
 {
-    static BoxStyleType const ButtonColors[BOXSTYLE_COUNT] = {
-
+    static BoxStyleType const ButtonColorsClassic[BOXSTYLE_COUNT] = {
         // Filler, Shadow, Hilite, Corner colors
-
         {LTGREY, WHITE, DKGREY, LTGREY},                                    // 0 Button is down.
         {LTGREY, DKGREY, WHITE, LTGREY},                                    // 1 Button is up w/border.
         {LTBLUE, BLUE, LTCYAN, LTBLUE},                                     // 2 Raised blue.
@@ -105,29 +104,45 @@ void Draw_Box(int x, int y, int w, int h, BoxStyleEnum up, bool filled)
         {LTGREY, DKGREY, WHITE, LTGREY},                                    // 5 Button is up w/arrows.
         {CC_GREEN_BKGD, CC_LIGHT_GREEN, CC_GREEN_SHADOW, CC_GREEN_CORNERS}, // 6 Button is down.
         {CC_GREEN_BKGD, CC_GREEN_SHADOW, CC_LIGHT_GREEN, CC_GREEN_CORNERS}, // 7 Button is up w/border.
-        // {CC_GREEN_BKGD, 14, 12, 13},    // 6 Button is down.
-        // {CC_GREEN_BKGD, 12, 14, 13},    // 7 Button is up w/border.
-        {DKGREY, WHITE, BLACK, DKGREY},             // 8 Button is disabled down.
-        {DKGREY, BLACK, LTGREY, DKGREY},            // 9 Button is disabled up.
-        {BLACK, CC_GREEN_BOX, CC_GREEN_BOX, BLACK}, // 10 List box.
-        {BLACK, CC_GREEN_BOX, CC_GREEN_BOX, BLACK}, // 11 Menu box.
-        // {BLACK, 14, 14, BLACK}, // 10 List box.
-        // {BLACK, 14, 14, BLACK}, // 11 Menu box.
+        {DKGREY, WHITE, BLACK, DKGREY},                                     // 8 Button is disabled down.
+        {DKGREY, BLACK, LTGREY, DKGREY},                                    // 9 Button is disabled up.
+        {BLACK, CC_GREEN_BOX, CC_GREEN_BOX, BLACK},                         // 10 List box.
+        {BLACK, CC_GREEN_BOX, CC_GREEN_BOX, BLACK},                         // 11 Menu box.
     };
+
+    static BoxStyleType const ButtonColorsGold[BOXSTYLE_COUNT] = {
+        // Filler, Shadow, Hilite, Corner colors
+        {LTGREY, WHITE, DKGREY, LTGREY}, // 0 Button is down.
+        {LTGREY, DKGREY, WHITE, LTGREY}, // 1 Button is up w/border.
+        {LTBLUE, BLUE, LTCYAN, LTBLUE},  // 2 Raised blue.
+        {DKGREY, WHITE, BLACK, DKGREY},  // 3 Button is disabled down.
+        {DKGREY, BLACK, WHITE, LTGREY},  // 4 Button is disabled up.
+        {LTGREY, DKGREY, WHITE, LTGREY}, // 5 Button is up w/arrows.
+        {CC_GREEN_BKGD, 14, 12, 13},     // 6 Button is down.
+        {CC_GREEN_BKGD, 12, 14, 13},     // 7 Button is up w/border.
+        {DKGREY, WHITE, BLACK, DKGREY},  // 8 Button is disabled down.
+        {DKGREY, BLACK, LTGREY, DKGREY}, // 9 Button is disabled up.
+        {BLACK, 14, 14, BLACK},          // 10 List box.
+        {BLACK, 14, 14, BLACK},          // 11 Menu box.
+    };
+
+    bool useGoldStyle;
+    if (Settings.Video.ButtonStyle == -1) {
+        useGoldStyle = !Settings.Video.DOSMode;
+    } else {
+        useGoldStyle = Settings.Video.ButtonStyle == 1;
+    }
 
     w--;
     h--;
-    BoxStyleType const& style = ButtonColors[up];
+    BoxStyleType const& style = useGoldStyle ? ButtonColorsGold[up] : ButtonColorsClassic[up];
 
     if (filled) {
-        /*
-        if (style.Filler == CC_GREEN_BKGD) {
+        if (useGoldStyle && style.Filler == CC_GREEN_BKGD) {
             CC_Texture_Fill(MFCD::Retrieve("BTEXTURE.SHP"), InMainLoop, x, y, w, h);
         } else {
             LogicPage->Fill_Rect(x, y, x + w, y + h, style.Filler);
         }
-        */
-        LogicPage->Fill_Rect(x, y, x + w, y + h, style.Filler);
     }
 
     switch (up) {


### PR DESCRIPTION
This PR restores the button style from C&C Gold when playing in hi-res mode. It additionally adds a `[Video]►ButtonStyle` setting to `CONQUER.INI` that allows forcing the buttons to either Gold (`"Gold"`) or Classic (`"DOS"` or `"Classic"`) style.

![image](https://github.com/TheAssemblyArmada/Vanilla-Conquer/assets/29167196/2d5fd0ec-e171-43ae-993e-0d1dac9bd879)
![image](https://github.com/TheAssemblyArmada/Vanilla-Conquer/assets/29167196/cdf04377-773f-405d-bea7-3f1eddf4419e)
![image](https://github.com/TheAssemblyArmada/Vanilla-Conquer/assets/29167196/9a6a466d-1f16-4b5b-b9f5-4573946c8c9a)
![image](https://github.com/TheAssemblyArmada/Vanilla-Conquer/assets/29167196/995ec10a-7b3b-46df-9f42-3443a828ac7f)
