### PR TITLE
Replace strlen upper bound with checks for '\0'

### DIFF
--- a/common/wwstd.h
+++ b/common/wwstd.h
@@ -250,18 +250,22 @@ inline static void _splitpath(const char* path, char* drive, char* dir, char* fn
         return;
     }
 
-    for (int i = 0; i < strlen(path); i++) {
-        if (path[i] == '.') {
-            strcpy(ext, path + i + 1);
+    while (*path != '\0') {
+        if (*path == '.') {
+            strcpy(ext, path + 1);
             break;
         }
+
+        ++path;
     }
 }
 
 inline static char* strupr(char* str)
 {
-    for (int i = 0; i < strlen(str); i++)
-        str[i] = toupper(str[i]);
+    while (*str != '\0') {
+        *str = toupper(*str);
+        ++str;
+    }
     return str;
 }
 
@@ -278,10 +282,9 @@ inline static void strrev(char* str)
 
 inline static void _strlwr(char* str)
 {
-    int len = strlen(str);
-
-    for (int i = 0; i < len; i++) {
-        str[i] = tolower(str[i]);
+    while (*str != '\0') {
+        *str = tolower(*str);
+        ++str;
     }
 }
 

--- a/redalert/session.cpp
+++ b/redalert/session.cpp
@@ -1089,8 +1089,9 @@ uint32_t SessionClass::Compute_Unique_ID(void)
     //------------------------------------------------------------------------
     path = getenv("PATH");
     if (path) {
-        for (i = 0; i < strlen(path); i++) {
-            Add_CRC(&id, (unsigned int)path[i]);
+        while (*path != '\0') {
+            Add_CRC(&id, (unsigned int)(*path));
+            ++path;
         }
     }
 


### PR DESCRIPTION
Strings in C are always terminated by the '\0' character. We can explore this to avoid sweeping through the string twice.

Constructs like `for (i = 0; i < strlen(str); i++)` are even worse than this, as it will call strlen **for each character of the string**, which is O(_n_ ²) instead of O(_n_), where n = size of string. Replace those cases as well.