### PR TITLE
Force disable of GoldButtons when running in DOSMode

### DIFF
--- a/tiberiandawn/dialog.cpp
+++ b/tiberiandawn/dialog.cpp
@@ -133,6 +133,12 @@ void Draw_Box(int x, int y, int w, int h, BoxStyleEnum up, bool filled)
         useGoldStyle = Settings.Video.ButtonStyle == 1;
     }
 
+    /* If DOSMode is enabled then force disable of goldstyle buttons once the
+       textures may not be available.  */
+    if (Get_Resolution_Factor() == 0) {
+        useGoldStyle = false;
+    }
+
     w--;
     h--;
     BoxStyleType const& style = useGoldStyle ? ButtonColorsGold[up] : ButtonColorsClassic[up];


### PR DESCRIPTION
When running with retaild DOS files the button texture file is not present and therefore we can't have this.

Therefore we force this to be disabled in this case.