### PR TITLE
Fix format-security error

### DIFF
--- a/common/wsproto.cpp
+++ b/common/wsproto.cpp
@@ -572,7 +572,7 @@ bool WinsockInterfaceClass::Set_Socket_Options(void)
     if (err == INVALID_SOCKET) {
         char out[128];
         sprintf(out, "TS: Failed to set socket option SO_RCVBUF - error code %d.\n", LastSocketError);
-        fprintf(stderr, out);
+        fprintf(stderr, "%s", out);
         assert(err != INVALID_SOCKET);
     }
 
@@ -583,7 +583,7 @@ bool WinsockInterfaceClass::Set_Socket_Options(void)
     if (err == INVALID_SOCKET) {
         char out[128];
         sprintf(out, "TS: Failed to set socket option SO_SNDBUF - error code %d.\n", LastSocketError);
-        fprintf(stderr, out);
+        fprintf(stderr, "%s", out);
         assert(err != INVALID_SOCKET);
     }
 

--- a/redalert/cheklist.cpp
+++ b/redalert/cheklist.cpp
@@ -339,7 +339,7 @@ void CheckListClass::Draw_Entry(int index, int x, int y, int width, int selected
             buffer[0] = UNCHECK_CHAR;
         }
         buffer[1] = ' ';
-        sprintf(&buffer[2], obj->Text);
+        sprintf(&buffer[2], "%s", obj->Text);
 
         TextPrintType flags = TextFlags;
         RemapControlType* scheme = GadgetClass::Get_Color_Scheme();

--- a/tiberiandawn/cheklist.cpp
+++ b/tiberiandawn/cheklist.cpp
@@ -338,7 +338,7 @@ void CheckListClass::Draw_Entry(int index, int x, int y, int width, int selected
             buffer[0] = UNCHECK_CHAR;
         }
         buffer[1] = ' ';
-        sprintf(&buffer[2], obj->Text);
+        sprintf(&buffer[2], "%s", obj->Text);
 
         TextPrintType flags = TextFlags;
 

--- a/tiberiandawn/netdlg.cpp
+++ b/tiberiandawn/netdlg.cpp
@@ -4076,7 +4076,7 @@ void Net_Reconnect_Dialog(int reconn, int fresh, int oldest_index, unsigned int 
             id = Ipx.Connection_ID(oldest_index);
             sprintf(buf1, Text_String(TXT_RECONNECTING_TO), Ipx.Connection_Name(id));
         } else {
-            sprintf(buf1, Text_String(TXT_WAITING_FOR_CONNECTIONS));
+            sprintf(buf1, "%s", Text_String(TXT_WAITING_FOR_CONNECTIONS));
         }
         sprintf(buf2, Text_String(TXT_TIME_ALLOWED), timeval + 1);
         buf3 = Text_String(TXT_PRESS_ESC);


### PR DESCRIPTION
In macOS clang version 19.1.5

```
/Vanilla-Conquer/tiberiandawn/netdlg.cpp:4079:27: error: format string is not a string literal (potentially insecure) [-Werror,-Wformat-security]
 4079 |             sprintf(buf1, Text_String(TXT_WAITING_FOR_CONNECTIONS));
      |                           ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Vanilla-Conquer/tiberiandawn/netdlg.cpp:4079:27: note: treat the string as an argument to avoid this
 4079 |             sprintf(buf1, Text_String(TXT_WAITING_FOR_CONNECTIONS));
      |                           ^
      |                           "%s", 
```