### PR TITLE
[RA] Fix out-of-bounds read in HouseClass::Quantity* accessors (#961)

### DIFF
--- a/redalert/house.h
+++ b/redalert/house.h
@@ -988,6 +988,9 @@ public:
 
     int QuantityB(int index)
     {
+        if (index < 0 || index >= (int)(sizeof(BQuantity) / sizeof(BQuantity[0]))) {
+            return (0);
+        }
         return (BQuantity[index]);
     }
 #ifdef FIXIT_CSII //	checked - ajw 9/28/98
@@ -995,39 +998,63 @@ public:
     {
         if (index >= UNIT_RA_COUNT)
             index -= UNIT_RA_COUNT;
+        if (index < 0 || index >= (int)(sizeof(UQuantity) / sizeof(UQuantity[0]))) {
+            return (0);
+        }
         return (UQuantity[index]);
     }
     int QuantityI(int index)
     {
         if (index >= INFANTRY_RA_COUNT)
             index -= INFANTRY_RA_COUNT;
+        if (index < 0 || index >= (int)(sizeof(IQuantity) / sizeof(IQuantity[0]))) {
+            return (0);
+        }
         return (IQuantity[index]);
     }
     int QuantityA(int index)
     {
+        if (index < 0 || index >= (int)(sizeof(AQuantity) / sizeof(AQuantity[0]))) {
+            return (0);
+        }
         return (AQuantity[index]);
     }
     int QuantityV(int index)
     {
         if (index >= VESSEL_RA_COUNT)
             index -= VESSEL_RA_COUNT;
+        if (index < 0 || index >= (int)(sizeof(VQuantity) / sizeof(VQuantity[0]))) {
+            return (0);
+        }
         return (VQuantity[index]);
     }
 #else
     int QuantityU(int index)
     {
+        if (index < 0 || index >= (int)(sizeof(UQuantity) / sizeof(UQuantity[0]))) {
+            return (0);
+        }
         return (UQuantity[index]);
     }
     int QuantityI(int index)
     {
+        if (index < 0 || index >= (int)(sizeof(IQuantity) / sizeof(IQuantity[0]))) {
+            return (0);
+        }
         return (IQuantity[index]);
     }
     int QuantityA(int index)
     {
+        if (index < 0 || index >= (int)(sizeof(AQuantity) / sizeof(AQuantity[0]))) {
+            return (0);
+        }
         return (AQuantity[index]);
     }
     int QuantityV(int index)
     {
+        if (index < 0 || index >= (int)(sizeof(VQuantity) / sizeof(VQuantity[0]))) {
+            return (0);
+        }
         return (VQuantity[index]);
     }
 #endif


### PR DESCRIPTION
## Problem

Fixes #961.

The per-house quantity tracking arrays in `HouseClass` are intentionally sized to exclude the trailing ant types:

```cpp
int BQuantity[STRUCT_COUNT - 3];        // excludes STRUCT_QUEEN/LARVA1/LARVA2
int UQuantity[UNIT_RA_COUNT - 3];       // excludes UNIT_ANT1/ANT2/ANT3
```

However, several callers iterate the **full** `*_COUNT` range and pass those indices straight into the accessors. The clearest case is `CellClass::Goodie_Check()` (`redalert/cell.cpp`):

```cpp
for (j = 0; j < STRUCT_COUNT; j++) {
    bcount += hptr->QuantityB(j);       // reads BQuantity[STRUCT_COUNT-3..-1] -> OOB
}
```

`QuantityB()` did no bounds checking (`return (BQuantity[index]);`), so the last three iterations read past the end of the array. GCC flags this as:

```
house.h:991:33: warning: iteration 84 invokes undefined behavior [-Waggressive-loop-optimizations]
```

The same size-vs-loop mismatch exists for `UQuantity` (ant units sit just below the array's excluded tail) as noted in the issue.

## Fix

Add a bounds guard to each `Quantity*` accessor, **after** the existing CSII index fold, so an out-of-range index returns `0` instead of reading out of bounds:

```cpp
int QuantityB(int index)
{
    if (index < 0 || index >= (int)(sizeof(BQuantity) / sizeof(BQuantity[0]))) {
        return (0);
    }
    return (BQuantity[index]);
}
```

- The bound comes from `sizeof`, so it stays correct for every `FIXIT_ANTS` / `FIXIT_CSII` configuration without duplicating that logic at call sites.
- Behavior is unchanged for all valid indices. The previously-out-of-range ant indices now return `0`, which is the correct count (those types are never tracked in these arrays).
- Applied uniformly to `QuantityB/U/I/A/V` in both `#ifdef` branches.

Only `redalert/house.h` is touched (27 insertions).

## Verification (macOS, clang)

- `cell.cpp` (the reported call site) and `house.cpp` both compile cleanly with the change on **arm64** and **x86_64**; the `-Waggressive-loop-optimizations` UB report no longer applies.
- Full unit-test suite green:

```
100% tests passed, 0 tests failed out of 12
```