### PR TITLE
[RA] Silence warnings C4291 from MSVC.

### DIFF
--- a/redalert/teamtype.h
+++ b/redalert/teamtype.h
@@ -144,6 +144,9 @@ public:
         return (ptr);
     };
     static void operator delete(void* ptr);
+    static void operator delete(void*, void*)
+    {
+    }
 
     /*
     **	Initialization: clears all team types in preparation for new scenario


### PR DESCRIPTION
Silences a warning when building redalert/heap.cpp with the Microsoft Visual Studio compiler.