### PR TITLE
[RA] Fix helipads counting towards Airstrips.

### DIFF
--- a/redalert/object.cpp
+++ b/redalert/object.cpp
@@ -2380,7 +2380,7 @@ BuildingClass* ObjectTypeClass::Who_Can_Build_Me(bool intheory, bool legal, Hous
             BuildingClass* building = Buildings.Ptr(index);
             assert(building != NULL);
 
-            if (!building->IsInLimbo && building->House->Class->House == house && building->Class->ToBuild == RTTI
+            if (!building->IsInLimbo && building->House->Class->House == house && (*building == STRUCT_AIRSTRIP)
                 && building->Mission != MISSION_DECONSTRUCTION && building->MissionQueue != MISSION_DECONSTRUCTION
                 && ((1L << building->ActLike) & Get_Ownable())
                 && (!legal || building->House->Can_Build(this, building->ActLike))) {


### PR DESCRIPTION
Chthon CFE Note: Bugfix! We need to specifically count ONLY airstrips. Original code also counted helipads
Which allowed you to create excess planes if you had 1+ helipads and 1+ planes in the air when the construction finished Petroglyph made it worse by making the blocked production spam retries every frame, guaranteeing you'll activate the bug as soon as your planes take off.
Fixes #812 