### PR TITLE
[Common] Remove unneeded packing from CommBufferClass queue entries (#973)

### DIFF
--- a/common/combuf.h
+++ b/common/combuf.h
@@ -56,7 +56,6 @@
 /*---------------------------------------------------------------------------
 This is one output queue entry
 ---------------------------------------------------------------------------*/
-#pragma pack(push, 1)
 typedef struct BITFIELD_STRUCT
 {
     unsigned int IsActive : 1; // 1 = this entry is ready to be processed
@@ -83,7 +82,6 @@ typedef struct BITFIELD_STRUCT
     int ExtraLen;              // size of extra data
     char* ExtraBuffer;         // extra data buffer
 } ReceiveQueueType;
-#pragma pack(pop)
 
 /*
 ***************************** Class Declaration *****************************


### PR DESCRIPTION
## Problem

Refs #973.

`SendQueueType` and `ReceiveQueueType` in `common/combuf.h` (the send/receive queue entries of `CommBufferClass`) are wrapped in `#pragma pack(push, 1)`:

```cpp
#pragma pack(push, 1)
typedef struct BITFIELD_STRUCT
{
    unsigned int IsActive : 1;
    unsigned int IsACK : 1;
    ...
    char* Buffer;        // <- 8-byte pointer forced to a misaligned offset
    ...
    char* ExtraBuffer;
} SendQueueType;
...
#pragma pack(pop)
```

Because they contain raw pointers, packing them to one byte pushes `Buffer`/`ExtraBuffer` onto misaligned offsets, which is slower on architectures that allow unaligned access and **undefined behaviour** on those that require alignment.

## Why this is safe (network/save compatibility)

@OmniBlade asked (in the issue) to confirm a patched client still interoperates with an unpatched one. Rather than rely on two-machine testing, this can be shown directly from the code — these structs never appear on the wire or on disk:

- They are **in-memory queue bookkeeping** that holds *pointers* to the real packet buffers. A pointer value is meaningless to another process/machine, so the struct itself is never a serialization format.
- There is **no `sizeof(SendQueueType)` / `sizeof(ReceiveQueueType)`** anywhere in the tree, and **no `memcpy`/`fwrite`/`send` of a whole entry**.
- Every user (`common/connect.cpp`, `redalert`/`tiberiandawn` `ipxgconn.cpp`, `ipxmgr.cpp`) accesses individual members through a `SendQueueType*`/`ReceiveQueueType*` and, when sending, uses `send_entry->Buffer` (cast to `CommHeaderType*`) — the **pointed-to buffer**, not the struct.

So the packing of these two structs has **zero effect on the bytes exchanged over the network or written to a savegame**: a patched and an unpatched client produce byte-identical wire data.

## Change

Remove the `#pragma pack(push, 1)` / `#pragma pack(pop)` so the members take their natural alignment (2 lines deleted, no logic change).

`BITFIELD_STRUCT` (`__attribute__((ms_struct))`) is intentionally **kept**: it only governs bitfield layout, not member alignment, so dropping `pack(1)` alone fixes the misalignment while leaving the MSVC-compatible bitfield layout untouched. Happy to also drop `ms_struct` from these two structs if you'd prefer — they're never serialized either — but I kept this minimal.

Scope is deliberately limited to these two `combuf.h` structs. The many other `BITFIELD_STRUCT` types (`event.h`, `defines.h`, `session.h`, `special.h`) *are* used as wire/save formats, so their packing is load-bearing and is left alone.

## Verification (macOS, clang, x86_64)

- `combuf.cpp` and all consumers (`connect.cpp`, `ipxgconn.cpp`, `ipxmgr.cpp`) compile cleanly.
- The **full `vanillara` target builds and links**, including the whole networking stack.
- Unit-test suite green: `100% tests passed, 0 tests failed out of 12`.