### PR TITLE
Fix credits output

### DIFF
--- a/tiberiandawn/credits.cpp
+++ b/tiberiandawn/credits.cpp
@@ -109,7 +109,7 @@ void CreditClass::Graphic_Logic(bool forced)
         unsigned fore = factor ? 11 : WHITE;
 
         TabClass::Draw_Credits_Tab();
-        Fancy_Text_Print("%ld", xx, 0, fore, TBLACK, flags, Current);
+        Fancy_Text_Print("%d", xx, 0, fore, TBLACK, flags, Current);
 
         IsToRedraw = false;
         IsAudible = false;


### PR DESCRIPTION
xx declared as "int" while it is printed as "long": in some cases this leads 
to incorrect output, see Issue #1025
