### PR TITLE
Cleans up MSVC only warnings pragmas.

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -28,7 +28,7 @@
             "hidden": true,
             "cacheVariables": {
                 "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded$<$<CONFIG:Debug>:Debug>DLL",
-                "VC_CXX_FLAGS": "/Zc:strictStrings;-wd4244;-wd4018;-wd4291;-wd4101;-wd4267",
+                "VC_CXX_FLAGS": "/Zc:strictStrings;-wd4244;-wd4018;-wd4291;-wd4101;-wd4267;-wd4200",
                 "CMAKE_CXX_FLAGS_RELEASE": "/Zi /O2 /Ob2 /DNDEBUG",
                 "CMAKE_EXE_LINKER_FLAGS_RELEASE": "/debug:full /INCREMENTAL:NO",
                 "CMAKE_MODULE_LINKER_FLAGS_RELEASE": "/debug:full /INCREMENTAL:NO",

--- a/common/field.cpp
+++ b/common/field.cpp
@@ -33,9 +33,6 @@
 #include "field.h"
 #include "endianness.h"
 
-// ST - 12/18/2018 10:14AM
-#pragma warning(disable : 4996)
-
 FieldClass::FieldClass(const char* id, char data)
 {
     strncpy(ID, id, sizeof(ID));

--- a/common/graphicsviewport.cpp
+++ b/common/graphicsviewport.cpp
@@ -779,8 +779,6 @@ unsigned int GraphicViewPortClass::Print(char const* str, int x, int y, int fcol
     return (return_code);
 }
 
-#pragma warning(disable : 4996)
-
 /***************************************************************************
  * GVPC::PRINT -- Stub function to print an integer                        *
  *                                                                         *

--- a/common/ini.cpp
+++ b/common/ini.cpp
@@ -80,9 +80,6 @@
 #include "cstraw.h"
 #endif
 
-// Disable the "temporary object used to initialize a non-constant reference" warning.
-//#pragma warning 665 9
-
 /***********************************************************************************************
  * INIClass::~INIClass -- Destructor for INI handler.                                          *
  *                                                                                             *

--- a/common/int.h
+++ b/common/int.h
@@ -476,8 +476,6 @@ template <class T> T Gcd(const T& a, const T& n)
     return g[(i - 1) % 3];
 }
 
-//#pragma warning 604 9
-//#pragma warning 595 9
 template <class T> T Generate_Prime(Straw& rng, int pbits)
 {
     T minQ = (T(1UL) << (unsigned short)(pbits - (unsigned short)2));

--- a/common/mp.cpp
+++ b/common/mp.cpp
@@ -333,7 +333,6 @@ unsigned XMP_Encode(unsigned char* to, unsigned tobytes, digit const* from, int 
  * HISTORY:                                                                                    *
  *   07/01/1996 JLB : Created.                                                                 *
  *=============================================================================================*/
-//#pragma warning 364 9
 unsigned XMP_Encode(unsigned char* to, digit const* from, int precision)
 {
     int i;

--- a/common/packet.cpp
+++ b/common/packet.cpp
@@ -402,7 +402,6 @@ bool PacketClass::Get_Field(const char* id, int& data)
  * HISTORY:                                                               *
  *   04/23/1996 PWG : Created.                                            *
  *========================================================================*/
-#pragma warning(disable : 4996)
 bool PacketClass::Get_Field(const char* id, char* data)
 {
     FieldClass* field = Find_Field(id);

--- a/common/shape.h
+++ b/common/shape.h
@@ -129,7 +129,6 @@ typedef struct
 /*
 ------------------------------- Shape block ---------------------------------
 */
-#pragma warning(disable : 4200)
 #pragma pack(push, 2)
 typedef struct
 {

--- a/common/soscodec.cpp
+++ b/common/soscodec.cpp
@@ -196,6 +196,7 @@ unsigned sosCODECDecompressData(_SOS_COMPRESS_INFO* stream, unsigned bytes)
     }
 #endif
     assert(0 && "Unreachable");
+    return 0;
 }
 
 //

--- a/redalert/dllinterface.cpp
+++ b/redalert/dllinterface.cpp
@@ -24,9 +24,6 @@
 **
 */
 
-// Exception handling isn't enabled
-#pragma warning(disable : 4530) // warning C4530: C++ exception handler used, but unwind semantics are not enabled.
-
 #include <string>
 #include <vector>
 #include <set>
@@ -72,9 +69,6 @@ typedef __int64 int64;
 **
 **
 */
-// For compatibility with Watcom in audio enums
-#pragma warning(disable : 4091)
-
 // From RedAlert\Audio.cpp
 typedef enum
 {

--- a/redalert/ipxmgr.cpp
+++ b/redalert/ipxmgr.cpp
@@ -85,9 +85,6 @@
 
 #endif // WINSOCK_IPX
 
-// Turn off "expression is not meaningful".
-//#pragma warning 628 9
-
 //#include "WolDebug.h"
 
 /***************************************************************************

--- a/tiberiandawn/conquer.cpp
+++ b/tiberiandawn/conquer.cpp
@@ -3613,7 +3613,6 @@ static bool Change_Local_Dir(int cd)
  *   07/11/1995 JLB : Created.                                                                 *
  *   05/22/1996  ST : Handles multiple CD drives / CD changers                                 *
  *=============================================================================================*/
-#pragma warning(disable : 4101)
 bool Force_CD_Available(int cd)
 {
 

--- a/tiberiandawn/defines.h
+++ b/tiberiandawn/defines.h
@@ -173,13 +173,6 @@
 
 #define FOREIGN_VERSION_NUMBER 6
 
-//
-// typedef enums with -1 will show this warning, even when the type of the enum is signed. It's a compiler bug,
-// apparently ST - 1/8/2019 9:23AM
-//
-#pragma warning(push)
-#pragma warning(disable : 4341)
-
 /**********************************************************************
 **	These enumerations are used to implement RTTI.
 */
@@ -3041,7 +3034,5 @@ typedef enum StrategyType : unsigned char
 } StrategyType;
 
 #endif // USE_RA_AI
-
-#pragma warning(pop)
 
 #endif

--- a/tiberiandawn/dllinterface.cpp
+++ b/tiberiandawn/dllinterface.cpp
@@ -65,9 +65,6 @@ typedef __int64 int64;
 **
 **
 */
-// For compatibility with Watcom in audio enums
-#pragma warning(disable : 4091)
-
 // From TiberianDawn\Audio.cpp
 typedef enum
 {

--- a/tiberiandawn/iomap.cpp
+++ b/tiberiandawn/iomap.cpp
@@ -65,8 +65,6 @@
 
 #include "function.h"
 
-#pragma warning(disable : 4302) // Truncation from pointer to TARGET
-
 /***********************************************************************************************
  * CellClass::Should_Save -- Should the cell be written to disk?                               *
  *                                                                                             *

--- a/tiberiandawn/ioobj.cpp
+++ b/tiberiandawn/ioobj.cpp
@@ -130,8 +130,6 @@
 
 #include "function.h"
 
-#pragma warning(disable : 4302) // Truncation from pointer to TARGET
-
 /***********************************************************************************************
  * TeamTypeClass::Load -- Loads from a save game file.                                         *
  *                                                                                             *

--- a/tiberiandawn/ipxmgr.cpp
+++ b/tiberiandawn/ipxmgr.cpp
@@ -89,9 +89,6 @@
 /* For `Players` vector */
 #include "externs.h"
 
-// Turn off "expression is not meaningful".
-//#pragma warning 628 9
-
 //#include "WolDebug.h"
 
 /***************************************************************************

--- a/tools/miniposix/dirent/dirent.c
+++ b/tools/miniposix/dirent/dirent.c
@@ -214,7 +214,7 @@ DIR *opendir(const char *name)
             __seterrno(ENOENT);
             return NULL;
         }
-        size = wcslen(full) + 1;
+        size = (int)wcslen(full) + 1;
         memcpy(wname, L"\\\\?\\", sizeof(wchar_t) * 5);
         if (size > NTFS_MAX_PATH) {
             free(wname);


### PR DESCRIPTION
Any warnings that need to be disabled at the current warning level are disabled through CMakePresets.json now. Also fixes two warnings seen at current warning level.
Obsoletes #981 