### PR TITLE
Remove need to define NOMINMAX on none windows.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -85,8 +85,32 @@ else()
 endif()
 
 if(WIN32)
-    add_definitions(-DWIN32 -D_WINDOWS -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE)
+    add_definitions(-DWIN32 -D_WINDOWS -D_CRT_SECURE_NO_DEPRECATE -D_CRT_NONSTDC_NO_DEPRECATE -DNOMINMAX)
     set(COMMON_LIBS winmm)
+endif()
+
+if(NOT MSVC)
+    # GCC and Clang don't check new allocations by default while MSVC does.
+    message(STATUS "Checking whether compiler supports -fcheck-new")
+    check_cxx_compiler_flag("-Werror -fcheck-new" HAVE_CHECK_NEW)
+
+    if(HAVE_CHECK_NEW)
+        message(STATUS "yes")
+        list(APPEND VC_CXX_FLAGS -fcheck-new)
+    else()
+        message(STATUS "no")
+    endif()
+
+    # Some platforms default to an unsigned char, this fixes that.
+    message(STATUS "Checking whether compiler supports -fsigned-char")
+    check_cxx_compiler_flag("-Werror -fsigned-char" HAVE_SIGNED_CHAR)
+
+    if(HAVE_SIGNED_CHAR)
+        message(STATUS "yes")
+        list(APPEND VC_CXX_FLAGS -fsigned-char)
+    else()
+        message(STATUS "no")
+    endif()
 endif()
 
 set(VANILLA_DEFS "")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -110,7 +110,7 @@
                 "CMAKE_C_FLAGS_DEBUG": "-g3 -Og",
                 "CMAKE_CXX_FLAGS_RELEASE": "-O3 -g3 -DNDEBUG",
                 "CMAKE_C_FLAGS_RELEASE": "-O3 -g3 -DNDEBUG",
-                "VC_CXX_FLAGS": "-w;-Wwrite-strings;-Werror=write-strings;-fcheck-new;-DNOMINMAX",
+                "VC_CXX_FLAGS": "-w;-Wwrite-strings;-Werror=write-strings",
                 "MAP_EDITORTD": "ON",
                 "MAP_EDITORRA": "ON",
                 "BUILD_TOOLS": "ON"
@@ -178,7 +178,7 @@
                 "CMAKE_C_FLAGS_RELEASE": "-O3 -g -DNDEBUG",
                 "CMAKE_EXE_LINKER_FLAGS": "-static-libstdc++ -static-libgcc",
                 "CMAKE_SHARESD_LINKER_FLAGS": "-static-libstdc++ -static-libgcc",
-                "VC_CXX_FLAGS": "-fpermissive;-w;-Wwrite-strings;-Werror=write-strings;-fcheck-new;-fsigned-char;-DNOMINMAX",
+                "VC_CXX_FLAGS": "-w;-Wwrite-strings;-Werror=write-strings",
                 "MAP_EDITORTD": "ON",
                 "MAP_EDITORRA": "ON",
                 "BUILD_TOOLS": "ON"
@@ -199,6 +199,7 @@
                 "BUILD_VANILLARA": "OFF",
                 "MAP_EDITORTD": "OFF",
                 "MAP_EDITORRA": "OFF",
+                "VC_CXX_FLAGS": "-fpermissive;-w;-Wwrite-strings;-Werror=write-strings",
                 "BUILD_TOOLS": "OFF"
             }
         },

--- a/common/packet.cpp
+++ b/common/packet.cpp
@@ -38,7 +38,7 @@
 #include "packet.h"
 #include "endianness.h"
 
-#ifdef NOMINMAX
+#if !defined _WIN32 || defined NOMINMAX
 inline int min(int a, int b)
 {
     return a < b ? a : b;

--- a/redalert/jshell.h
+++ b/redalert/jshell.h
@@ -80,7 +80,7 @@ template <class T> inline T operator~(T t1)
     return ((T)(~(int)t1));
 }
 
-#ifdef NOMINMAX
+#if !defined _WIN32 || defined NOMINMAX
 inline int min(int a, int b)
 {
     return a < b ? a : b;

--- a/tiberiandawn/function.h
+++ b/tiberiandawn/function.h
@@ -88,7 +88,7 @@ Map(screen) class heirarchy.
                    ³ InfantryTypeClass AircraftTypeClass
 */
 
-#ifdef NOMINMAX
+#if !defined _WIN32 || defined NOMINMAX
 inline int min(int a, int b)
 {
     return a < b ? a : b;


### PR DESCRIPTION
This is a quick fix, a better solution is to move to using std::min/std::max that will require a larger refactor.