### PR TITLE
Remove accidently duplicated call to SwapCommHeaderType

### DIFF
--- a/common/connect.cpp
+++ b/common/connect.cpp
@@ -227,8 +227,6 @@ int ConnectionClass::Send_Packet(void* buf, int buflen, int ack_req)
 
     SwapCommHeaderType((CommHeaderType*)PacketBuf);
 
-    SwapCommHeaderType((CommHeaderType*)PacketBuf);
-
     /*------------------------------------------------------------------------
     Now build the packet
     ------------------------------------------------------------------------*/


### PR DESCRIPTION
This slipped in from commit https://github.com/TheAssemblyArmada/Vanilla-Conquer/commit/8688c7a9bcf101fd5675312144461179a619eec0