### PR TITLE
[CI] Fix incorrect packaging of mix tool on linux.

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -74,8 +74,8 @@ jobs:
         cp ./build/${{ matrix.preset }}/RelWithDebInfo/vanillamix ./build/${{ matrix.preset }}/RelWithDebInfo/vanillamix.dbg
         objcopy --add-gnu-debuglink=./build/${{ matrix.preset }}/RelWithDebInfo/vanillamix.dbg ./build/${{ matrix.preset }}/RelWithDebInfo/vanillamix
         strip --strip-all ./build/${{ matrix.preset }}/RelWithDebInfo/vanillamix
-        7z a artifact/vanilla-conquer-${{ matrix.preset }}-linux-${{ matrix.compiler.cc }}-${{ matrix.os }}-${{ steps.gitinfo.outputs.sha_short }}.zip ./build/${{ matrix.preset }}/RelWithDebInfo/vanillamix
-        7z a artifact/vanilla-conquer-${{ matrix.preset }}-linux-${{ matrix.compiler.cc }}-${{ matrix.os }}-${{ steps.gitinfo.outputs.sha_short }}-debug.zip ./build/${{ matrix.preset }}/RelWithDebInfo/vanillamix.dbg
+        7z a artifact/vanilla-conquer-${{ matrix.preset }}-linux-${{ matrix.compiler.cc }}-${{ matrix.os }}-x86_64-${{ steps.gitinfo.outputs.sha_short }}.zip ./build/${{ matrix.preset }}/RelWithDebInfo/vanillamix
+        7z a artifact/vanilla-conquer-${{ matrix.preset }}-linux-${{ matrix.compiler.cc }}-${{ matrix.os }}-x86_64-${{ steps.gitinfo.outputs.sha_short }}-debug.zip ./build/${{ matrix.preset }}/RelWithDebInfo/vanillamix.dbg
     
     - name: Upload artifact
       if: ${{ matrix.preset != 'testing' &&  matrix.preset != 'nonet' }}

--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -28,7 +28,7 @@ jobs:
         sudo apt-get update -qq > /dev/null
         sudo apt-get install -qq -y ninja-build mingw-w64 imagemagick > /dev/null
         wget -q https://www.libsdl.org/release/SDL2-devel-2.0.12-mingw.tar.gz
-        wget -q --no-check-certificate https://www.openal-soft.org/openal-binaries/openal-soft-1.21.0-bin.zip
+        wget -q --no-check-certificate https://openal-soft.org/openal-binaries/openal-soft-1.21.0-bin.zip
         tar -xf SDL2-devel-2.0.12-mingw.tar.gz -C /tmp
         unzip -qq openal-soft-1.21.0-bin.zip -d /tmp
         mv /tmp/openal-soft-1.21.0-bin/bin/${{ matrix.arch.win }}/soft_oal.dll /tmp/openal-soft-1.21.0-bin/bin/${{ matrix.arch.win }}/OpenAL32.dll

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -104,7 +104,7 @@ jobs:
       run: |
         Invoke-WebRequest -Uri https://www.libsdl.org/release/SDL2-devel-2.0.12-VC.zip -OutFile SDL2-devel.zip
         Invoke-WebRequest -Uri https://github.com/ninja-build/ninja/releases/download/v1.10.1/ninja-win.zip -OutFile $Env:TEMP\ninja-win.zip
-        Invoke-WebRequest -SkipCertificateCheck -Uri https://www.openal-soft.org/openal-binaries/openal-soft-1.21.0-bin.zip -OutFile openal-soft-1.21.0-bin.zip
+        Invoke-WebRequest -SkipCertificateCheck -Uri https://openal-soft.org/openal-binaries/openal-soft-1.21.0-bin.zip -OutFile openal-soft-1.21.0-bin.zip
         Expand-Archive SDL2-devel.zip -DestinationPath .
         Expand-Archive $Env:TEMP\ninja-win.zip -DestinationPath $Env:TEMP\ninja
         Expand-Archive openal-soft-1.21.0-bin.zip -DestinationPath .


### PR DESCRIPTION
Fixes #1045 

Updated to fix CI dependency issues for the windows builds.